### PR TITLE
Create `vitest.config`, loading `dotenv` and set a higher global test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "lint": "tsc",
-    "test": "vitest run",
+    "test": "vitest",
     "example": "ts-node examples/helpers/runner.ts",
     "prepublishOnly": "tsup src/index.ts --dts",
     "changeset": "changeset",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+// vitest.config.ts
+import dotenv from 'dotenv';
+dotenv.config();
+
+export default {
+  test: {
+    testTimeout: 10000, // Global timeout of 10000ms for all tests
+  },
+};


### PR DESCRIPTION
These are both necessary to run the tests locally.
- [x] Import `dotenv` to set the api key for tests
- [x] Increase the global test timeout

This is just helpful for testing
- [x] Use the vitest default which is to run in `--watch` mode.
