### PR TITLE
Add simpler agent context retrieval functions

### DIFF
--- a/.changeset/heavy-moons-bake.md
+++ b/.changeset/heavy-moons-bake.md
@@ -1,0 +1,12 @@
+---
+'@statelyai/agent': minor
+---
+
+Added four new methods for easily retrieving agent messages, observations, feedback, and plans:
+
+- `agent.getMessages()`
+- `agent.getObservations()`
+- `agent.getFeedback()`
+- `agent.getPlans()`
+
+The `agent.select(…)` method is deprecated in favor of these methods.

--- a/examples/chatbot.ts
+++ b/examples/chatbot.ts
@@ -46,7 +46,7 @@ const machine = setup({
           context: {
             userMessage: 'User says: ' + x.context.userMessage,
           },
-          messages: agent.select((mem) => mem.messages),
+          messages: agent.getMessages(),
           goal: 'Respond to the user, unless they want to end the conversation.',
         }),
       },

--- a/examples/email.ts
+++ b/examples/email.ts
@@ -50,7 +50,7 @@ const machine = setup({
             instructions: x.context.instructions,
             clarifications: x.context.clarifications,
           },
-          messages: agent.select((ctx) => ctx.messages),
+          messages: agent.getMessages(),
           goal: 'Respond to the email given the instructions and the provided clarifications. If not enough information is provided, ask for clarification. Otherwise, if you are absolutely sure that there is no ambiguous or missing information, create and submit a response email.',
         }),
       },

--- a/examples/ticTacToe.ts
+++ b/examples/ticTacToe.ts
@@ -36,26 +36,16 @@ const agent = createAgent({
       .union([z.literal('x'), z.literal('o')])
       .describe('The current player (x or o)'),
     gameReport: z.string(),
-    events: z.array(z.string()),
   },
 });
 
 type Player = 'x' | 'o';
-
-interface GameContext {
-  board: (Player | null)[];
-  moves: number;
-  player: Player;
-  gameReport: string;
-  events: string[];
-}
 
 const initialContext = {
   board: Array(9).fill(null) as Array<Player | null>,
   moves: 0,
   player: 'x' as Player,
   gameReport: '',
-  events: [],
 } satisfies typeof agent.types.context;
 
 function getWinner(board: typeof initialContext.board): Player | null {
@@ -96,16 +86,8 @@ export const ticTacToeMachine = setup({
       },
       moves: ({ context }) => context.moves + 1,
       player: ({ context }) => (context.player === 'x' ? 'o' : 'x'),
-      events: ({ context, event }) => {
-        return [...context.events, JSON.stringify(event)];
-      },
     }),
     resetGame: assign(initialContext),
