### PR TITLE
Simplify event choices

### DIFF
--- a/.changeset/soft-readers-attend.md
+++ b/.changeset/soft-readers-attend.md
@@ -1,0 +1,28 @@
+---
+'@statelyai/agent': patch
+---
+
+The `createSchemas(…)` function has been removed. The `defineEvents(…)` function should be used instead, as it is a simpler way of defining events and event schemas using Zod:
+
+```ts
+import { defineEvents } from '@statelyai/agent';
+import { z } from 'zod';
+import { setup } from 'xstate';
+
+const events = defineEvents({
+  inc: z.object({
+    by: z.number().describe('Increment amount'),
+  }),
+});
+
+const machine = setup({
+  types: {
+    events: events.types,
+  },
+  schema: {
+    events: events.schemas,
+  },
+}).createMachine({
+  // ...
+});
+```

--- a/examples/joke.ts
+++ b/examples/joke.ts
@@ -8,7 +8,7 @@ const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
 
-const eventSchemas = defineEvents({
+const events = defineEvents({
   askForTopic: z.object({
     topic: z.string().describe('The topic for the joke'),
   }),
@@ -93,7 +93,9 @@ const loader = fromCallback(({ input }: { input: string }) => {
 });
 
 const jokeMachine = setup({
-  schemas: eventSchemas,
+  schemas: {
+    events: events.schemas,
+  },
   types: {
     context: {} as {
       topic: string;
@@ -102,7 +104,7 @@ const jokeMachine = setup({
       lastRating: number | null;
       loader: string | null;
     },
-    events: eventSchemas.types,
+    events: events.types,
   },
   actors: {
     getJokeCompletion,
@@ -112,6 +114,7 @@ const jokeMachine = setup({
     loader,
   },
 }).createMachine({
+  id: 'joke',
   context: () => ({
     topic: '',
     jokes: [],
@@ -203,7 +206,7 @@ const jokeMachine = setup({
 const agent = createAgent(jokeMachine, {
   inspect: (ev) => {
     if (ev.type === '@xstate.event') {
-      console.log(ev.event);
+      console.log(`\n${ev.actorRef.id}`, ev.event);
     }
   },
 });

--- a/examples/joke.ts
+++ b/examples/joke.ts
@@ -2,46 +2,25 @@ import OpenAI from 'openai';
 import { assign, fromCallback, fromPromise, log, setup } from 'xstate';
 import { createAgent, createOpenAIAdapter, defineEvents } from '../src';
 import { loadingAnimation } from './helpers/loader';
+import { z } from 'zod';
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
 
 const eventSchemas = defineEvents({
-  askForTopic: {
-    type: 'object',
-    properties: {
-      topic: {
-        type: 'string',
-      },
-    },
-  },
-  tellJoke: {
-    type: 'object',
-    properties: {
-      joke: {
-        type: 'string',
-      },
-    },
-  },
-  endJokes: {
-    type: 'object',
-    properties: {},
-  },
-  rateJoke: {
-    type: 'object',
-    properties: {
-      rating: {
-        type: 'number',
-        minimum: 1,
-        maximum: 10,
-      },
-      explanation: {
-        type: 'string',
-        description: 'An explanation for the rating',
-      },
-    },
-  },
+  askForTopic: z.object({
+    topic: z.string().describe('The topic for the joke'),
+  }),
+  tellJoke: z.object({
+    joke: z.string().describe('The joke text'),
+  }),
+  endJokes: z.object({}).describe('End the jokes'),
+
+  rateJoke: z.object({
+    rating: z.number().min(1).max(10),
+    explanation: z.string(),
+  }),
 });
 
 const adapter = createOpenAIAdapter(openai, {
@@ -123,7 +102,7 @@ const jokeMachine = setup({
       lastRating: number | null;
       loader: string | null;
     },
-    events: eventSchemas.types,
+    events: eventSchemas.type,
   },
   actors: {
     getJokeCompletion,

--- a/examples/joke.ts
+++ b/examples/joke.ts
@@ -102,7 +102,7 @@ const jokeMachine = setup({
       lastRating: number | null;
       loader: string | null;
     },
-    events: eventSchemas.type,
+    events: eventSchemas.types,
   },
   actors: {
     getJokeCompletion,

--- a/examples/numberGuesser.ts
+++ b/examples/numberGuesser.ts
@@ -37,7 +37,7 @@ const machine = setup({
       answer: number;
     },
     input: {} as { answer: number },
-    events: eventSchemas.type,
+    events: eventSchemas.types,
   },
   schemas: eventSchemas,
   actors: {

--- a/examples/numberGuesser.ts
+++ b/examples/numberGuesser.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
 import { createAgent, createOpenAIAdapter, defineEvents } from '../src';
 import { assign, setup } from 'xstate';
+import { z } from 'zod';
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
@@ -24,17 +25,9 @@ const guessLogic = adapter.fromEvent(
 );
 
 const eventSchemas = defineEvents({
-  guess: {
-    properties: {
-      number: {
-        // integer
-        type: 'number',
-        minimum: 1,
-        maximum: 10,
-      },
-    },
-    required: ['number'],
-  },
+  guess: z.object({
+    number: z.number().min(1).max(10).describe('The number guessed'),
+  }),
 });
 
 const machine = setup({
@@ -44,7 +37,7 @@ const machine = setup({
       answer: number;
     },
     input: {} as { answer: number },
-    events: eventSchemas.types,
+    events: eventSchemas.type,
   },
   schemas: eventSchemas,
   actors: {

--- a/examples/numberGuesser.ts
+++ b/examples/numberGuesser.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import { createAgent, createOpenAIAdapter, createSchemas } from '../src';
+import { createAgent, createOpenAIAdapter, defineEvents } from '../src';
 import { assign, setup } from 'xstate';
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
@@ -23,39 +23,17 @@ const guessLogic = adapter.fromEvent(
 `
 );
 
-const schemas = createSchemas({
-  context: {
-    type: 'object',
+const eventSchemas = defineEvents({
+  guess: {
     properties: {
-      lastGuess: {
-        type: ['number', 'null'],
-        description: 'The last guess',
-      },
-      previousGuesses: {
-        type: 'array',
-        items: {
-          type: 'number',
-        },
-        description: 'The previous guesses',
-      },
-      answer: {
+      number: {
+        // integer
         type: 'number',
-        description: 'The answer',
+        minimum: 1,
+        maximum: 10,
       },
     },
-  },
-  events: {
-    guess: {
-      properties: {
-        number: {
-          // integer
-          type: 'number',
-          minimum: 1,
-          maximum: 10,
-        },
-      },
-      required: ['number'],
-    },
+    required: ['number'],
   },
 });
 
@@ -66,9 +44,9 @@ const machine = setup({
       answer: number;
     },
     input: {} as { answer: number },
-    events: schemas.types.events,
+    events: eventSchemas.types,
   },
-  schemas,
+  schemas: eventSchemas,
   actors: {
     guessLogic,
   },

--- a/examples/numberGuesser.ts
+++ b/examples/numberGuesser.ts
@@ -24,7 +24,7 @@ const guessLogic = adapter.fromEvent(
 `
 );
 
-const eventSchemas = defineEvents({
+const events = defineEvents({
   guess: z.object({
     number: z.number().min(1).max(10).describe('The number guessed'),
   }),
@@ -37,9 +37,11 @@ const machine = setup({
       answer: number;
     },
     input: {} as { answer: number },
-    events: eventSchemas.types,
+    events: events.types,
   },
-  schemas: eventSchemas,
+  schemas: {
+    events: events.schemas,
+  },
   actors: {
     guessLogic,
   },

--- a/examples/ticTacToe.ts
+++ b/examples/ticTacToe.ts
@@ -28,7 +28,7 @@ const eventSchemas = defineEvents({
   reset: z.object({}).describe('Reset the game to the initial state'),
 });
 
-eventSchemas.type;
+eventSchemas.types;
 
 interface GameContext {
   board: (Player | null)[];
@@ -96,7 +96,7 @@ export const ticTacToeMachine = setup({
   schemas: eventSchemas,
   types: {
     context: {} as GameContext,
-    events: eventSchemas.type,
+    events: eventSchemas.types,
   },
   actors: {
     bot,

--- a/examples/ticTacToe.ts
+++ b/examples/ticTacToe.ts
@@ -1,5 +1,7 @@
 import { assign, setup, assertEvent } from 'xstate';
 import OpenAI from 'openai';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import { createOpenAIAdapter, defineEvents, createAgent } from '../src';
 
 const openai = new OpenAI({
@@ -9,31 +11,24 @@ const openai = new OpenAI({
 type Player = 'x' | 'o';
 
 const eventSchemas = defineEvents({
-  'x.play': {
-    properties: {
-      index: {
-        description: 'The index of the cell to play on',
-        type: 'number',
-
-        minimum: 0,
-        maximum: 8,
-      },
-    },
-  },
-  'o.play': {
-    properties: {
-      index: {
-        description: 'The index of the cell to play on',
-        type: 'number',
-        minimum: 0,
-        maximum: 8,
-      },
-    },
-  },
-  reset: {
-    properties: {},
-  },
+  'x.play': z.object({
+    index: z
+      .number()
+      .min(0)
+      .max(8)
+      .describe('The index of the cell to play on'),
+  }),
+  'o.play': z.object({
+    index: z
+      .number()
+      .min(0)
+      .max(8)
+      .describe('The index of the cell to play on'),
+  }),
+  reset: z.object({}).describe('Reset the game to the initial state'),
 });
+
+eventSchemas.type;
 
 interface GameContext {
   board: (Player | null)[];
@@ -101,7 +96,7 @@ export const ticTacToeMachine = setup({
   schemas: eventSchemas,
   types: {
     context: {} as GameContext,
-    events: eventSchemas.types,
+    events: eventSchemas.type,
   },
   actors: {
     bot,

--- a/examples/ticTacToe.ts
+++ b/examples/ticTacToe.ts
@@ -10,7 +10,7 @@ const openai = new OpenAI({
 
 type Player = 'x' | 'o';
 
-const eventSchemas = defineEvents({
+const events = defineEvents({
   'x.play': z.object({
     index: z
       .number()
@@ -27,8 +27,6 @@ const eventSchemas = defineEvents({
   }),
   reset: z.object({}).describe('Reset the game to the initial state'),
 });
-
-eventSchemas.types;
 
 interface GameContext {
   board: (Player | null)[];
@@ -93,10 +91,12 @@ function getWinner(board: typeof initialContext.board): Player | null {
 }
 
 export const ticTacToeMachine = setup({
-  schemas: eventSchemas,
+  schemas: {
+    events: events.schemas,
+  },
   types: {
     context: {} as GameContext,
-    events: eventSchemas.types,
+    events: events.types,
   },
   actors: {
     bot,

--- a/examples/ticTacToe.ts
+++ b/examples/ticTacToe.ts
@@ -1,6 +1,6 @@
 import { assign, setup, assertEvent } from 'xstate';
 import OpenAI from 'openai';
-import { createOpenAIAdapter, createSchemas, createAgent } from '../src';
+import { createOpenAIAdapter, defineEvents, createAgent } from '../src';
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
@@ -8,69 +8,40 @@ const openai = new OpenAI({
 
 type Player = 'x' | 'o';
 
-const schemas = createSchemas({
-  context: {
-    type: 'object',
+const eventSchemas = defineEvents({
+  'x.play': {
     properties: {
-      board: {
-        type: 'array',
-        items: {
-          type: ['null', 'string'],
-          enum: [null, 'x', 'o'],
-        },
-        minItems: 9,
-        maxItems: 9,
-        description: 'The board of the tic-tac-toe game',
-      },
-      moves: {
+      index: {
+        description: 'The index of the cell to play on',
         type: 'number',
-        description: 'The number of moves that have been played',
-      },
-      player: {
-        type: 'string',
-        enum: ['x', 'o'],
-        description: 'The player whose turn it is',
-      },
-      gameReport: {
-        type: 'string',
-        description: 'The game report',
-      },
-      events: {
-        type: 'array',
-        items: {
-          type: 'string',
-        },
-      },
-    },
-    required: ['board', 'moves', 'player', 'gameReport', 'events'],
-  },
-  events: {
-    'x.play': {
-      properties: {
-        index: {
-          description: 'The index of the cell to play on',
-          type: 'number',
 
-          minimum: 0,
-          maximum: 8,
-        },
+        minimum: 0,
+        maximum: 8,
       },
     },
-    'o.play': {
-      properties: {
-        index: {
-          description: 'The index of the cell to play on',
-          type: 'number',
-          minimum: 0,
-          maximum: 8,
-        },
+  },
+  'o.play': {
+    properties: {
+      index: {
+        description: 'The index of the cell to play on',
+        type: 'number',
+        minimum: 0,
+        maximum: 8,
       },
     },
-    reset: {
-      properties: {},
-    },
+  },
+  reset: {
+    properties: {},
   },
 });
+
+interface GameContext {
+  board: (Player | null)[];
+  moves: number;
+  player: Player;
+  gameReport: string;
+  events: string[];
+}
 
 const adapter = createOpenAIAdapter(openai, {
   model: 'gpt-4-1106-preview',
@@ -82,10 +53,10 @@ const initialContext = {
   player: 'x' as Player,
   gameReport: '',
   events: [],
-} satisfies typeof schemas.types.context;
+} satisfies GameContext;
 
 const bot = adapter.fromEvent(
-  ({ context }: { context: typeof schemas.types.context }) => `
+  ({ context }: { context: GameContext }) => `
 You are playing a game of tic tac toe. This is the current game state. The 3x3 board is represented by a 9-element array. The first element is the top-left cell, the second element is the top-middle cell, the third element is the top-right cell, the fourth element is the middle-left cell, and so on. The value of each cell is either null, x, or o. The value of null means that the cell is empty. The value of x means that the cell is occupied by an x. The value of o means that the cell is occupied by an o.
 
 ${JSON.stringify(context, null, 2)}
@@ -94,11 +65,7 @@ Execute the single best next move to try to win the game. Do not play on an exis
 );
 
 const gameReporter = adapter.fromChatStream(
-  ({
-    context,
-  }: {
-    context: typeof schemas.types.context;
-  }) => `Here is the game board:
+  ({ context }: { context: GameContext }) => `Here is the game board:
 
 ${JSON.stringify(context.board, null, 2)}
 
@@ -131,8 +98,11 @@ function getWinner(board: typeof initialContext.board): Player | null {
 }
 
 export const ticTacToeMachine = setup({
-  schemas,
-  types: schemas.types,
+  schemas: eventSchemas,
+  types: {
+    context: {} as GameContext,
+    events: eventSchemas.types,
+  },
   actors: {
     bot,
     gameReporter,

--- a/examples/weather.ts
+++ b/examples/weather.ts
@@ -41,7 +41,7 @@ const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
 
-const eventSchemas = defineEvents({
+const events = defineEvents({
   getWeather: z.object({
     location: z.string().describe('The location to get the weather for'),
   }),
@@ -66,14 +66,14 @@ const getWeather = fromPromise(async ({ input }: { input: string }) => {
 });
 
 const machine = setup({
-  schemas: eventSchemas,
+  schemas: events,
   types: {
     context: {} as {
       location: string;
       history: string[];
       count: number;
     },
-    events: eventSchemas.type,
+    events: events.type,
   },
   actors: {
     getWeather,

--- a/examples/weather.ts
+++ b/examples/weather.ts
@@ -45,6 +45,14 @@ const events = defineEvents({
   getWeather: z.object({
     location: z.string().describe('The location to get the weather for'),
   }),
+  reportWeather: z.object({
+    location: z
+      .string()
+      .describe('The location the weather is being reported for'),
+    highF: z.number().describe('The high temperature today in Fahrenheit'),
+    lowF: z.number().describe('The low temperature today in Fahrenheit'),
+    summary: z.string().describe('A summary of the weather conditions'),
+  }),
   doSomethingElse: z
     .object({})
     .describe('Do something else, because the user did not provide a location'),
@@ -65,8 +73,12 @@ const getWeather = fromPromise(async ({ input }: { input: string }) => {
   return results;
 });
 
+const reportWeather = adapter.fromEvent(() => 'Report the weather');
+
 const machine = setup({
-  schemas: events,
+  schemas: {
+    events: events.schemas,
+  },
   types: {
     context: {} as {
       location: string;
@@ -77,6 +89,7 @@ const machine = setup({
   },
   actors: {
     getWeather,
+    reportWeather,
     decide: adapter.fromEvent(
       (input: string) =>
         `Decide what to do based on the given input, which may or may not be a location: ${input}`
@@ -133,6 +146,17 @@ const machine = setup({
               count: ({ context }) => context.count + 1,
             }),
           ],
+          target: 'reportWeather',
+        },
+      },
+    },
+    reportWeather: {
+      invoke: {
+        src: 'reportWeather',
+      },
+      on: {
+        reportWeather: {
+          actions: log(({ event }) => event),
           target: 'getLocation',
         },
       },
@@ -146,8 +170,12 @@ const machine = setup({
   },
 });
 
-createAgent(machine, {
+const actor = createAgent(machine, {
   input: {
     location: 'New York',
   },
-}).start();
+});
+actor.subscribe((s) => {
+  console.log(s.value);
+});
+actor.start();

--- a/examples/weather.ts
+++ b/examples/weather.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai';
 import { createAgent, createOpenAIAdapter, defineEvents } from '../src';
 import { assign, fromPromise, log, setup } from 'xstate';
 import { getFromTerminal } from './helpers/helpers';
+import { z } from 'zod';
 
 async function searchTavily(
   input: string,
@@ -41,20 +42,12 @@ const openai = new OpenAI({
 });
 
 const eventSchemas = defineEvents({
-  getWeather: {
-    description: 'Get the weather for a location',
-    properties: {
-      location: {
-        type: 'string',
-        description: 'The location to get the weather for',
-      },
-    },
-  },
-  doSomethingElse: {
-    description:
-      'Do something else, because the user did not provide a location',
-    properties: {},
-  },
+  getWeather: z.object({
+    location: z.string().describe('The location to get the weather for'),
+  }),
+  doSomethingElse: z
+    .object({})
+    .describe('Do something else, because the user did not provide a location'),
 });
 
 const adapter = createOpenAIAdapter(openai, {
@@ -80,7 +73,7 @@ const machine = setup({
       history: string[];
       count: number;
     },
-    events: eventSchemas.types,
+    events: eventSchemas.type,
   },
   actors: {
     getWeather,

--- a/examples/weather.ts
+++ b/examples/weather.ts
@@ -73,7 +73,7 @@ const machine = setup({
       history: string[];
       count: number;
     },
-    events: events.type,
+    events: events.types,
   },
   actors: {
     getWeather,

--- a/examples/wordGuesser.ts
+++ b/examples/wordGuesser.ts
@@ -2,6 +2,7 @@ import { assign, log, setup } from 'xstate';
 import { getFromTerminal } from './helpers/helpers';
 import { createAgent, createOpenAIAdapter, defineEvents } from '../src';
 import OpenAI from 'openai';
+import { z } from 'zod';
 
 const openAI = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
@@ -11,27 +12,14 @@ const adapter = createOpenAIAdapter(openAI, {
   model: 'gpt-4-1106-preview',
 });
 
-const eventSchemas = defineEvents({
-  guessLetter: {
-    description: 'Player guesses a letter',
-    properties: {
-      letter: {
-        type: 'string',
-        description: 'The letter guessed',
-        maxLength: 1,
-        minLength: 1,
-      },
-    },
-  },
-  guessWord: {
-    description: 'Player guesses the full word',
-    properties: {
-      word: {
-        type: 'string',
-        description: 'The word guessed',
-      },
-    },
-  },
+const events = defineEvents({
+  guessLetter: z.object({
+    letter: z.string().min(1).max(1).describe('The letter guessed'),
+  }),
+
+  guessWord: z.object({
+    word: z.string().describe('The word guessed'),
+  }),
 });
 
 const context = {
@@ -43,7 +31,7 @@ const context = {
 const wordGuesserMachine = setup({
   types: {
     context: {} as typeof context,
-    events: eventSchemas.types,
+    events: events.type,
   },
   actors: {
     getFromTerminal,
@@ -65,7 +53,9 @@ Please make your next guess - type a letter or the full word. You can only make 
     `
     ),
   },
-  schemas: eventSchemas,
+  schemas: {
+    events: events.schemas,
+  },
 }).createMachine({
   initial: 'providingWord',
   context,

--- a/examples/wordGuesser.ts
+++ b/examples/wordGuesser.ts
@@ -31,7 +31,7 @@ const context = {
 const wordGuesserMachine = setup({
   types: {
     context: {} as typeof context,
-    events: events.type,
+    events: events.types,
   },
   actors: {
     getFromTerminal,

--- a/examples/wordGuesser.ts
+++ b/examples/wordGuesser.ts
@@ -1,6 +1,6 @@
 import { assign, log, setup } from 'xstate';
 import { getFromTerminal } from './helpers/helpers';
-import { createAgent, createOpenAIAdapter, createSchemas } from '../src';
+import { createAgent, createOpenAIAdapter, defineEvents } from '../src';
 import OpenAI from 'openai';
 
 const openAI = new OpenAI({
@@ -11,26 +11,24 @@ const adapter = createOpenAIAdapter(openAI, {
   model: 'gpt-4-1106-preview',
 });
 
-const schemas = createSchemas({
-  events: {
-    guessLetter: {
-      description: 'Player guesses a letter',
-      properties: {
-        letter: {
-          type: 'string',
-          description: 'The letter guessed',
-          maxLength: 1,
-          minLength: 1,
-        },
+const eventSchemas = defineEvents({
+  guessLetter: {
+    description: 'Player guesses a letter',
+    properties: {
+      letter: {
+        type: 'string',
+        description: 'The letter guessed',
+        maxLength: 1,
+        minLength: 1,
       },
     },
-    guessWord: {
-      description: 'Player guesses the full word',
-      properties: {
-        word: {
-          type: 'string',
-          description: 'The word guessed',
-        },
+  },
+  guessWord: {
+    description: 'Player guesses the full word',
+    properties: {
+      word: {
+        type: 'string',
+        description: 'The word guessed',
       },
     },
   },
@@ -45,7 +43,7 @@ const context = {
 const wordGuesserMachine = setup({
   types: {
     context: {} as typeof context,
-    events: schemas.types.events,
+    events: eventSchemas.types,
   },
   actors: {
     getFromTerminal,
@@ -67,7 +65,7 @@ Please make your next guess - type a letter or the full word. You can only make 
     `
     ),
   },
-  schemas,
+  schemas: eventSchemas,
 }).createMachine({
   initial: 'providingWord',
   context,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "ts-node": "^10.9.2",
     "tsup": "^8.0.1",
     "typescript": "^5.3.3",
-    "vitest": "^1.2.2"
+    "vitest": "^1.2.2",
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.22.4"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
-    "lint": "tsc",
+    "lint": "tsc --noEmit",
     "test": "vitest",
     "example": "ts-node examples/helpers/runner.ts",
     "prepublishOnly": "tsup src/index.ts --dts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,12 @@ devDependencies:
   vitest:
     specifier: ^1.2.2
     version: 1.2.2(@types/node@20.10.6)
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
+  zod-to-json-schema:
+    specifier: ^3.22.4
+    version: 3.22.4(zod@3.22.4)
 
 packages:
 
@@ -3478,4 +3484,16 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==, tarball: https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz}
     engines: {node: '>=12.20'}
+    dev: true
+
+  /zod-to-json-schema@3.22.4(zod@3.22.4):
+    resolution: {integrity: sha512-2Ed5dJ+n/O3cU383xSY28cuVi0BCQhF8nYqWU5paEpl7fVdqdAmiLdqLyfblbNdfOFwFfi/mqU4O1pwc60iBhQ==, tarball: https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.22.4.tgz}
+    peerDependencies:
+      zod: ^3.22.4
+    dependencies:
+      zod: 3.22.4
+    dev: true
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==, tarball: https://registry.npmjs.org/zod/-/zod-3.22.4.tgz}
     dev: true

--- a/src/adapters/openai.ts
+++ b/src/adapters/openai.ts
@@ -140,15 +140,20 @@ export function fromEvent<TInput>(
         .map((t) => {
           const name = t.eventType.replace(/\./g, '_');
           functionNameMapping[name] = t.eventType;
+          const eventSchema = eventSchemaMap[t.eventType];
+          const {
+            description,
+            properties: { type, ...properties },
+          } = eventSchema ?? {};
+
           return {
             type: 'function',
             function: {
               name,
-              description:
-                t.description ?? eventSchemaMap[t.eventType]?.description,
+              description: t.description ?? description,
               parameters: {
                 type: 'object',
-                properties: eventSchemaMap[t.eventType]?.properties ?? {},
+                properties: properties ?? {},
               },
             },
           } as const;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,4 +1,4 @@
-import { ActorOptions, AnyStateMachine, createActor } from 'xstate';
+import { AnyStateMachine, createActor } from 'xstate';
 
 export function createAgent<T extends AnyStateMachine>(
   ...args: Parameters<typeof createActor<T>>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { defineEventSchemas as defineEvents } from './schemas';
+export { defineEvents as defineEvents } from './schemas';
 export { createAgent } from './agent';
 export { createOpenAIAdapter } from './adapters/openai';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { createSchemas } from './schemas';
+export { defineEventSchemas as defineEvents } from './schemas';
 export { createAgent } from './agent';
 export { createOpenAIAdapter } from './adapters/openai';

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,19 +1,26 @@
 import { Values } from 'xstate';
-import {
-  EventSchemas,
-  ConvertToJSONSchemas,
-  createEventSchemas,
-} from './utils';
-import { FromSchema } from 'json-schema-to-ts';
+import { createZodEventSchemas } from './utils';
+import { SomeZodObject, TypeOf } from 'zod';
 
-export function defineEventSchemas<const TEventSchemas extends EventSchemas>(
+export type ZodEventTypes = {
+  // map event types to Zod types
+  [eventType: string]: SomeZodObject;
+};
+
+export function defineEvents<const TEventSchemas extends ZodEventTypes>(
   events: TEventSchemas
 ): {
-  events: ConvertToJSONSchemas<TEventSchemas>;
-  types: FromSchema<Values<ConvertToJSONSchemas<TEventSchemas>>>;
+  type: Values<{
+    [K in keyof TEventSchemas]: {
+      type: K;
+    } & TypeOf<TEventSchemas[K]>;
+  }>;
+  schemas: {
+    [K in keyof TEventSchemas]: unknown;
+  };
 } {
   return {
-    events: createEventSchemas(events),
-    types: {} as any,
+    type: {} as any,
+    schemas: createZodEventSchemas(events),
   };
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,39 +1,18 @@
 import { Values } from 'xstate';
 import {
-  ContextSchema,
   EventSchemas,
   ConvertToJSONSchemas,
   createEventSchemas,
 } from './utils';
 import { FromSchema } from 'json-schema-to-ts';
 
-export function createSchemas<
-  const TContextSchema extends ContextSchema,
-  const TEventSchemas extends EventSchemas
->({
-  context,
-  events,
-}: {
-  /**
-   * The JSON schema for the context object.
-   *
-   * Must be of `{ type: 'object' }`.
-   */
-  context?: TContextSchema;
-  /**
-   * An object mapping event types to each event object's JSON Schema.
-   */
-  events: TEventSchemas;
-}): {
-  context: TContextSchema | undefined;
+export function defineEventSchemas<const TEventSchemas extends EventSchemas>(
+  events: TEventSchemas
+): {
   events: ConvertToJSONSchemas<TEventSchemas>;
-  types: {
-    context: FromSchema<TContextSchema>;
-    events: FromSchema<Values<ConvertToJSONSchemas<TEventSchemas>>>;
-  };
+  types: FromSchema<Values<ConvertToJSONSchemas<TEventSchemas>>>;
 } {
   return {
-    context,
     events: createEventSchemas(events),
     types: {} as any,
   };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -10,7 +10,7 @@ export type ZodEventTypes = {
 export function defineEvents<const TEventSchemas extends ZodEventTypes>(
   events: TEventSchemas
 ): {
-  type: Values<{
+  types: Values<{
     [K in keyof TEventSchemas]: {
       type: K;
     } & TypeOf<TEventSchemas[K]>;
@@ -20,7 +20,7 @@ export function defineEvents<const TEventSchemas extends ZodEventTypes>(
   };
 } {
   return {
-    type: {} as any,
+    types: {} as any,
     schemas: createZodEventSchemas(events),
   };
 }


### PR DESCRIPTION
The `createSchemas(…)` function has been removed. The `defineEvents(…)` function should be used instead, as it is a simpler way of defining events and event schemas using Zod:

```ts
import { defineEvents } from '@statelyai/agent';
import { z } from 'zod';
import { setup } from 'xstate';

const events = defineEvents({
  inc: z.object({
    by: z.number().describe('Increment amount'),
  }),
});

const machine = setup({
  types: {
    events: events.types,
  },
  schema: {
    events: events.schemas,
  },
}).createMachine({
  // ...
});
```
