### PR TITLE
Fix #66: Bad link ?

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Stately Expert is a flexible framework for building AI agents using state machin
 - Enabling custom **planning** abilities for agents to achieve specific goals based on state machine logic, observations, and feedback
 - First-class integration with the [Vercel AI SDK](https://sdk.vercel.ai/) to easily support multiple model providers, such as OpenAI, Anthropic, Google, Mistral, Groq, Perplexity, and more
 
-**Read the documentation: [stately.ai/docs/agents](https://stately.ai/docs/agents)**
+**Read the documentation: [github.com/statelyai/agent](https://github.com/statelyai/agent)**
 
 # Stately Expert
 


### PR DESCRIPTION
Closes #66

Updates the broken documentation link in `readme.md` from the non-existent `https://stately.ai/docs/agents` to the working `https://github.com/statelyai/agent` repository URL.

## Changes

- **`readme.md`, line 10**: Replaces the dead link `[stately.ai/docs/agents](https://stately.ai/docs/agents)` with `[github.com/statelyai/agent](https://github.com/statelyai/agent)` in the documentation callout line.

## Motivation

The `https://stately.ai/docs/agents` URL returns a 404, leaving users with no way to reach documentation from the README's primary docs link. Pointing to the GitHub repository ensures the link resolves and gives readers access to the source, examples, and any documentation hosted there.

## Testing

- Manually verified `https://stately.ai/docs/agents` returns 404.
- Manually verified `https://github.com/statelyai/agent` resolves to the correct repository page.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*