### PR TITLE
Add `context` field in agent

### DIFF
--- a/.changeset/wild-bobcats-care.md
+++ b/.changeset/wild-bobcats-care.md
@@ -1,0 +1,26 @@
+---
+'@statelyai/agent': minor
+---
+
+You can now add `context` Zod schema to your agent. For now, this is meant to be passed directly to the state machine, but in the future, the schema can be shared with the LLM agent to better understand the state machine and its context for decision making.
+
+Breaking: The `context` and `events` types are now in `agent.types` instead of ~~`agent.eventTypes`.
+
+```ts
+const agent = createAgent({
+  // ...
+  context: {
+    score: z.number().describe('The score of the game'),
+    // ...
+  },
+});
+
+const machine = setup({
+  types: agent.types,
+}).createMachine({
+  context: {
+    score: 0,
+  },
+  // ...
+});
+```

--- a/examples/cot.ts
+++ b/examples/cot.ts
@@ -17,16 +17,14 @@ const agent = createAgent({
       answer: z.string().describe('The answer to the question'),
     }),
   },
+  context: {
+    question: z.string().nullable(),
+    thought: z.string().nullable(),
+  },
 });
 
 const machine = setup({
-  types: {
-    context: {} as {
-      question: string | null;
-      thought: string | null;
-    },
-    events: agent.eventTypes,
-  },
+  types: agent.types,
   actors: { agent: fromDecision(agent), getFromTerminal },
 }).createMachine({
   initial: 'asking',

--- a/examples/email.ts
+++ b/examples/email.ts
@@ -19,7 +19,7 @@ const agent = createAgent({
 
 const machine = setup({
   types: {
-    events: agent.eventTypes,
+    events: agent.types.events,
     input: {} as {
       email: string;
       instructions: string;

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -18,7 +18,7 @@ const agent = createAgent({
 
 const machine = setup({
   types: {
-    events: agent.eventTypes,
+    events: agent.types.events,
   },
   actors: { agent: fromDecision(agent), summarizer: fromText(agent) },
 }).createMachine({

--- a/examples/goal.ts
+++ b/examples/goal.ts
@@ -25,7 +25,7 @@ const machine = setup({
       question: string | null;
       goal: string | null;
     },
-    events: agent.eventTypes,
+    events: agent.types.events,
   },
   actors: { decider, getFromTerminal },
 }).createMachine({

--- a/examples/joke.ts
+++ b/examples/joke.ts
@@ -67,19 +67,17 @@ const agent = createAgent({
       .describe('Explains why the joke was irrelevant'),
     'agent.markAsRelevant': z.object({}).describe('The joke was relevant'),
   },
+  context: {
+    topic: z.string().describe('The topic for the joke'),
+    jokes: z.array(z.string()).describe('The jokes told so far'),
+    desire: z.string().nullable().describe('The user desire'),
+    lastRating: z.number().nullable().describe('The last joke rating'),
+    loader: z.string().nullable().describe('The loader text'),
+  },
 });
 
 const jokeMachine = setup({
-  types: {
-    context: {} as {
-      topic: string;
-      jokes: string[];
-      desire: string | null;
-      lastRating: number | null;
-      loader: string | null;
-    },
-    events: agent.eventTypes,
-  },
+  types: agent.types,
   actors: {
     agent: fromDecision(agent),
     loader,

--- a/examples/number.ts
+++ b/examples/number.ts
@@ -20,7 +20,7 @@ const machine = setup({
       previousGuesses: number[];
       answer: number | null;
     },
-    events: agent.eventTypes,
+    events: agent.types.events,
   },
   actors: {
     agent: fromDecision(agent),

--- a/examples/raffle.ts
+++ b/examples/raffle.ts
@@ -27,7 +27,7 @@ const machine = setup({
       lastInput: string | null;
       entries: string[];
     },
-    events: {} as typeof agent.eventTypes | { type: 'draw' },
+    events: {} as typeof agent.types.events | { type: 'draw' },
   },
   actors: { agent: fromDecision(agent), getFromTerminal },
 }).createMachine({

--- a/examples/support.ts
+++ b/examples/support.ts
@@ -35,7 +35,7 @@ const agent = createAgent({
 
 const machine = setup({
   types: {
-    events: agent.eventTypes,
+    events: agent.types.events,
     input: {} as string,
     context: {} as {
       customerIssue: string;

--- a/examples/ticTacToe.ts
+++ b/examples/ticTacToe.ts
@@ -23,6 +23,13 @@ const agent = createAgent({
     }),
     reset: z.object({}).describe('Reset the game to the initial state'),
   },
+  context: {
+    board: z.array(z.union([z.literal(null), z.literal('x'), z.literal('o')])),
+    moves: z.number().min(0).max(9),
+    player: z.union([z.literal('x'), z.literal('o')]),
+    gameReport: z.string(),
+    events: z.array(z.string()),
+  },
 });
 
 type Player = 'x' | 'o';
@@ -41,7 +48,7 @@ const initialContext = {
   player: 'x' as Player,
   gameReport: '',
   events: [],
-} satisfies GameContext;
+} satisfies typeof agent.contextType;
 
 function getWinner(board: typeof initialContext.board): Player | null {
   const lines = [
@@ -64,7 +71,7 @@ function getWinner(board: typeof initialContext.board): Player | null {
 
 export const ticTacToeMachine = setup({
   types: {
-    context: {} as GameContext,
+    context: agent.contextType,
     events: agent.eventTypes,
   },
   actors: {

--- a/examples/ticTacToe.ts
+++ b/examples/ticTacToe.ts
@@ -24,9 +24,17 @@ const agent = createAgent({
     reset: z.object({}).describe('Reset the game to the initial state'),
   },
   context: {
-    board: z.array(z.union([z.literal(null), z.literal('x'), z.literal('o')])),
-    moves: z.number().min(0).max(9),
-    player: z.union([z.literal('x'), z.literal('o')]),
+    board: z
+      .array(z.union([z.literal(null), z.literal('x'), z.literal('o')]))
+      .describe('The 3x3 board represented as a 9-element array.'),
+    moves: z
+      .number()
+      .min(0)
+      .max(9)
+      .describe('The number of moves made in the game.'),
+    player: z
+      .union([z.literal('x'), z.literal('o')])
+      .describe('The current player (x or o)'),
     gameReport: z.string(),
     events: z.array(z.string()),
   },
@@ -48,7 +56,7 @@ const initialContext = {
   player: 'x' as Player,
   gameReport: '',
   events: [],
-} satisfies typeof agent.contextType;
+} satisfies typeof agent.types.context;
 
 function getWinner(board: typeof initialContext.board): Player | null {
   const lines = [
@@ -71,8 +79,8 @@ function getWinner(board: typeof initialContext.board): Player | null {
 
 export const ticTacToeMachine = setup({
   types: {
-    context: agent.contextType,
-    events: agent.eventTypes,
+    context: agent.types.context,
+    events: agent.types.events,
   },
   actors: {
     agent: fromDecision(agent),

--- a/examples/todo.ts
+++ b/examples/todo.ts
@@ -36,7 +36,9 @@ const machine = setup({
       todos: Todo[];
       command: string | null;
     },
-    events: {} as typeof agent.eventTypes | { type: 'assist'; command: string },
+    events: {} as
+      | typeof agent.types.events
+      | { type: 'assist'; command: string },
   },
   actors: { agent: fromDecision(agent), getFromTerminal },
 }).createMachine({

--- a/examples/tutor.ts
+++ b/examples/tutor.ts
@@ -28,7 +28,7 @@ const machine = setup({
     context: {} as {
       conversation: string[];
     },
-    events: agent.eventTypes,
+    events: agent.types.events,
   },
   actors: { agent: fromDecision(agent), getFromTerminal },
 }).createMachine({

--- a/examples/verify.ts
+++ b/examples/verify.ts
@@ -35,7 +35,7 @@ const machine = setup({
       answer: string | null;
       validation: string | null;
     },
-    events: agent.eventTypes,
+    events: agent.types.events,
   },
   actors: {
     getFromTerminal,

--- a/examples/weather.ts
+++ b/examples/weather.ts
@@ -78,7 +78,7 @@ const machine = setup({
       history: string[];
       count: number;
     },
-    events: agent.eventTypes,
+    events: agent.types.events,
   },
   actors: {
     agent: fromDecision(agent),

--- a/examples/word.ts
+++ b/examples/word.ts
@@ -36,7 +36,7 @@ const agent = createAgent({
 const wordGuesserMachine = setup({
   types: {
     context: {} as typeof context,
-    events: agent.eventTypes,
+    events: agent.types.events,
   },
   actors: {
     agent: fromDecision(agent),

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -302,3 +302,24 @@ test('You can listen for plan events', async () => {
     })
   );
 });
+
+test('agent.types provides context and event types', () => {
+  const agent = createAgent({
+    model: {} as any,
+    events: {
+      setScore: z.object({
+        score: z.number(),
+      }),
+    },
+    context: {
+      score: z.number(),
+    },
+  });
+
+  agent.types satisfies { context: any; events: any };
+
+  agent.types.context satisfies { score: number };
+
+  // @ts-expect-error
+  agent.types.context satisfies { score: string };
+});

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -7,7 +7,7 @@ import {
   Observer,
   toObserver,
 } from 'xstate';
-import { ZodEventMapping } from './schemas';
+import { ZodContextMapping, ZodEventMapping } from './schemas';
 import {
   Agent,
   AgentLogic,
@@ -21,12 +21,14 @@ import {
   AgentObservationInput,
   AgentMemoryContext,
   AgentObservation,
+  ContextFromZodContextMapping,
 } from './types';
 import { simplePlanner } from './planners/simplePlanner';
 import { agentGenerateText, agentStreamText } from './text';
 import { agentDecide } from './decision';
 import { vercelAdapter } from './adapters/vercel';
 import { getMachineHash, randomId } from './utils';
+import { SomeZodObject, TypeOf } from 'zod';
 
 export const agentLogic: AgentLogic<AnyEventObject> = fromTransition(
   (state, event, { emit }) => {
@@ -81,14 +83,17 @@ export const agentLogic: AgentLogic<AnyEventObject> = fromTransition(
 );
 
 export function createAgent<
+  const TContextSchema extends ZodContextMapping,
   const TEventSchemas extends ZodEventMapping,
-  TEvents extends EventObject = EventsFromZodEventMapping<TEventSchemas>
+  TEvents extends EventObject = EventsFromZodEventMapping<TEventSchemas>,
+  TContext = ContextFromZodContextMapping<TContextSchema>
 >({
   name,
   description,
   model,
   events,
-  planner = simplePlanner as AgentPlanner<Agent<TEvents>>,
+  context,
+  planner = simplePlanner as AgentPlanner<Agent<TContext, TEvents>>,
   stringify = JSON.stringify,
   getMemory,
   logic = agentLogic as AgentLogic<TEvents>,
@@ -123,21 +128,22 @@ export function createAgent<
    * that the agent knows about.
    */
   events: TEventSchemas;
-  planner?: AgentPlanner<Agent<TEvents>>;
+  context?: TContextSchema;
+  planner?: AgentPlanner<Agent<TContext, TEvents>>;
   stringify?: typeof JSON.stringify;
   /**
    * A function that retrieves the agent's long term memory
    */
-  getMemory?: (agent: Agent<any>) => AgentLongTermMemory;
+  getMemory?: (agent: Agent<TContext, TEvents>) => AgentLongTermMemory;
   /**
    * Agent logic
    */
   logic?: AgentLogic<TEvents>;
   adapter?: AIAdapter;
-} & GenerateTextOptions): Agent<TEvents> {
+} & GenerateTextOptions): Agent<TContext, TEvents> {
   const messageHistoryListeners: Observer<AgentMessageHistory>[] = [];
 
-  const agent = createActor(logic) as unknown as Agent<TEvents>;
+  const agent = createActor(logic) as unknown as Agent<TContext, TEvents>;
   agent.events = events;
   agent.model = model;
   agent.name = name;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -286,6 +286,8 @@ export function createAgent<
     };
   };
 
+  agent.types = {} as any;
+
   agent.start();
 
   return agent;

--- a/src/decision.ts
+++ b/src/decision.ts
@@ -1,6 +1,6 @@
 import { AnyMachineSnapshot, fromPromise } from 'xstate';
 import {
-  Agent,
+  AnyAgent,
   AgentDecideOptions,
   AgentDecisionLogic,
   AgentDecisionInput,
@@ -9,7 +9,7 @@ import {
 } from './types';
 import { simplePlanner } from './planners/simplePlanner';
 
-export async function agentDecide<T extends Agent<any>>(
+export async function agentDecide<T extends AnyAgent>(
   agent: T,
   options: AgentDecideOptions
 ): Promise<AgentPlan<any> | undefined> {
@@ -45,7 +45,7 @@ export async function agentDecide<T extends Agent<any>>(
 }
 
 export function fromDecision(
-  agent: Agent<any>,
+  agent: AnyAgent,
   defaultInput?: AgentDecisionInput
 ): AgentDecisionLogic<any> {
   return fromPromise(async ({ input, self }) => {

--- a/src/planners/shortestPathPlanner.ts
+++ b/src/planners/shortestPathPlanner.ts
@@ -1,5 +1,4 @@
-import { AnyAgent } from '../../dist';
-import { Agent, AgentPlan, AgentPlanInput } from '../types';
+import { Agent, AgentPlan, AgentPlanInput, AnyAgent } from '../types';
 import { getShortestPaths } from '@xstate/graph';
 
 export async function simplePlanner<T extends AnyAgent>(

--- a/src/planners/shortestPathPlanner.ts
+++ b/src/planners/shortestPathPlanner.ts
@@ -1,7 +1,8 @@
+import { AnyAgent } from '../../dist';
 import { Agent, AgentPlan, AgentPlanInput } from '../types';
 import { getShortestPaths } from '@xstate/graph';
 
-export async function simplePlanner<T extends Agent<any>>(
+export async function simplePlanner<T extends AnyAgent>(
   agent: T,
   input: AgentPlanInput<any>
 ): Promise<AgentPlan<any> | undefined> {

--- a/src/planners/simplePlanner.ts
+++ b/src/planners/simplePlanner.ts
@@ -105,7 +105,7 @@ export async function simplePlanner<T extends AnyAgent>(
   });
 
   const result = await agent.generateText({
-    toolChoice: 'auto',
+    toolChoice: 'required',
     ...input,
     prompt,
     tools: toolMap,

--- a/src/planners/simplePlanner.ts
+++ b/src/planners/simplePlanner.ts
@@ -1,11 +1,11 @@
 import { CoreTool, tool } from 'ai';
 import {
-  Agent,
   AgentPlan,
   AgentPlanInput,
   ObservedState,
   PromptTemplate,
   TransitionData,
+  AnyAgent,
 } from '../types';
 import { getAllTransitions } from '../utils';
 import { AnyStateMachine } from 'xstate';
@@ -31,7 +31,7 @@ Make at most one tool call to achieve the above goal. If the goal cannot be achi
   `.trim();
 };
 
-export async function simplePlanner<T extends Agent<any>>(
+export async function simplePlanner<T extends AnyAgent>(
   agent: T,
   input: AgentPlanInput<any>
 ): Promise<AgentPlan<any> | undefined> {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,15 +1,11 @@
-import type { SomeZodObject } from 'zod';
-import { AnyEventObject } from 'xstate';
-import { ObservedState } from './types';
+import { ZodType, type SomeZodObject } from 'zod';
 
 export type ZodEventMapping = {
   // map event types to Zod types
   [eventType: string]: SomeZodObject;
 };
 
-export type ZodActionMapping = {
-  [eventType: string]: {
-    schema: SomeZodObject;
-    action: (state: ObservedState, event: AnyEventObject) => Promise<void>;
-  };
+export type ZodContextMapping = {
+  // map context keys to Zod types
+  [contextKey: string]: ZodType;
 };

--- a/src/strategies/chain-of-note.ts
+++ b/src/strategies/chain-of-note.ts
@@ -1,7 +1,7 @@
 import { GenerateTextResult, LanguageModel } from 'ai';
 import wiki, { wikiSearchResult, wikiSummary } from 'wikipedia';
 import { assign, fromPromise, setup } from 'xstate';
-import { Agent } from '../types';
+import { AnyAgent } from '../types';
 
 const searchWiki = fromPromise(
   async ({
@@ -44,7 +44,7 @@ export const chainOfNote = setup({
   types: {
     input: {} as {
       model: LanguageModel;
-      agent: Agent<any>;
+      agent: AnyAgent;
       prompt: string;
     },
     context: {} as {
@@ -56,7 +56,7 @@ export const chainOfNote = setup({
           }[]
         | null;
       model: LanguageModel;
-      agent: Agent<any>;
+      agent: AnyAgent;
       prompt: string;
     },
     output: {} as GenerateTextResult<any>,

--- a/src/text.ts
+++ b/src/text.ts
@@ -5,13 +5,12 @@ import type {
   StreamTextResult,
 } from 'ai';
 import {
-  Agent,
   AgentGenerateTextOptions,
   AgentStreamTextOptions,
+  AnyAgent,
 } from './types';
 import { defaultTextTemplate } from './templates/defaultText';
 import {
-  AnyMachineSnapshot,
   ObservableActorLogic,
   Observer,
   PromiseActorLogic,
@@ -30,7 +29,7 @@ import { randomId } from './utils';
  * @returns
  */
 async function getMessages(
-  agent: Agent<any>,
+  agent: AnyAgent,
   prompt: string,
   options: AgentStreamTextOptions
 ): Promise<CoreMessage[]> {
@@ -49,7 +48,7 @@ async function getMessages(
   return messages;
 }
 
-export async function agentGenerateText<T extends Agent<any>>(
+export async function agentGenerateText<T extends AnyAgent>(
   agent: T,
   options: AgentGenerateTextOptions
 ) {
@@ -98,7 +97,7 @@ export async function agentGenerateText<T extends Agent<any>>(
 }
 
 export async function agentStreamText(
-  agent: Agent<any>,
+  agent: AnyAgent,
   options: AgentStreamTextOptions
 ): Promise<StreamTextResult<any>> {
   const resolvedOptions = {
@@ -156,7 +155,7 @@ export async function agentStreamText(
   return result;
 }
 
-export function fromTextStream<T extends Agent<any>>(
+export function fromTextStream<T extends AnyAgent>(
   agent: T,
   defaultOptions?: AgentStreamTextOptions
 ): ObservableActorLogic<
@@ -201,7 +200,7 @@ export function fromTextStream<T extends Agent<any>>(
   });
 }
 
-export function fromText<T extends Agent<any>>(
+export function fromText<T extends AnyAgent>(
   agent: T,
   defaultOptions?: AgentGenerateTextOptions
 ): PromiseActorLogic<

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ import {
   streamText,
   StreamTextResult,
 } from 'ai';
-import { ZodEventMapping } from './schemas';
+import { ZodContextMapping, ZodEventMapping } from './schemas';
 import { TypeOf } from 'zod';
 
 export type GenerateTextOptions = Parameters<typeof generateText>[0];
@@ -108,7 +108,7 @@ export type PromptTemplate<TEvents extends EventObject> = (data: {
   plans?: AgentPlan<TEvents>[];
 }) => string;
 
-export type AgentPlanner<T extends Agent<any>> = (
+export type AgentPlanner<T extends AnyAgent> = (
   agent: T['eventTypes'],
   input: AgentPlanInput<T['eventTypes']>
 ) => Promise<AgentPlan<T['eventTypes']> | undefined>;
@@ -243,7 +243,13 @@ export type EventsFromZodEventMapping<TEventSchemas extends ZodEventMapping> =
     } & TypeOf<TEventSchemas[K]>;
   }>;
 
-export type Agent<TEvents extends EventObject> = ActorRefFrom<
+export type ContextFromZodContextMapping<
+  TContextSchema extends ZodContextMapping
+> = {
+  [K in keyof TContextSchema & string]: TypeOf<TContextSchema[K]>;
+};
+
+export type Agent<TContext, TEvents extends EventObject> = ActorRefFrom<
   AgentLogic<TEvents>
 > & {
   /**
@@ -258,6 +264,7 @@ export type Agent<TEvents extends EventObject> = ActorRefFrom<
   description?: string;
   events: ZodEventMapping;
   eventTypes: TEvents;
+  contextType: Compute<TContext>;
   model: LanguageModel;
   defaultOptions: GenerateTextOptions;
   memory: AgentLongTermMemory | undefined;
@@ -318,7 +325,7 @@ export type Agent<TEvents extends EventObject> = ActorRefFrom<
   ) => Subscription;
 };
 
-export type AnyAgent = Agent<any>;
+export type AnyAgent = Agent<any, any>;
 
 export type FromAgent<T> = T | ((self: AnyAgent) => T | Promise<T>);
 
@@ -398,3 +405,5 @@ export interface AIAdapter {
   generateText: typeof generateText;
   streamText: typeof streamText;
 }
+
+export type Compute<A extends any> = { [K in keyof A]: A[K] } & unknown;

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,9 +109,9 @@ export type PromptTemplate<TEvents extends EventObject> = (data: {
 }) => string;
 
 export type AgentPlanner<T extends AnyAgent> = (
-  agent: T['eventTypes'],
-  input: AgentPlanInput<T['eventTypes']>
-) => Promise<AgentPlan<T['eventTypes']> | undefined>;
+  agent: T,
+  input: AgentPlanInput<T['types']['events']>
+) => Promise<AgentPlan<T['types']['events']> | undefined>;
 
 export type AgentDecideOptions = {
   goal: string;
@@ -263,8 +263,10 @@ export type Agent<TContext, TEvents extends EventObject> = ActorRefFrom<
   id?: string;
   description?: string;
   events: ZodEventMapping;
-  eventTypes: TEvents;
-  contextType: Compute<TContext>;
+  types: {
+    events: TEvents;
+    context: Compute<TContext>;
+  };
   model: LanguageModel;
   defaultOptions: GenerateTextOptions;
   memory: AgentLongTermMemory | undefined;


### PR DESCRIPTION
You can now add `context` Zod schema to your agent. For now, this is meant to be passed directly to the state machine, but in the future, the schema can be shared with the LLM agent to better understand the state machine and its context for decision making.

Breaking: The `context` and `events` types are now in `agent.types` instead of ~~`agent.eventTypes`.

```ts
const agent = createAgent({
  // ...
  context: {
    score: z.number().describe('The score of the game'),
    // ...
  },
});

const machine = setup({
  types: agent.types,
}).createMachine({
  context: {
    score: 0,
  },
  // ...
});
```