-    recordEvent: assign({
-      events: ({ context, event }) => {
-        return [...context.events, JSON.stringify(event)];
-      },
-    }),
     printBoard: ({ context }) => {
       // Print the context.board in a 3 x 3 grid format
       let boardString = '';
@@ -187,7 +169,7 @@ export const ticTacToeMachine = setup({
         src: 'gameReporter',
         input: ({ context }) => ({
           context: {
-            events: context.events,
+            events: agent.getObservations().map((o) => o.event),
             board: context.board,
           },
           prompt: 'Provide a short game report analyzing the game.',

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -52,8 +52,20 @@ test('agent.addMessage() adds to message history', () => {
       content: 'msg 1',
     })
   );
+  expect(agent.getMessages()).toContainEqual(
+    expect.objectContaining({
+      content: 'msg 1',
+    })
+  );
 
   expect(agent.select((c) => c.messages)).toContainEqual(
+    expect.objectContaining({
+      content: 'response 1',
+      sessionId: expect.any(String),
+      timestamp: expect.any(Number),
+    })
+  );
+  expect(agent.getMessages()).toContainEqual(
     expect.objectContaining({
       content: 'response 1',
       sessionId: expect.any(String),
@@ -80,6 +92,17 @@ test('agent.addFeedback() adds to feedback', () => {
   expect(feedback.sessionId).toEqual(agent.sessionId);
 
   expect(agent.select((c) => c.feedback)).toContainEqual(
+    expect.objectContaining({
+      attributes: {
+        score: -1,
+      },
+      goal: 'Win the game',
+      observationId: 'obs-1',
+      sessionId: expect.any(String),
+      timestamp: expect.any(Number),
+    })
+  );
+  expect(agent.getFeedback()).toContainEqual(
     expect.objectContaining({
       attributes: {
         score: -1,
@@ -182,6 +205,12 @@ test('agent.interact() observes machine actors (no 2nd arg)', () => {
   actor.start();
 
   expect(agent.select((c) => c.observations)).toContainEqual(
+    expect.objectContaining({
+      prevState: undefined,
+      state: expect.objectContaining({ value: 'a' }),
+    })
+  );
+  expect(agent.getObservations()).toContainEqual(
     expect.objectContaining({
       prevState: undefined,
       state: expect.objectContaining({ value: 'a' }),

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -15,10 +15,15 @@ test('an agent has the expected interface', () => {
   expect(agent.generateText).toBeDefined();
   expect(agent.streamText).toBeDefined();
 
-  expect(agent.addFeedback).toBeDefined();
   expect(agent.addMessage).toBeDefined();
   expect(agent.addObservation).toBeDefined();
+  expect(agent.addFeedback).toBeDefined();
   expect(agent.addPlan).toBeDefined();
+
+  expect(agent.getMessages).toBeDefined();
+  expect(agent.getObservations).toBeDefined();
+  expect(agent.getFeedback).toBeDefined();
+  expect(agent.getPlans).toBeDefined();
 
   expect(agent.interact).toBeDefined();
 });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -11,7 +11,7 @@ import { ZodContextMapping, ZodEventMapping } from './schemas';
 import {
   Agent,
   AgentLogic,
-  AgentMessageHistory,
+  AgentMessage,
   AgentPlanner,
   EventsFromZodEventMapping,
   GenerateTextOptions,
@@ -141,7 +141,7 @@ export function createAgent<
   logic?: AgentLogic<TEvents>;
   adapter?: AIAdapter;
 } & GenerateTextOptions): Agent<TContext, TEvents> {
-  const messageHistoryListeners: Observer<AgentMessageHistory>[] = [];
+  const messageHistoryListeners: Observer<AgentMessage>[] = [];
 
   const agent = createActor(logic) as unknown as Agent<TContext, TEvents>;
   agent.events = events;
@@ -177,6 +177,7 @@ export function createAgent<
 
     return message;
   };
+  agent.getMessages = () => agent.getSnapshot().context.messages;
 
   agent.generateText = (opts) => agentGenerateText(agent, opts);
 
@@ -194,6 +195,7 @@ export function createAgent<
     });
     return feedback;
   };
+  agent.getFeedback = () => agent.getSnapshot().context.feedback;
 
   agent.addObservation = (observationInput) => {
     const { prevState, event, state } = observationInput;
@@ -216,6 +218,7 @@ export function createAgent<
 
     return observation;
   };
+  agent.getObservations = () => agent.getSnapshot().context.observations;
 
   agent.addPlan = (plan) => {
     agent.send({
@@ -223,6 +226,7 @@ export function createAgent<
       plan,
     });
   };
+  agent.getPlans = () => agent.getSnapshot().context.plans;
 
   agent.interact = (actorRef, getInput) => {
     let prevState: ObservedState | undefined = undefined;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -28,7 +28,6 @@ import { agentGenerateText, agentStreamText } from './text';
 import { agentDecide } from './decision';
 import { vercelAdapter } from './adapters/vercel';
 import { getMachineHash, randomId } from './utils';
-import { SomeZodObject, TypeOf } from 'zod';
 
 export const agentLogic: AgentLogic<AnyEventObject> = fromTransition(
   (state, event, { emit }) => {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -227,7 +227,7 @@ export function createAgent<
   };
   agent.getPlans = () => agent.getSnapshot().context.plans;
 
-  agent.interact = (actorRef, getInput) => {
+  agent.interact = ((actorRef, getInput) => {
     let prevState: ObservedState | undefined = undefined;
     let subscribed = true;
 
@@ -287,7 +287,7 @@ export function createAgent<
         subscribed = false;
       }, // TODO: make this actually unsubscribe
     };
-  };
+  }) as typeof agent.interact;
 
   agent.types = {} as any;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -312,6 +312,12 @@ export type Agent<TContext, TEvents extends EventObject> = ActorRefFrom<
   onMessage: (callback: (message: AgentMessage) => void) => void;
   /**
    * Selects agent data from its context.
+   *
+   * @deprecated Select from `agent.getSnapshot().context` directly or:
+   * - `agent.getMessages()`
+   * - `agent.getObservations()`
+   * - `agent.getFeedback()`
+   * - `agent.getPlans()`
    */
   select: <T>(selector: (context: AgentMemoryContext) => T) => T;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -342,22 +342,55 @@ export type Agent<TContext, TEvents extends EventObject> = ActorRefFrom<
   getPlans: () => AgentPlan<TEvents>[];
 
   /**
-   * Interacts with this state machine actor by:
-   * 1. Inspecting state transitions and storing them as observations
-   * 2. Deciding what to do next (which event to send the actor) based on
-   * the agent input returned from `getInput(observation)`.
+   * Interacts with this state machine actor by inspecting state transitions and storing them as observations.
    *
    * Observations contain the `prevState`, `event`, and current `state` of this
    * actor, as well as other properties that are useful when recalled.
    * These observations are stored in the `agent`'s short-term (local) memory
    * and can be retrieved via `agent.getObservations()`.
+   *
+   * @example
+   * ```ts
+   * // Only observes the actor's state transitions
+   * agent.interact(actor);
+   *
+   * actor.start();
+   * ```
    */
-  interact: <TActor extends AnyActorRef>(
+  interact<TActor extends AnyActorRef>(actorRef: TActor): Subscription;
+  /**
+   * Interacts with this state machine actor by:
+   * 1. Inspecting state transitions and storing them as observations
+   * 2. Deciding what to do next (which event to send the actor) based on
+   * the agent input returned from `getInput(observation)`, if `getInput(…)` is provided as the 2nd argument.
+   *
+   * Observations contain the `prevState`, `event`, and current `state` of this
+   * actor, as well as other properties that are useful when recalled.
+   * These observations are stored in the `agent`'s short-term (local) memory
+   * and can be retrieved via `agent.getObservations()`.
+   *
+   * @example
+   * ```ts
+   * // Observes the actor's state transitions and
+   * // makes a decision if on the "summarize" state
+   * agent.interact(actor, observed => {
+   *   if (observed.state.matches('summarize')) {
+   *     return {
+   *       context: observed.state.context,
+   *       goal: 'Summarize the message'
+   *     }
+   *   }
+   * });
+   *
+   * actor.start();
+   * ```
+   */
+  interact<TActor extends AnyActorRef>(
     actorRef: TActor,
-    getInput?: (
+    getInput: (
       observation: AgentObservation<TActor>
     ) => AgentDecisionInput | undefined
-  ) => Subscription;
+  ): Subscription;
 };
 
 export type AnyAgent = Agent<any, any>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -342,8 +342,15 @@ export type Agent<TContext, TEvents extends EventObject> = ActorRefFrom<
   getPlans: () => AgentPlan<TEvents>[];
 
   /**
-   * Inspects state machine actor transitions and automatically observes
-   * (prevState, event, state) tuples.
+   * Interacts with this state machine actor by:
+   * 1. Inspecting state transitions and storing them as observations
+   * 2. Deciding what to do next (which event to send the actor) based on
+   * the agent input returned from `getInput(observation)`.
+   *
+   * Observations contain the `prevState`, `event`, and current `state` of this
+   * actor, as well as other properties that are useful when recalled.
+   * These observations are stored in the `agent`'s short-term (local) memory
+   * and can be retrieved via `agent.getObservations()`.
    */
   interact: <TActor extends AnyActorRef>(
     actorRef: TActor,

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,7 @@ export type PromptTemplate<TEvents extends EventObject> = (data: {
    */
   observations?: AgentObservation<any>[]; // TODO
   feedback?: AgentFeedback[];
-  messages?: AgentMessageHistory[];
+  messages?: AgentMessage[];
   plans?: AgentPlan<TEvents>[];
 }) => string;
 
@@ -142,7 +142,7 @@ export interface AgentFeedbackInput {
   timestamp?: number;
 }
 
-export type AgentMessageHistory = CoreMessage & {
+export type AgentMessage = CoreMessage & {
   timestamp: number;
   id: string;
   /**
@@ -154,7 +154,7 @@ export type AgentMessageHistory = CoreMessage & {
   sessionId: string;
 };
 
-export type AgentMessageHistoryInput = CoreMessage & {
+export type AgentMessageInput = CoreMessage & {
   timestamp?: number;
   id?: string;
   /**
@@ -206,7 +206,7 @@ export type AgentEmitted<TEvents extends EventObject> =
     }
   | {
       type: 'message';
-      message: AgentMessageHistory;
+      message: AgentMessage;
     }
   | {
       type: 'plan';
@@ -225,7 +225,7 @@ export type AgentLogic<TEvents extends EventObject> = ActorLogic<
     }
   | {
       type: 'agent.message';
-      message: AgentMessageHistory;
+      message: AgentMessage;
     }
   | {
       type: 'agent.plan';
@@ -303,17 +303,37 @@ export type Agent<TContext, TEvents extends EventObject> = ActorRefFrom<
   addObservation: (
     observationInput: AgentObservationInput
   ) => AgentObservation<any>; // TODO
-  addMessage: (historyInput: AgentMessageHistoryInput) => AgentMessageHistory;
+  addMessage: (messageInput: AgentMessageInput) => AgentMessage;
   addFeedback: (feedbackInput: AgentFeedbackInput) => AgentFeedback;
   addPlan: (plan: AgentPlan<TEvents>) => void;
   /**
    * Called whenever the agent (LLM assistant) receives or sends a message.
    */
-  onMessage: (callback: (message: AgentMessageHistory) => void) => void;
+  onMessage: (callback: (message: AgentMessage) => void) => void;
   /**
    * Selects agent data from its context.
    */
   select: <T>(selector: (context: AgentMemoryContext) => T) => T;
+
+  /**
+   * Retrieves messages from the agent's short-term (local) memory.
+   */
+  getMessages: () => AgentMessage[];
+
+  /**
+   * Retrieves observations from the agent's short-term (local) memory.
+   */
+  getObservations: () => AgentObservation<Agent<TContext, TEvents>>[];
+
+  /**
+   * Retrieves feedback from the agent's short-term (local) memory.
+   */
+  getFeedback: () => AgentFeedback[];
+
+  /**
+   * Retrieves strategies from the agent's short-term (local) memory.
+   */
+  getPlans: () => AgentPlan<TEvents>[];
 
   /**
    * Inspects state machine actor transitions and automatically observes
@@ -370,7 +390,7 @@ export type ObservedStateFrom<TActor extends AnyActorRef> = Pick<
 
 export type AgentMemoryContext = {
   observations: AgentObservation<any>[]; // TODO
-  messages: AgentMessageHistory[];
+  messages: AgentMessage[];
   plans: AgentPlan<any>[];
   feedback: AgentFeedback[];
 };


### PR DESCRIPTION
Added four new methods for easily retrieving agent messages, observations, feedback, and plans:

- `agent.getMessages()`
- `agent.getObservations()`
- `agent.getFeedback()`
- `agent.getPlans()`

The `agent.select(…)` method is deprecated in favor of these methods.
