### PR TITLE
DX P0: executor inheritance, wait tags, resume validation, canonical form

### DIFF
--- a/.changeset/audit-bugfixes-batch.md
+++ b/.changeset/audit-bugfixes-batch.md
@@ -1,0 +1,12 @@
+---
+"@statelyai/agent": patch
+---
+
+Six correctness fixes from a source audit:
+
+- **ai-sdk `streamText` now honors `metadata.maxSteps`** — like `generateText`, so a streaming tool loop is bounded instead of running unbounded (both share one `maxStepsSetting` helper).
+- **openai-compat `decide` now forwards an abort signal** — `resolveDecision` threads its `options.signal` onto the request (`AgentDecisionRequest.signal`), and both adapters forward it to the underlying model call, so an in-flight decision is cancellable (symmetric with the text executors).
+- **`RunAgentResult` error `cause` split** — the overloaded `'machine'` is now `'machine' | 'decision-exhausted' | 'stopped'`: an unhandled `DecisionExhaustedError` (or one wrapped in the error's `cause` chain) settles `'decision-exhausted'`, an external stop settles `'stopped'`, and any other machine error state stays `'machine'` (`'aborted'`/`'max-model-calls'` unchanged).
+- **Reserved `agent.*` actor keys are enforced** — `setupAgent({ actorSources })`/`{ requests }` now throws if a key collides with a builtin (`agent.generateText`, `agent.streamText`, `agent.userInput`, `agent.decide`, `agent.plan`) instead of silently clobbering it via spread order. Deliberate overrides are still possible via `machine.provide({ actorSources })`.
+- **Dev-only snapshot-serialization warning** — when a run settles idle, in non-production it walks the machine context once and `console.warn`s (at most once per run, naming the offending path) if it holds a value that won't survive JSON persist/resume (`Date`, `Map`, `Set`, function, `undefined`, `bigint`, class instance, circular). Never throws.
+- **Decision adapters: the event's own `type` always wins** — confirmed both adapters already spread the chosen event's `type` last, so a stray `type` key in the model's tool input can never override the machine event type; added regression tests locking this in.

--- a/.changeset/child-machine-bind-validation.md
+++ b/.changeset/child-machine-bind-validation.md
@@ -1,21 +1,20 @@
 ---
-"@statelyai/agent": patch
+"@statelyai/agent": minor
 ---
 
-`runAgent` now validates invoked child machines at bind time.
+`runAgent`'s executors now inherit down the whole actor tree.
 
-Previously, when a machine invoked a child machine whose own states invoke agent requests (`agent.generateText`, a named text request, or `agent.decide`) and that child request was left unbound, `runAgent` would not catch it at bind time — the run would settle in a wrong idle-looking state or fail mid-run instead of failing fast. The bind walk treated an invoked child machine as one opaque actor and never descended into its internal invokes.
-
-The bind walk now recurses into invoked child state machines (arbitrarily deep, with a cycle guard for self-invoking machines). An unbound agent request inside a child machine throws a loud bind-time error naming the child invoke chain and the request `src`, with the fix spelled out. Child machine requests do **not** inherit the parent `runAgent`'s `generateText`/`streamText`/`decide` executors at runtime, so each child request must carry its own executor (`requestLogic.withExecutor(...)`) or be bound as a string-keyed source inside the child via nested `.provide`:
+Agent requests inside invoked child machines — at any depth — inherit the `generateText`/`streamText`/`decide` executors passed to `runAgent`, the same host-backed wrappers the top-level machine's own requests get. A child request participates in the run's `maxModelCalls` budget, `onTrace`, `onChunk`, and `onResult` exactly like a parent request. No per-child `.provide` ceremony is needed:
 
 ```ts
-runAgent(parentMachine, {
-  actorSources: {
-    child: childMachine.provide({
-      actorSources: { request: requestLogic.withExecutor(...) },
-    }),
-  },
-});
+runAgent(parentMachine, { input, generateText }); // child requests inherit generateText
 ```
 
-Properly-bound children (the existing nested-`.provide` pattern) are unaffected.
+Rules:
+
+- **Inheritance is the default** for any request reached through string-keyed actor sources (invoke `src` strings, registered `actorSources`), arbitrarily deep, cycle-safe.
+- **Explicit bindings win.** A request that carries its own executor (`.withExecutor(...)`, `bindRequestExecutor(...)`, or a child's own `.provide({ actorSources })`) keeps it — the parent's executors are never called for it.
+- **Missing executors still fail fast.** A reachable request whose required executor kind was not passed (e.g. a child stream request with no `streamText`) throws a loud bind-time error naming the invoke chain and the request `src`, before any actor runs.
+- **Escape hatch.** Dynamically created logics (e.g. machine factories used with `enq.spawn`) and children invoked as direct-object `src` objects aren't reachable by the static bind walk; bind those explicitly with `bindRequestExecutor(...)` / `.withExecutor(...)`, or register the child as a string-keyed source.
+
+This replaces the previous alpha behavior, where a child machine was treated as one opaque actor and an unbound child request threw a bind-time error demanding a nested `.provide`.

--- a/.changeset/explicit-suspension-and-illegal-resume.md
+++ b/.changeset/explicit-suspension-and-illegal-resume.md
@@ -1,0 +1,9 @@
+---
+"@statelyai/agent": minor
+---
+
+Two `runAgent` additions for human-in-the-loop resume:
+
+- **Explicit suspension detection.** New exported `WAIT_TAG` (`'agent.wait'`): put it in a state's `tags` to mark an intentional wait for an external event. When the machine rests in a tagged snapshot and nothing is in flight, `runAgent` settles idle deterministically instead of relying on the `setTimeout(0)` timing heuristic. New `RunAgentOptions.isSuspended?: (snapshot) => boolean` customizes detection (default `(s) => s.hasTag(WAIT_TAG)`). Whole-machine idle semantics and the `agent.userInput` placeholder exemption are unchanged, and untagged machines fall back to the heuristic exactly as before — fully backward compatible. (Provisional name: `isSuspended` may change before 2.0.)
+
+- **Illegal resume events throw.** Resuming with `{ snapshot, event }` whose `type` the restored state cannot take now throws `IllegalResumeEventError` (carrying `eventType` and `acceptedTypes`) before delivering the event — a programmer error in the same class as `runAgent`'s bind-time throws, rather than a silent drop. A type-legal event a guard rejects is not an error (the machine takes no transition and settles normally). Opt out with `RunAgentOptions.onIllegalResumeEvent: 'ignore'` to restore the older silent behavior. `IllegalResumeEventError` is exported.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,94 @@
+---
+title: Compared to LangGraph and hand-rolling
+description: Honest head-to-heads against LangGraph JS and a hand-rolled tool-calling loop, including where LangGraph is ahead today.
+---
+
+## Overview
+
+If you are choosing between this library, [LangGraph JS](https://github.com/langchain-ai/langgraphjs), and a hand-rolled loop, here is the honest comparison. The short version:
+
+- **Vs LangGraph JS:** this is an authoring layer over XState, not a runtime with its own platform. It wins on pause/resume semantics, plain-JSON persistence, and model decoupling. LangGraph wins today on prebuilts, dynamic fan-out, and the LangSmith/Studio platform.
+- **Vs a hand-rolled loop:** a `switch` loop is fine until you need durability, legality enforcement, audit/replay, or review. Each of those is real work to hand-build.
+
+## Vs LangGraph JS
+
+### 1. Human-in-the-loop resume
+
+LangGraph pauses with `interrupt()` inside a node. On resume, **the node function re-executes from the top** up to the `interrupt()` call, so any side effect before the interrupt runs again unless you isolate it in its own node. The author has to remember this.
+
+Here a waiting state **is** a state. `runAgent` settles `{ status: 'idle', snapshot }`; resume starts *at* the waiting state, so states before it never re-enter. Pre-pause side effects and model calls run exactly once, with nothing to isolate. This is pinned by a test in `src/run-agent.test.ts` ("pre-idle side effects and model calls run exactly once").
+
+```ts
+// here: resume starts AT `reviewing`; `drafting` (and its model call) never re-runs
+const first = await runAgent(machine, { input, ...executors });   // -> idle
+const done = await runAgent(machine, {
+  snapshot: first.snapshot,
+  event: { type: 'APPROVE' },
+  ...executors,
+});
+```
+
+See [Human in the loop](human-in-the-loop.md).
+
+### 2. Persistence
+
+LangGraph persists through a **checkpointer** wired to the graph, addressed by a `thread_id` in run config:
+
+```ts
+const graph = builder.compile({ checkpointer: new MemorySaver() });
+await graph.invoke(input, { configurable: { thread_id: 'abc' } });
+const state = await graph.getState({ configurable: { thread_id: 'abc' } });
+```
+
+Here the snapshot is plain JSON you store anywhere, with no checkpointer to wire and no thread addressing:
+
+```ts
+const result = await runAgent(machine, { input, ...executors });
+await store.put(id, JSON.stringify(result.snapshot)); // any DB, file, queue, localStorage
+// later, any process:
+await runAgent(machine, { snapshot: JSON.parse(await store.get(id)), event, ...executors });
+```
+
+Context must be JSON-serializable; that is the one constraint. See [Human in the loop](human-in-the-loop.md#persist-and-resume-across-processes).
+
+### 3. Model coupling
+
+LangGraph nodes typically hold LangChain model objects (`ChatOpenAI`, `ChatAnthropic`) and call them inside node code, so swapping SDKs means editing nodes.
+
+Here the machine never talks to a model. It emits typed requests; a host resolves them with an executor set of up to three plain functions (`generateText`, `streamText`, `decide`) returning `{ output }`. Swap SDKs by swapping executors; the machine is untouched.
+
+```ts
+const executors = createAiSdkExecutors({ models });      // Vercel AI SDK adapter
+// or createOpenAiCompatExecutors({ baseUrl }), or hand-rolled { generateText, decide }
+await runAgent(machine, { input, ...executors });
+```
+
+See [Host actors](host-actors.md).
+
+### 4. Where LangGraph is ahead today
+
+- **Prebuilts.** `createReactAgent(...)` is a one-liner tool-calling agent. Here you author the states yourself (though [examples/react-agent](../examples/react-agent) shows the same loop, and the Vercel AI SDK loop can run inside a state).
+- **Dynamic fan-out.** LangGraph's `Send` API fans out to N branches at runtime cleanly. Fan-out invokes are landing in XState ([statelyai/xstate#5602](https://github.com/statelyai/xstate/pull/5602)) and will close this gap; see [examples/fan-out](../examples/fan-out) for what works today.
+- **Platform.** LangSmith tracing and LangGraph Studio are a mature, hosted observability and debugging platform. Here you get Stately's visualization and `onTrace`/JSONL, but not a hosted platform of that depth.
+
+## Vs hand-rolling a switch-loop
+
+A `while` loop over `switch (phase)` is the right first move. It is readable, has no dependencies, and for a linear tool-calling agent it may never need to be anything else. Do not reach for a machine before you feel the pain.
+
+Structure earns its place when one of these four shows up. Each is cheap in a machine and real work to hand-build:
+
+| What you need | Hand-rolled cost | Here |
+|---|---|---|
+| **Durable pause/resume across processes** | Serialize loop-local state, rebuild it on load, and make sure no pre-pause work re-runs. Easy to get subtly wrong. | Settle `idle`, persist the JSON snapshot, resume with an event. Pre-pause work runs once by construction. |
+| **Enforcing which actions are legal mid-flow** | Hand-written `if` checks scattered per phase; the model can still request an out-of-bounds action and you catch it late. | Guards make illegal transitions return `undefined`; the model can only choose a currently-legal event. See [Decisions](decisions.md). |
+| **Audit / replay of what happened** | Bolt on your own event log, then keep it in sync with the mutations. | The [step path](steps.md) is event-sourced: each step applies one event; persist the ordered log and replay deterministically. |
+| **Visualization / review by teammates or agents** | None; the flow lives only in code. | The machine is a graph — inspect it in Stately, review it visually, or hand the JSON to an agent. See [Machines as data](machines-as-data.md). |
+
+The trade: a machine is more upfront structure than a loop. The payoff is that these four capabilities come from the shape of the machine instead of being hand-maintained. If you need none of them, a loop is genuinely fine.
+
+## Related
+
+- [Human in the loop](human-in-the-loop.md)
+- [Decisions](decisions.md)
+- [The step path](steps.md)
+- [Migrating from a hand-rolled loop](from-a-loop.md)

--- a/docs/from-a-loop.md
+++ b/docs/from-a-loop.md
@@ -1,0 +1,156 @@
+---
+title: Migrating from a hand-rolled loop
+description: Convert a realistic while-loop tool-calling agent into an agent machine one step at a time, and see what you get for free.
+---
+
+## Start: a hand-rolled loop
+
+Here is a realistic refund agent as a `while` loop with any SDK. It works. The model calls tools until it stops, a `$100` limit is enforced inline, and anything bigger has to pause for a human.
+
+```ts
+import { generateText, tool } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { z } from 'zod';
+
+async function runRefundAgent(request: string) {
+  const messages: any[] = [{ role: 'user', content: request }];
+  let refunded = false;
+
+  while (true) {
+    const { toolCalls } = await generateText({
+      model: openai('gpt-5.4-mini'),
+      messages,
+      tools: {
+        lookupOrder: tool({ inputSchema: z.object({ id: z.string() }) }),
+        issueRefund: tool({ inputSchema: z.object({ amount: z.number() }) }),
+        escalate: tool({ inputSchema: z.object({ reason: z.string() }) }),
+      },
+    });
+
+    if (!toolCalls?.length) return { refunded };
+
+    for (const call of toolCalls) {
+      if (call.toolName === 'issueRefund') {
+        if (call.input.amount > 100) return { pending: true }; // ...now what?
+        refunded = true;
+      }
+      // push tool result onto messages, continue the loop
+    }
+  }
+}
+```
+
+Three things are quietly wrong: the `$100` rule is an `if` the model could be prompted around, nothing stops `issueRefund` before `lookupOrder`, and the human pause returns `{ pending: true }` and **throws away all the loop's state**. There is no way to resume.
+
+## Step 1: make the implicit phases explicit states
+
+The loop has phases even though nothing names them: it is deciding what to do, then doing it, then either finishing or waiting on a human. Name them as states. Declare schemas and the setup with the flat `setupAgent` form.
+
+```ts
+import { z } from 'zod';
+import { setupAgent, runAgent, sendDecision } from '@statelyai/agent';
+import { createAiSdkExecutors } from '@statelyai/agent/ai-sdk';
+import { openai } from '@ai-sdk/openai';
+
+const models = { quick: openai('gpt-5.4-mini') } as const;
+
+const agentSetup = setupAgent({
+  models,
+  context: z.object({ request: z.string(), amount: z.number(), refunded: z.boolean() }),
+  input: z.object({ request: z.string(), amount: z.number() }),
+  output: z.object({ refunded: z.boolean() }),
+  events: {
+    REFUND: z.object({}),
+    ESCALATE: z.object({ reason: z.string() }),
+    APPROVE: z.object({}),
+    DENY: z.object({}),
+  },
+});
+```
+
+The phases become `deciding`, `awaitingHuman`, `refunded`, `denied`.
+
+## Step 2: the tool-choice becomes a decision with `allowedEvents` + guards
+
+In the loop, "which tool" was a model output you validated after the fact. Make it a **decision**: the model chooses exactly one currently-legal event, and a **guard** owns the `$100` limit so no prompt can talk past it.
+
+```ts
+const machine = agentSetup.createMachine({
+  context: ({ input }) => ({ ...input, refunded: false }),
+  initial: 'deciding',
+  states: {
+    deciding: {
+      invoke: {
+        src: 'agent.decide',
+        input: ({ context }) => ({
+          model: 'quick',
+          system: 'Decide whether this refund can be issued directly.',
+          prompt: `${context.request} (amount: $${context.amount})`,
+          allowedEvents: ['REFUND', 'ESCALATE'] as const, // typo = compile error
+        }),
+        onDone: sendDecision(),
+      },
+      on: {
+        // The guard owns the limit, not the prompt: REFUND above $100 returns
+        // undefined, so the model is rejected and re-asked with typed feedback.
+        REFUND: ({ context }) =>
+          context.amount <= 100 ? { target: 'refunded', context: { refunded: true } } : undefined,
+        ESCALATE: { target: 'awaitingHuman' },
+      },
+    },
+    // ...
+  },
+});
+```
+
+A chosen `REFUND` for `$5000` can no longer slip through — the guard returns `undefined` and the decision retries. See [Decisions](decisions.md).
+
+## Step 3: the pause becomes an idle state with snapshot persistence
+
+The loop's `return { pending: true }` becomes a real waiting **state** with no invoke. `runAgent` settles `idle` there instead of losing everything; the snapshot is plain JSON you persist anywhere.
+
+```ts
+    awaitingHuman: {
+      // No invoke: runAgent settles { status: 'idle', snapshot } here.
+      on: {
+        APPROVE: { target: 'refunded', context: { refunded: true } },
+        DENY: { target: 'denied' },
+      },
+    },
+    refunded: { type: 'final', output: () => ({ refunded: true }) },
+    denied: { type: 'final', output: () => ({ refunded: false }) },
+```
+
+## Step 4: run it with `runAgent`
+
+The loop and its `while (true)` are gone. `runAgent` owns the loop; you supply executors built from the same `models` map.
+
+```ts
+const executors = createAiSdkExecutors({ models });
+
+const result = await runAgent(machine, {
+  input: { request: 'Refund my duplicate charge', amount: 5000 },
+  ...executors,
+});
+
+if (result.status === 'idle') {
+  // Persist result.snapshot anywhere (plain JSON), then resume in any process:
+  const resumed = await runAgent(machine, {
+    snapshot: result.snapshot,
+    event: { type: 'APPROVE' },
+    ...executors,
+  });
+  if (resumed.status === 'done') console.log(resumed.output); // { refunded: true }
+}
+```
+
+## What you got for free
+
+The same behavior as the loop, plus four things the loop could not give you without hand-built machinery:
+
+- **Legality.** The model can only choose a currently-legal event, and the `$100` rule is a guard, not a promptable `if`. Illegal actions are impossible, not caught late.
+- **Resume.** The human pause is a JSON snapshot you persist and resume in another process, days later, with pre-pause work guaranteed to run exactly once. See [Human in the loop](human-in-the-loop.md).
+- **Inspection.** Drive the same machine one model call at a time on the [step path](steps.md) for a durable host that checkpoints after every call and replays deterministically.
+- **Visualization.** The machine is a graph: open it in Stately to see and review the flow, or store it as [data](machines-as-data.md) for an agent to generate or edit.
+
+If you never need those four, the loop was fine. When you do, the machine gives you each one without hand-built machinery. See [Compared to LangGraph and hand-rolling](comparison.md).

--- a/docs/host-actors.md
+++ b/docs/host-actors.md
@@ -1,4 +1,7 @@
-# Host Actors
+---
+title: Host actors
+description: The machine declares typed actor requests; the host executes them with executors or actor implementations, on any SDK or runtime.
+---
 
 `setupAgent(...)` gives a machine typed, built-in actor sources for model work: `agent.generateText` / `agent.streamText` for inline text requests, `agent.decide` for decisions, `agent.userInput` for human input, plus co-located `requests:` when a call deserves a reusable name. Decisions are state-local: author them inline on the invoke with `src: 'agent.decide'`. In every case, the machine only *declares* the request; the host executes it by supplying executors to `runAgent(...)` (or the step helpers) or by providing actor implementations directly.
 
@@ -24,20 +27,17 @@ Inline `agent.generateText` is the fastest path for a one-off text request:
 
 ```ts
 import {
-  createAgentSchemas,
   parseOutput,
   runAgent,
   setupAgent,
 } from '@statelyai/agent';
 
-const schemas = createAgentSchemas({
+const agent = setupAgent({
   context: contextSchema,
   input: inputSchema,
   output: outputSchema,
   events: eventSchemas,
 });
-
-const agent = setupAgent({ schemas });
 const machine = agent.createMachine({
   initial: 'generating',
   states: {
@@ -80,7 +80,7 @@ step = transitionAgentStep(machine, step, { type: 'REVISE', prompt: nextPrompt }
 
 ## User input
 
-Use `agent.userInput` when workflow logic needs to wait for a human *without* going through the idle-first pattern (see [`../readme.md`](../readme.md#human-in-the-loop--persistence) for that default). It's a normal invoked actor; the host owns how the request is delivered and resumed. Two ways to implement it:
+`agent.userInput` is one of the two waiting styles; see [Choosing between the two waiting styles](human-in-the-loop.md#choosing-between-the-two-waiting-styles) for when to pick it over an idle state. It's a normal invoked actor; the host owns how the request is delivered and resumed. Two ways to implement it:
 
 **`RunAgentOptions.userInput`** — the inline path, for gathering input without settling the run:
 

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -27,11 +27,11 @@ Those functions are the **executors**, typed as `AgentRequestExecutors`:
 import { createAiSdkExecutors } from '@statelyai/agent/ai-sdk';
 import { openai } from '@ai-sdk/openai';
 
+const models = { quick: openai('gpt-5.4-mini') } as const;
+
 const result = await runAgent(machine, {
   input: { prompt: 'Why state machines?' },
-  ...createAiSdkExecutors({
-    resolveModel: (modelRef) => openai(modelRef.replace(/^openai\//, '')),
-  }),
+  ...createAiSdkExecutors({ models }),
 });
 ```
 
@@ -50,8 +50,10 @@ const models = {
 } as const;
 
 const agentSetup = setupAgent({
-  schemas,
   models,
+  context: z.object({ prompt: z.string(), answer: z.string().nullable() }),
+  input: z.object({ prompt: z.string() }),
+  output: answerSchema,
   requests: {
     answerQuestion: {
       schemas: { input: z.object({ prompt: z.string() }), output: answerSchema },
@@ -67,7 +69,7 @@ await runAgent(machine, {
 });
 ```
 
-For a fully dynamic or externally configured host, use `resolveModel` instead: it takes the raw ref string and returns a model, so refs like `"openai/gpt-5.4-mini"` resolve without a static map. You can pass both; `resolveModel` wins. With `models` alone, an unknown ref throws.
+For a fully dynamic or externally configured host — one whose machine must not name concrete models — use `resolveModel` instead: it takes the raw ref string and returns a model, so refs like `"openai/gpt-5.4-mini"` resolve without a static map. You can pass both; `resolveModel` wins. With `models` alone, an unknown ref throws. This is the max-portability escape hatch — see [Which authoring form when](machines.md#which-authoring-form-when).
 
 Model refs are opaque strings, so any string is a legal `model:` value. A `models` map is optional: it gives you key autocomplete on request `model:` fields and a place for the executor to resolve those refs. The AI SDK adapter resolves a ref through its `models` map, or through `resolveModel` when the map has no match.
 

--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -13,6 +13,35 @@ The machine decides which events are legal in the waiting state; the host delive
 
 > **Note:** Idle is a whole-machine condition: `runAgent` settles only when nothing else is in flight. In a parallel machine where one region waits for a human while a sibling still has work running, the run finishes that work first. Waits modeled with `agent.userInput` are exempt: they are pending placeholders that never block the settle. See [Parallel machines and pending user input](#parallel-machines-and-pending-user-input).
 
+### Tag intentional waits
+
+<!-- WAIT_TAG and RunAgentOptions.isSuspended from src/run-agent.ts -->
+
+By default `runAgent` detects a resting state with a timing heuristic. Mark states that intentionally wait for an external event with the `WAIT_TAG` tag and the settle becomes deterministic instead:
+
+```ts
+import { WAIT_TAG } from '@statelyai/agent';
+
+reviewing: {
+  tags: [WAIT_TAG],
+  on: { APPROVE: { target: 'published' } },
+},
+```
+
+Tags are serializable and show up in the Stately visualizer. The tag is recommended, not required: untagged machines fall back to the heuristic and behave exactly as before. A tagged wait still respects whole-machine idle — a sibling region's in-flight work runs to completion first.
+
+To detect suspension some other way, pass `isSuspended`. The default is `(s) => s.hasTag(WAIT_TAG)`; a custom detector replaces it:
+
+```ts
+await runAgent(machine, {
+  input,
+  generateText,
+  isSuspended: (snapshot) => snapshot.matches('reviewing'),
+});
+```
+
+> The `isSuspended` option name is provisional and may change before 2.0.
+
 ## A waiting state
 
 In this drafting workflow, `reviewing` has no invoke. Once reached, nothing happens until a human sends `APPROVE` or `REJECT`:
@@ -132,15 +161,34 @@ The persist-and-resume loop has one recurring shape: **run to idle → serialize
 - [file-snapshot-store](../examples/file-snapshot-store/index.ts): a `node:fs` store keyed by session id, resumed across several fresh `runAgent` calls (with a SQLite variant sketched inline).
 - [machine-as-tool](../examples/machine-as-tool/index.ts): the same handle passed through a host harness's tool call. `startTool` runs to idle and returns the handle; `resumeTool` revives it and delivers the event.
 
-To reject an event the current state can't take before resuming, rehydrate the handle and check `getAcceptedEvents`:
+### Illegal resume events throw
+
+<!-- IllegalResumeEventError and onIllegalResumeEvent from src/run-agent.ts -->
+
+Resuming with an event the restored state cannot take is a programmer error, so `runAgent` throws `IllegalResumeEventError` (carrying `eventType` and `acceptedTypes`) before delivering it — the same class as its bind-time throws, not an `error`-status settle. You do not need to pre-check legality yourself:
+
+```ts
+import { IllegalResumeEventError, runAgent } from '@statelyai/agent';
+
+try {
+  await runAgent(machine, { snapshot, event: { type: 'NOPE' }, generateText });
+} catch (error) {
+  if (error instanceof IllegalResumeEventError) {
+    // error.acceptedTypes lists what the restored state does accept
+  }
+}
+```
+
+A type-legal event a **guard** rejects is not an illegal resume event: the machine simply takes no transition and the run settles per normal semantics. To restore the older silent-drop behavior, pass `onIllegalResumeEvent: 'ignore'`.
+
+You still call `getAcceptedEvents` yourself only when you want to *render* the choices — rehydrate the handle and read them:
 
 ```ts
 import { createActor } from 'xstate';
 import { getAcceptedEvents } from '@statelyai/agent';
 
 const snapshot = createActor(machine, { snapshot: JSON.parse(handle) }).getSnapshot();
-const legal = getAcceptedEvents(snapshot).map((e) => e.type);
-if (!legal.includes(event.type)) throw new Error(`Event '${event.type}' is not legal here.`);
+const choices = getAcceptedEvents(snapshot); // one descriptor per legal event
 ```
 
 ### Reading interaction meta
@@ -214,10 +262,10 @@ if (first.status === 'idle' && first.pendingUserInputs) {
 
 Resuming without a handler settles idle again with the same pending inputs, so a host can safely re-enter the loop.
 
-Choosing between the two waiting styles:
+## Choosing between the two waiting styles
 
-- **Idle state** (`on:` handler, no invoke): the wait is an event choice; resume delivers the event. Best for approve/reject flows where `getAcceptedEvents` drives a UI.
-- **`agent.userInput`**: the wait is a value request with a prompt and schema; resume supplies the value. Best for free-form input, and the only style that lets sibling parallel regions keep working while a human is pending.
+- **Idle state** (`on:` handler, no invoke, marked with `tags: [WAIT_TAG]`): the wait is an **event choice**; resume delivers the chosen event. Best for approve/reject flows where `getAcceptedEvents` drives a UI.
+- **`agent.userInput`**: the wait is a **value request** with a prompt and schema; resume supplies the value. Best for free-form input, and the only style that lets sibling parallel regions keep working while a human is pending.
 
 ## Related
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,22 +31,22 @@ A [decision](decisions.md) is where this matters most: the model chooses exactly
 
 ```ts
 import { z } from 'zod';
-import { createAgentSchemas, parseOutput, runAgent, setupAgent } from '@statelyai/agent';
+import { runAgent, setupAgent } from '@statelyai/agent';
 import { createAiSdkExecutors } from '@statelyai/agent/ai-sdk';
 import { openai } from '@ai-sdk/openai';
 
+const models = { quick: openai('gpt-5.4-mini') } as const;
 const answerSchema = z.object({ answer: z.string() });
 
 const agentSetup = setupAgent({
-  schemas: createAgentSchemas({
-    context: z.object({ prompt: z.string(), answer: z.string().nullable() }),
-    input: z.object({ prompt: z.string() }),
-    output: answerSchema,
-  }),
+  models,
+  context: z.object({ prompt: z.string(), answer: z.string().nullable() }),
+  input: z.object({ prompt: z.string() }),
+  output: answerSchema,
   requests: {
     answerQuestion: {
       schemas: { input: z.object({ prompt: z.string() }), output: answerSchema },
-      model: 'openai/gpt-5.4-mini',
+      model: 'quick',
       prompt: ({ input }) => input.prompt,
     },
   },
@@ -62,7 +62,7 @@ const machine = agentSetup.createMachine({
         input: ({ context }) => ({ prompt: context.prompt }),
         onDone: ({ output }) => ({
           target: 'done',
-          context: { answer: parseOutput(answerSchema, output).answer },
+          context: { answer: output.answer },
         }),
       },
     },
@@ -72,7 +72,7 @@ const machine = agentSetup.createMachine({
 
 const result = await runAgent(machine, {
   input: { prompt: 'Why state machines?' },
-  ...createAiSdkExecutors({ resolveModel: (ref) => openai(ref.replace(/^openai\//, '')) }),
+  ...createAiSdkExecutors({ models }),
 });
 
 if (result.status === 'done') {
@@ -95,7 +95,6 @@ Explicitly not shipped yet:
 - **OpenTelemetry exporter.** Build your own from the observation seams on `runAgent`.
 - **SSE/WebSocket transport helpers.** Host your own stream over what `onChunk` gives you.
 - **Dynamic-parallelism primitive.** Fan-out is plain `Promise.all(...)` over host actors.
-- **Nested-machine executor binding.** A child machine keeps its own `.provide({ actorSources })` binding.
 - **Visualization tooling.** Stately Studio and a VS Code extension own diagramming and inspection.
 
 If something here blocks you, or the API surface feels wrong, open an issue. This alpha exists to find that out before 2.0 stable.

--- a/docs/machines.md
+++ b/docs/machines.md
@@ -9,78 +9,74 @@ An **agent machine** is a typed XState state machine describing what your agent 
 
 You author a machine in three steps:
 
-1. Declare schemas with `createAgentSchemas`.
-2. Wire up models, requests, and actor sources with `setupAgent`.
+1. Declare a models registry and your `context`/`input`/`output`/`events` schema fields.
+2. Pass them to `setupAgent` along with your requests and actor sources.
 3. Build the machine with `agentSetup.createMachine`.
 
 ## Declare schemas
 
-<!-- createAgentSchemas surface from src/setup-agent.ts -->
+<!-- flat schema fields on setupAgent from src/setup-agent.ts -->
 
-`createAgentSchemas` builds the schema pack that types your machine's context, event payloads, input, output, and state meta. Only `context` is required; `events`, `input`, `output`, and `meta` default to empty or unknown schemas.
+`setupAgent` takes your schema fields directly — `context`, `events`, `input`, `output`, and `meta` — typing the machine's context, event payloads, input, output, and state meta. Only `context` is required; the rest default to empty or unknown schemas. Every schema is a [Standard Schema](https://standardschema.dev), so Zod, Valibot, ArkType, or a hand-written validator all work, and they are retained on the agent for runtime validation, so you get typed context and events without `{} as Type` casts.
 
 ```ts
 import { z } from 'zod';
-import { createAgentSchemas } from '@statelyai/agent';
+import { setupAgent } from '@statelyai/agent';
 
-const schemas = createAgentSchemas({
+const agentSetup = setupAgent({
+  models,
   context: z.object({ prompt: z.string(), answer: z.string().nullable() }),
   input: z.object({ prompt: z.string() }),
   output: z.object({ answer: z.string() }),
 });
 ```
 
-Every schema is a [Standard Schema](https://standardschema.dev), so Zod, Valibot, ArkType, or a hand-written validator all work. The pack is retained on the agent for runtime validation, so you get typed context and events without `{} as Type` casts.
-
-**Event schemas** make event payloads typed. Declare one schema per event type:
+**Event schemas** make event payloads typed. Declare one schema per event type under `events`:
 
 ```ts
-const schemas = createAgentSchemas({
-  context: z.object({ playerHp: z.number(), enemyHp: z.number() }),
-  input: z.object({ playerHp: z.number(), enemyHp: z.number() }),
-  output: z.object({ outcome: z.string() }),
-  events: {
-    ATTACK: z.object({ target: z.string().default('goblin') }),
-    HEAL: z.object({ amount: z.number().min(1).max(8).default(4) }),
-    FLEE: z.object({}),
-  },
-});
+events: {
+  ATTACK: z.object({ target: z.string().default('goblin') }),
+  HEAL: z.object({ amount: z.number().min(1).max(8).default(4) }),
+  FLEE: z.object({}),
+},
 ```
 
 In a `HEAL` transition, `event.amount` is a `number`. Reading a field the event does not carry is a compile error.
 
-**Emitted event schemas** type the progress events a machine narrates outward with `enq.emit(...)` (received by hosts via [`runAgent`'s `on` handlers](hosts.md#observation-seams)):
+**Emitted event schemas** type the progress events a machine narrates outward with `enq.emit(...)` (received by hosts via [`runAgent`'s `on` handlers](hosts.md#observation-seams)). Declare them under `emitted`:
 
 ```ts
-const schemas = createAgentSchemas({
-  context: z.object({ /* ... */ }),
-  emitted: {
-    EVALUATED: z.object({ qualityScore: z.number(), iteration: z.number() }),
-  },
-});
+emitted: {
+  EVALUATED: z.object({ qualityScore: z.number(), iteration: z.number() }),
+},
 ```
 
 With this declared, `enq.emit({ type: 'EVALUATED', ... })` and the host-side `on: { EVALUATED: handler }` are both fully typed; emitting an undeclared type or a wrong payload is a compile error.
+
+> **Sharing a schema pack.** To reuse one schema set across several machines or the step helpers, declare it once with `createAgentSchemas({ context, input, output, events })` and pass the result as `setupAgent({ schemas })`. The two forms are equivalent — see [Which authoring form when](#which-authoring-form-when).
 
 ## Set up the agent
 
 <!-- setupAgent config surface (models, requests, actorSources, builtins) from src/setup-agent.ts -->
 
-`setupAgent` takes the schemas plus optional `models`, `requests`, and `actorSources`, and returns a **setup** whose `createMachine` builds the machine. Like XState's `setup()`, the return value is not a running agent; it is the typed foundation machines are authored from, so name it accordingly (`agentSetup`, `gameSetup`).
+`setupAgent` takes your models and schema fields plus optional `requests` and `actorSources`, and returns a **setup** whose `createMachine` builds the machine. Like XState's `setup()`, the return value is not a running agent; it is the typed foundation machines are authored from, so name it accordingly (`agentSetup`, `gameSetup`).
 
 ```ts
 import { setupAgent } from '@statelyai/agent';
 
 const agentSetup = setupAgent({
-  schemas,
   models,
+  context,
+  input,
+  output,
+  events,
   requests,
   actorSources,
 });
 ```
 
 - The builtins `agent.generateText`, `agent.streamText`, `agent.userInput`, and `agent.decide` are registered automatically; invoke them by name.
-- You can skip `createAgentSchemas` and pass schema fields directly: `setupAgent({ context, input, output, events, ... })`. The two forms are equivalent; the standalone pack is useful when you share schemas across machines or the step helpers.
+- Prefer inline schema fields (above); reach for the `createAgentSchemas` pack form only to share one schema set across machines or the step helpers — see [Which authoring form when](#which-authoring-form-when).
 
 ### Models
 
@@ -95,8 +91,10 @@ const models = {
 } as const;
 
 const agentSetup = setupAgent({
-  schemas,
   models,
+  context,
+  input,
+  output,
   requests: {
     answerQuestion: {
       schemas: { input: z.object({ prompt: z.string() }), output: answerSchema },
@@ -107,7 +105,7 @@ const agentSetup = setupAgent({
 });
 ```
 
-Aliases are optional. A request can carry any `model:` string (like `'openai/gpt-5.4-mini'`) that the host resolves at run time. See [Hosts](hosts.md).
+Aliases are optional. A request can carry any `model:` string (like `'openai/gpt-5.4-mini'`) that the host resolves at run time — see [Which authoring form when](#which-authoring-form-when) and [Hosts](hosts.md).
 
 ### Requests
 
@@ -115,8 +113,10 @@ Aliases are optional. A request can carry any `model:` string (like `'openai/gpt
 
 ```ts
 const agentSetup = setupAgent({
-  schemas,
   models,
+  context,
+  input,
+  output,
   requests: {
     classifyAnswer: {
       schemas: {
@@ -174,6 +174,20 @@ const machine = agentSetup.createMachine({
   },
 });
 ```
+
+## Which authoring form when
+
+<!-- canonical form vs the supported escape hatches -->
+
+The canonical form covers most machines. Each alternate is a supported escape hatch for one specific need:
+
+| Form | Reach for it when |
+|---|---|
+| **Canonical** — `models` registry + flat schema fields on `setupAgent`, `model: 'quick'` keys, host with `createAiSdkExecutors({ models })` | Default. A single machine whose models are known at author time. |
+| **`createAgentSchemas` pack** — `setupAgent({ schemas })` | Sharing one schema set across several machines or the [step helpers](steps.md). |
+| **String refs + `resolveModel`** — `model: 'openai/gpt-5.4-mini'`, `createAiSdkExecutors({ resolveModel })` | The machine must not name concrete models — maximum portability, refs resolved by the host or loaded from JSON [config](machines-as-data.md). |
+| **`createTextLogic`** — a standalone request value | A request that is exported, reused across states or machines, or unit-tested on its own. See [Text requests](text-requests.md#reusable-request-logic-with-createtextlogic). |
+| **`withExecutor`** — `logic.withExecutor(...)` | Binding execution onto one logic rather than the whole host: per-logic host binding or dynamic spawns. See [Hosts](hosts.md#testing-with-deterministic-executors). |
 
 ## Transitions
 
@@ -266,7 +280,7 @@ When the root declares no `output` and exactly one final state does, `agentSetup
 
 <!-- typed meta protocol from examples/email-drafter/index.ts -->
 
-`meta` attaches typed data to a state or transition. With a `meta` schema in `createAgentSchemas`, hosts read a typed interaction protocol instead of `Record<string, unknown>`:
+`meta` attaches typed data to a state or transition. With a `meta` schema on `setupAgent`, hosts read a typed interaction protocol instead of `Record<string, unknown>`:
 
 ```ts
 prompting: {

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -50,9 +50,9 @@ userMessage([
 Messages are plain context state. Declare a `messages` field validated by `messagesSchema`, and grow it over transitions:
 
 ```ts
-import { createAgentSchemas, messagesSchema } from '@statelyai/agent';
+import { messagesSchema, setupAgent } from '@statelyai/agent';
 
-const schemas = createAgentSchemas({
+const agentSetup = setupAgent({
   context: z.object({
     prompt: z.string(),
     messages: messagesSchema,

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -14,6 +14,8 @@
     "steps",
     "machines-as-data",
     "multi-agent",
+    "from-a-loop",
+    "comparison",
     "examples",
     "roadmap"
   ]

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -55,7 +55,7 @@ const machine = agentSetup.createMachine({
 });
 ```
 
-Each child binds its own request executors with `.provide({ actorSources })` **before** being registered as a parent actor. The section on nested executor binding below explains why.
+A child machine's own requests inherit the executors you pass to `runAgent` — no per-child binding needed. The section on nested executor inheritance below explains the rules.
 
 ## Sub-agents as host-owned tools
 
@@ -122,33 +122,27 @@ states: {
 
 Each debater sits idle until it receives `DEBATE.ARGUMENT_REQUESTED`, composes an argument, and sends `DEBATE.ARGUMENT_SUBMITTED` back. The parent appends to a shared transcript and requests the next turn. The machines share state only through the messages they choose to send.
 
-## Nested-machine executor binding
+## Nested-machine executor inheritance
 
-<!-- nested executor binding caveat from src/run-agent.ts and examples/subflows -->
+<!-- nested executor inheritance from src/run-agent.ts and examples/subflows -->
 
-> **Warning:** `runAgent` binds executors only for the **top-level** machine's own text and decision sources. A child machine keeps its own `.provide({ actorSources })` binding; `runAgent` does not reach into it; child requests do **not** inherit the parent's `generateText`/`streamText`/`decide`. Bind the child's request executors yourself before registering it.
->
-> `runAgent` validates this at **bind time**: it recurses into invoked child machines (arbitrarily deep) and throws a loud error naming the child and the unbound request `src` before any actor runs, rather than settling the parent in a wrong idle-looking state.
-
-[examples/subflows/index.ts](../examples/subflows/index.ts) shows the pattern:
+`runAgent` rebinds the executors you pass it (`generateText`/`streamText`/`decide`) onto every unbound agent request in the machine — **including requests inside invoked child machines, at any depth**. A child request inherits the same host-backed executors as the parent's own requests and shares the run's `maxModelCalls` budget, `onTrace`, `onChunk`, and `onResult`.
 
 ```ts
 const result = await runAgent(parentMachine, {
   input: { topic: 'agents' },
-  generateText: async () => ({}),
-  actorSources: {
-    child: childMachine.provide({
-      actorSources: {
-        researchTopic: childSetup.requests.researchTopic.withExecutor(
-          async ({ input }) => `Research: ${input.topic}`,
-        ),
-      },
-    }),
-  },
+  generateText, // covers the parent's requests AND the child's researchTopic
 });
 ```
 
-The `generateText` passed to `runAgent` covers the parent's own requests; the child's request is covered by its own `.withExecutor(...)` binding.
+The rules:
+
+- **Inheritance is the default.** Any request reached through string-keyed actor sources (invoke `src` strings, registered `actorSources`) inherits, no matter how deeply nested. Cycles are handled.
+- **Explicit bindings win.** A request that already carries its own executor — via `.withExecutor(...)`, `bindRequestExecutor(...)`, or a child's own `.provide({ actorSources })` — keeps it. Explicit binding shadows inheritance, so the parent's executors are never called for it.
+- **Missing executors still fail fast.** If a reachable request needs an executor kind you didn't pass (e.g. a child has a `mode: 'stream'` request but `runAgent` got no `streamText`), binding throws a loud error naming the invoke chain and the request `src` before any actor runs.
+- **Escape hatch for dynamic spawns.** Logics created dynamically (e.g. machine factories used with `enq.spawn`) aren't in any invoke config for the static bind walk to reach, so they can't inherit. Bind those explicitly with `bindRequestExecutor(...)` / `.withExecutor(...)` (see [examples/fan-out/index.ts](../examples/fan-out/index.ts)). The same applies to a child invoked as a **direct-object** `src` (an inline machine object rather than a registered name): register it as a string-keyed source to let it inherit, or bind its requests yourself.
+
+[examples/subflows/index.ts](../examples/subflows/index.ts) shows the default: the parent registers the child under `actorSources.child`, passes `generateText` to `runAgent`, and the child's `researchTopic` request inherits it — no nested `.provide`.
 
 ## Fan-out today
 

--- a/docs/p0-design.md
+++ b/docs/p0-design.md
@@ -420,7 +420,7 @@ export type RunAgentResult<TMachine extends AnyStateMachine> =
   | { status: 'idle'; snapshot: SnapshotFrom<TMachine> }
   | {
       status: 'error';
-      cause: 'aborted' | 'max-model-calls' | 'machine';
+      cause: 'aborted' | 'max-model-calls' | 'decision-exhausted' | 'machine' | 'stopped';
       error: unknown;
       snapshot: SnapshotFrom<TMachine>;
     };
@@ -448,7 +448,7 @@ Typing is load-bearing: `input`/`event`/`onTransition` are machine-typed (`Input
     r = await runAgent(machine, { snapshot: r.snapshot, event, ...executors });
   }
   ```
-- **`error`** — a `runAgent`-level failure, discriminated by `cause`: `'aborted'` (signal fired), `'max-model-calls'` (budget exceeded), `'machine'` (machine error state, decision exhausted surfacing as one, or external stop). Programmer errors (bad config, missing executor/actor source) still throw — at bind time (§3.2). **(Q3.1 resolved: `error` is a variant, not a throw.)**
+- **`error`** — a `runAgent`-level failure, discriminated by `cause`: `'aborted'` (signal fired), `'max-model-calls'` (budget exceeded), `'decision-exhausted'` (machine error state whose error is/wraps an unhandled `DecisionExhaustedError`), `'machine'` (any other machine error state), or `'stopped'` (external stop). Programmer errors (bad config, missing executor/actor source) still throw — at bind time (§3.2). **(Q3.1 resolved: `error` is a variant, not a throw.)**
 
 ### 3.2 Behavior
 
@@ -464,8 +464,8 @@ Typing is load-bearing: `input`/`event`/`onTransition` are machine-typed (`Input
 4. `actor.start()`; if `options.event`, `actor.send(event)`.
 5. **Settle loop.** Subscribe; on each snapshot:
    - `status === 'done'` ⇒ `{ status:'done', output, snapshot }`.
-   - `status === 'error'` ⇒ `{ status:'error', cause:'machine', error: snapshot.error, snapshot }`.
-   - `status === 'stopped'` (external stop) ⇒ `{ status:'error', cause:'machine', error: new Error('Actor stopped externally.'), snapshot }` — without this the settle loop hangs forever.
+   - `status === 'error'` ⇒ `{ status:'error', cause: <'decision-exhausted' if snapshot.error is/wraps an unhandled DecisionExhaustedError, else 'machine'>, error: snapshot.error, snapshot }`.
+   - `status === 'stopped'` (external stop) ⇒ `{ status:'error', cause:'stopped', error: new Error('Actor stopped externally.'), snapshot }` — without this the settle loop hangs forever.
    - `isIdle(snapshot)` and not done ⇒ `{ status:'idle', snapshot }`. No callback consulted — idle always settles; the caller resumes (§3.4).
    - every transition ⇒ `onTransition(snapshot, event)` (observation only, exceptions in the callback are the caller's).
 6. `maxModelCalls` ⇒ `{ status:'error', cause:'max-model-calls', … }`; abort ⇒ `{ status:'error', cause:'aborted', … }`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,53 +15,53 @@ npm install @statelyai/agent xstate ai @ai-sdk/openai zod
 - `ai` (the Vercel AI SDK) is optional: only needed for the shipped adapter, `createAiSdkExecutors`. Core has no runtime dependency besides `xstate`.
 - `@ai-sdk/openai` and `zod` are used in the examples below.
 
-## Describe your schemas
+## Describe your models and schemas
 
 <!-- quickstart walkthrough, based on readme.md quickstart -->
 
-`createAgentSchemas` takes the machine's `context`, `input`, and `output` as [Standard Schema](https://standardschema.dev) values (Zod works). These types flow through the rest of the setup.
+Declare a **models registry** (short keys mapped to resolved models, shared between `setupAgent` and the host) and the machine's `context`, `input`, and `output` as [Standard Schema](https://standardschema.dev) values (Zod works). These pass directly to `setupAgent` and flow through the rest of the setup.
 
 ```ts
 import { z } from 'zod';
-import { createAgentSchemas } from '@statelyai/agent';
+import { openai } from '@ai-sdk/openai';
+
+// Model ids here are placeholders — use any model your provider offers.
+const models = { quick: openai('gpt-5.4-mini') } as const;
 
 const answerSchema = z.object({ answer: z.string() });
-
-const schemas = createAgentSchemas({
-  context: z.object({ prompt: z.string(), answer: z.string().nullable() }),
-  input: z.object({ prompt: z.string() }),
-  output: answerSchema,
-});
+const contextSchema = z.object({ prompt: z.string(), answer: z.string().nullable() });
+const inputSchema = z.object({ prompt: z.string() });
 ```
 
 ## Set up the agent with a request
 
-`setupAgent` takes your schemas and requests, and returns a **setup** (not a running agent) that you author machines from, just like XState's `setup()`. A **text request** is a typed model call: it names a `model`, declares its own input and output schemas, and builds a prompt from its input.
+`setupAgent` takes your models, schema fields, and requests, and returns a **setup** (not a running agent) that you author machines from, just like XState's `setup()`. A **text request** is a typed model call: it names a `model`, declares its own input and output schemas, and builds a prompt from its input.
 
 ```ts
 import { setupAgent } from '@statelyai/agent';
 
 const agentSetup = setupAgent({
-  schemas,
+  models,
+  context: contextSchema,
+  input: inputSchema,
+  output: answerSchema,
   requests: {
     answerQuestion: {
       schemas: { input: z.object({ prompt: z.string() }), output: answerSchema },
-      model: 'openai/gpt-5.4-mini',
+      model: 'quick',
       prompt: ({ input }) => input.prompt,
     },
   },
 });
 ```
 
-The `model` value is a string reference. The host resolves it to a real model later, so the machine stays free of any SDK.
+The `model` value is a key into the `models` registry, so a typo is a compile error. For a machine that must not name concrete models, drop the registry and use string refs the host resolves at run time — see [Which authoring form when](machines.md#which-authoring-form-when).
 
 ## Author the machine
 
-`agentSetup.createMachine` builds a typed XState machine. The `answering` state invokes `answerQuestion`; its `onDone` moves to `done` and writes the parsed answer into context. `parseOutput` validates the request output against its schema.
+`agentSetup.createMachine` builds a typed XState machine. The `answering` state invokes `answerQuestion`; its `onDone` moves to `done` and writes the answer into context. `output` is already validated against the request's output schema and typed as `{ answer: string }`, so you read `output.answer` directly.
 
 ```ts
-import { parseOutput } from '@statelyai/agent';
-
 const machine = agentSetup.createMachine({
   context: ({ input }) => ({ prompt: input.prompt, answer: null }),
   initial: 'answering',
@@ -73,7 +73,7 @@ const machine = agentSetup.createMachine({
         input: ({ context }) => ({ prompt: context.prompt }),
         onDone: ({ output }) => ({
           target: 'done',
-          context: { answer: parseOutput(answerSchema, output).answer },
+          context: { answer: output.answer },
         }),
       },
     },
@@ -89,18 +89,15 @@ The machine now fully describes the agent, but nothing has called a model yet. T
 
 ## Run it against a host
 
-`runAgent` drives the machine and calls the host's executors whenever a state needs a model. Build the executor set with `createAiSdkExecutors` from the `@statelyai/agent/ai-sdk` entry point.
+`runAgent` drives the machine and calls the host's executors whenever a state needs a model. Build the executor set with `createAiSdkExecutors` from the `@statelyai/agent/ai-sdk` entry point, passing the same `models` registry so request keys resolve to real models.
 
 ```ts
 import { runAgent } from '@statelyai/agent';
 import { createAiSdkExecutors } from '@statelyai/agent/ai-sdk';
-import { openai } from '@ai-sdk/openai';
 
 const result = await runAgent(machine, {
   input: { prompt: 'Why state machines?' },
-  ...createAiSdkExecutors({
-    resolveModel: (modelRef) => openai(modelRef.replace(/^openai\//, '')),
-  }),
+  ...createAiSdkExecutors({ models }),
 });
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,6 @@ Everything here is **additive**: none of it blocks the alpha, and all of it bene
 ## Runtime options
 
 - **`hostContext` on `runAgent`.** Host-owned values (sessions, auth/billing ids) threaded to executors and actors without touching machine context. The documented patterns (see [host actors](host-actors.md)) cover this today via closures and input mapping; the option ships only if those prove insufficient in practice.
-- **Automatic nested-machine executor binding.** `runAgent` binds the top-level machine's sources; a child machine's requests must be bound via `.provide(...)`. The alpha adds a loud bind-time error when a child request is unbound; transitive auto-binding is the follow-up.
 - **Dynamic fan-out helper.** Declarative dynamic parallelism. Today: `Promise.all` over host actors inside one invoke (see `examples/ai-sdk-orchestrator-worker`). A `fanOut(...)` helper plus per-branch progress events ships if the manual pattern proves too repetitive.
 
 ## Ecosystem

--- a/docs/text-requests.md
+++ b/docs/text-requests.md
@@ -15,22 +15,21 @@ Pass a `requests` map to `setupAgent`. Each entry becomes an invokable actor und
 
 ```ts
 import { z } from 'zod';
-import { createAgentSchemas, setupAgent } from '@statelyai/agent';
+import { setupAgent } from '@statelyai/agent';
+import { openai } from '@ai-sdk/openai';
 
+const models = { quick: openai('gpt-5.4-mini') } as const;
 const answerSchema = z.object({ answer: z.string() });
 
-const schemas = createAgentSchemas({
+const agentSetup = setupAgent({
+  models,
   context: z.object({ prompt: z.string(), answer: z.string().nullable() }),
   input: z.object({ prompt: z.string() }),
   output: answerSchema,
-});
-
-const agentSetup = setupAgent({
-  schemas,
   requests: {
     answerQuestion: {
       schemas: { input: z.object({ prompt: z.string() }), output: answerSchema },
-      model: 'openai/gpt-5.4-mini',
+      model: 'quick',
       system: 'Answer the question directly.',
       prompt: ({ input }) => input.prompt,
     },
@@ -43,7 +42,7 @@ const agentSetup = setupAgent({
 
 ### Model references and typed aliases
 
-`model` is a string. By default any string, passed straight through to your [host](hosts.md). Register a `models` map on `setupAgent` to narrow `model` to the map's keys, making a typo a compile error and sharing one alias map between authoring and the host adapter:
+Prefer a `models` registry (the canonical form): it narrows `model` to the map's keys, making a typo a compile error and sharing one alias map between authoring and the host adapter. A bare `model` string is the escape hatch — any string, passed straight through to your [host](hosts.md) to resolve — for a machine that must not name concrete models (see [Which authoring form when](machines.md#which-authoring-form-when)).
 
 ```ts
 import { openai } from '@ai-sdk/openai';
@@ -54,8 +53,10 @@ const models = {
 } as const;
 
 const agentSetup = setupAgent({
-  schemas,
   models,
+  context: z.object({ prompt: z.string(), answer: z.string().nullable() }),
+  input: z.object({ prompt: z.string() }),
+  output: answerSchema,
   requests: {
     answerQuestion: {
       schemas: { input: z.object({ prompt: z.string() }), output: answerSchema },
@@ -71,8 +72,6 @@ const agentSetup = setupAgent({
 Invoke by name with `src`, pass `input`, read the typed result in `onDone`:
 
 ```ts
-import { parseOutput } from '@statelyai/agent';
-
 const machine = agentSetup.createMachine({
   context: ({ input }) => ({ prompt: input.prompt, answer: null }),
   initial: 'answering',
@@ -84,7 +83,7 @@ const machine = agentSetup.createMachine({
         input: ({ context }) => ({ prompt: context.prompt }),
         onDone: ({ output }) => ({
           target: 'done',
-          context: { answer: parseOutput(answerSchema, output).answer },
+          context: { answer: output.answer },
         }),
       },
     },
@@ -96,7 +95,18 @@ const machine = agentSetup.createMachine({
 });
 ```
 
-`parseOutput(schema, output)` validates a value against a schema and returns it parsed, throwing on mismatch. The output is already validated against the request's own output schema when it resolves, so `parseOutput` is a convenience for narrowing at the call site.
+Inside `onDone`, `output` is already validated against the request's own output schema and typed from it (`{ answer: string }` here), so you read `output.answer` directly — no parsing step is ever needed in the machine.
+
+### Narrowing an unknown output outside the machine
+
+`parseOutput(schema, output)` validates a value against a schema and returns it parsed, throwing on mismatch. It is an escape hatch for host code that holds a raw, still-untyped output — e.g. a value read back from a persisted snapshot, or an inline `agent.generateText` result whose static type is `unknown`. Inside a request's `onDone` it is never needed.
+
+```ts
+import { parseOutput } from '@statelyai/agent';
+
+// Host code with an untyped value from elsewhere:
+const answer = parseOutput(answerSchema, rawOutput); // typed as { answer: string }
+```
 
 ## Structured output vs plain text
 
@@ -188,7 +198,7 @@ export const research = createTextLogic({
 
 <!-- createTextLogic from src/text-logic.ts and examples/email-drafter -->
 
-`createTextLogic` builds a standalone text request you can export, test on its own, and register under `actorSources`. A `requests` entry is exactly what `setupAgent` builds internally from `createTextLogic`, so the two are interchangeable.
+Inline `requests:` (above) is the default. `createTextLogic` is the escape hatch when a request should be standalone — exported, tested on its own, or shared across machines — and registered under `actorSources`. A `requests` entry is exactly what `setupAgent` builds internally from `createTextLogic`, so the two are interchangeable (see [Which authoring form when](machines.md#which-authoring-form-when)).
 
 ```ts
 import { createTextLogic, setupAgent } from '@statelyai/agent';
@@ -204,8 +214,10 @@ export const draftEmail = createTextLogic({
 });
 
 const agentSetup = setupAgent({
-  schemas,
   models,
+  context,
+  input,
+  output,
   actorSources: { draftEmail },
 });
 ```

--- a/docs/xstate-as-agent-workflow.md
+++ b/docs/xstate-as-agent-workflow.md
@@ -29,7 +29,6 @@ The default. Prompts live next to the states that use them.
 import { z } from 'zod';
 import { openai } from '@ai-sdk/openai';
 import {
-  createAgentSchemas,
   createTextLogic,
   runAgent,
   sendDecision,
@@ -41,22 +40,6 @@ const models = {
   writer: openai('gpt-5.4-mini'),
   judge: openai('gpt-5.4-mini'),
 } as const;
-
-const schemas = createAgentSchemas({
-  context: z.object({
-    topic: z.string(),
-    haiku: z.string().nullable(),
-    critique: z.string().nullable(),
-    revisions: z.number(),
-  }),
-  events: {
-    // The judge chooses exactly one of these.
-    APPROVE: z.object({}),
-    REVISE: z.object({ critique: z.string() }),
-  },
-  input: z.object({ topic: z.string() }),
-  output: z.object({ haiku: z.string() }),
-});
 
 // Text logic: "produce a value." Prompt embedded.
 const writeHaiku = createTextLogic({
@@ -77,7 +60,23 @@ const reviseHaiku = createTextLogic({
     `Revise this haiku:\n${input.haiku}\n\nCritique:\n${input.critique}`,
 });
 
-const agent = setupAgent({ schemas, models, actorSources: { writeHaiku, reviseHaiku } });
+const agent = setupAgent({
+  models,
+  context: z.object({
+    topic: z.string(),
+    haiku: z.string().nullable(),
+    critique: z.string().nullable(),
+    revisions: z.number(),
+  }),
+  events: {
+    // The judge chooses exactly one of these.
+    APPROVE: z.object({}),
+    REVISE: z.object({ critique: z.string() }),
+  },
+  input: z.object({ topic: z.string() }),
+  output: z.object({ haiku: z.string() }),
+  actorSources: { writeHaiku, reviseHaiku },
+});
 
 const haikuMachine = agent.createMachine({
   id: 'haiku',
@@ -331,5 +330,3 @@ That closes the loop: **the machine is the portable artifact.** Prompts embedded
 - **`createTextLogic(config)`** — reusable "produce a value" actor source. `system`/`prompt`/`model` can each be static or `({ input }) => value`. Decisions are state-local via `src: 'agent.decide'`; to reuse one, share its input builder.
 - **Step path** — `initialAgentStep` / `transitionAgentStep` / `resolveAgentStep` / `getAgentRequests`, `executeAgentRequest` (text), `resolveDecision` (decision), `getAcceptedEvents` (enumerate legal events), `sendDecision()` (deliver a chosen event from an `agent.decide` `onDone`).
 - **`createAiSdkExecutors({ models })`** — returns `{ generateText, streamText, decide }` from a Vercel AI SDK model map. Spread into `runAgent` or pass to the step helpers.
-</content>
-</invoke>

--- a/examples/human-in-the-loop/index.ts
+++ b/examples/human-in-the-loop/index.ts
@@ -27,6 +27,7 @@ import {
   persistSnapshot,
   runAgent,
   setupAgent,
+  WAIT_TAG,
   type AgentRequestExecutors,
 } from "../../src/index.js";
 
@@ -83,6 +84,7 @@ export const humanInTheLoopMachine = agentSetup.createMachine({
     // `meta.interaction` tells the host what to show; legal events come from
     // `getAcceptedEvents(snapshot)`.
     reviewing: {
+      tags: [WAIT_TAG],
       meta: {
         interaction: {
           label: "Review the draft: approve to publish, or reject with a reason.",

--- a/examples/json-agent/index.ts
+++ b/examples/json-agent/index.ts
@@ -75,6 +75,9 @@ export const jsonAgentMachine = setupAgent.fromConfig(workflowConfig, {
   compileSchema: ajvCompiler,
 });
 
+// A JSON-authored machine carries string model refs (it cannot reference a
+// `models` registry object), so this host uses `resolveModel` — the max-portability
+// escape hatch — instead of the canonical `createAiSdkExecutors({ models })`.
 function resolveModel(modelRef: string): LanguageModel {
   return openai(modelRef.replace(/^openai\//, ""));
 }

--- a/examples/machine-as-tool/index.test.ts
+++ b/examples/machine-as-tool/index.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { createAsyncLogic } from "xstate";
-import type { RunAgentOptions } from "../../src/index.js";
-import { assertEventLegal, refundMachine, resumeTool, startTool } from "./index.js";
+import { IllegalResumeEventError, type RunAgentOptions } from "../../src/index.js";
+import { refundMachine, resumeTool, startTool } from "./index.js";
 
 // Mock executors: validator returns valid, processRefund is a no-op side effect.
 const executors: RunAgentOptions<typeof refundMachine> = {
@@ -38,14 +38,18 @@ test("reject path: resume with REJECT ends with refunded:false", async () => {
   expect(done.output).toEqual({ refunded: false, reason: "duplicate" });
 });
 
-test("illegal event is rejected before resuming", async () => {
+test("illegal event is rejected when resuming (runAgent throws IllegalResumeEventError)", async () => {
   const started = await startTool({ amount: 5, orderId: "ord-3" }, executors);
   expect(started.status).toBe("pending");
   if (started.status !== "pending") return;
 
-  // PROMPT_SUBMITTED is not a legal event in awaitingApproval.
-  expect(() => assertEventLegal(started.handle, { type: "PROMPT_SUBMITTED" })).toThrow(/not legal/);
+  // PROMPT_SUBMITTED is not a legal event in awaitingApproval — resumeTool's
+  // runAgent throws IllegalResumeEventError before delivering it.
+  await expect(
+    resumeTool(started.handle, { type: "PROMPT_SUBMITTED" } as never, executors),
+  ).rejects.toBeInstanceOf(IllegalResumeEventError);
 
-  // The legal events are exactly APPROVE and REJECT.
-  expect(() => assertEventLegal(started.handle, { type: "APPROVE" })).not.toThrow();
+  // The legal events (APPROVE / REJECT) resume without throwing.
+  const done = await resumeTool(started.handle, { type: "APPROVE" }, executors);
+  expect(done.status).toBe("done");
 });

--- a/examples/machine-as-tool/index.ts
+++ b/examples/machine-as-tool/index.ts
@@ -23,14 +23,8 @@
 import assert from "node:assert/strict";
 import { z } from "zod";
 import { openai } from "@ai-sdk/openai";
+import { createAsyncLogic, type AnyMachineSnapshot } from "xstate";
 import {
-  createActor,
-  createAsyncLogic,
-  type AnyMachineSnapshot,
-  type AnyStateMachine,
-} from "xstate";
-import {
-  getAcceptedEvents,
   getStateMeta,
   runAgent,
   setupAgent,
@@ -236,23 +230,10 @@ export async function resumeTool(
   return toToolResult(result);
 }
 
-/**
- * Reject an event the machine can't take in its current state. The harness
- * calls this before `resumeTool` so an illegal event is refused up front
- * instead of being silently dropped by the machine.
- */
-export function assertEventLegal(handle: Handle, event: { type: string }): void {
-  // Rehydrate the persisted handle into a live snapshot so `getAcceptedEvents`
-  // can read the machine's legal transitions from it.
-  const actor = createActor(refundMachine as AnyStateMachine, {
-    snapshot: JSON.parse(handle),
-  });
-  const snapshot = actor.getSnapshot() as AnyMachineSnapshot;
-  const legal = getAcceptedEvents(snapshot).map((e) => e.type);
-  if (!legal.includes(event.type)) {
-    throw new Error(`Event '${event.type}' is not legal here. Legal events: ${legal.join(", ")}`);
-  }
-}
+// Illegal events are refused up front by `runAgent` itself: `resumeTool`'s
+// `runAgent(refundMachine, { snapshot, event })` throws `IllegalResumeEventError`
+// when the restored state can't take the event, so the harness needs no
+// hand-rolled legality check before resuming.
 
 // Demo: happy path through the harness bridge.
 export async function runMachineAsToolExample() {
@@ -294,7 +275,6 @@ export async function main() {
   }
   console.log("\n[harness auto-approves]\n");
 
-  assertEventLegal(started.handle, { type: "APPROVE" });
   const finished = await resumeTool(started.handle, { type: "APPROVE" }, realExecutors);
   console.log("Result:", finished);
 }

--- a/examples/subflows/index.ts
+++ b/examples/subflows/index.ts
@@ -8,9 +8,10 @@
  *   - a parent that registers the child under `actorSources.child` and invokes
  *     it by name, mapping its own `{ topic }` in and the child's
  *     `{ research }` out.
- *   - the child's own request bound via `.provide({ actorSources })` — runAgent
- *     only wraps the parent's own sources, so the nested child carries its own
- *     executor binding (same as handing the child machine to any actor system).
+ *   - the child's request inheriting runAgent's `generateText` automatically —
+ *     runAgent rebinds every unbound request in an invoked child machine (at
+ *     any depth) with the same host executors it gives the parent's own
+ *     requests. No nested `.provide` ceremony; bind explicitly only to override.
  *
  * Dual-mode: `runSubflowsExample(options?)` takes an injectable `generateText`
  * executor (the test passes a mock — keyless CI); the direct run below uses a
@@ -22,12 +23,7 @@ import { z } from "zod";
 import { openai } from "@ai-sdk/openai";
 import { type LanguageModel } from "ai";
 import { type InspectionEvent } from "xstate";
-import {
-  bindRequestExecutor,
-  runAgent,
-  setupAgent,
-  type AgentRequestExecutor,
-} from "../../src/index.js";
+import { runAgent, setupAgent, type AgentRequestExecutor } from "../../src/index.js";
 import { createAiSdkExecutors } from "../../src/ai-sdk/index.js";
 
 export const models: Record<"researcher", LanguageModel> = {
@@ -117,18 +113,10 @@ export async function runSubflowsExample(options?: {
 
   const result = await runAgent(subflowsMachine, {
     input: options?.input ?? { topic: "state machines for AI agents" },
-    actorSources: {
-      // The child is a nested machine invoked by name, not a parent request —
-      // runAgent only wraps the parent's own sources, so the child's request
-      // keeps its own binding before being registered as the `child` source.
-      child: childMachine.provide({
-        actorSources: {
-          // Adapt the raw `(request, info)` executor to a TextLogic executor
-          // via the shared bridge (defaults `tools`, forwards `signal`).
-          researchTopic: bindRequestExecutor(childAgentSetup.requests.researchTopic, generateText),
-        },
-      }),
-    },
+    // The child is registered as the `child` actor source in the parent setup;
+    // runAgent rebinds its unbound `researchTopic` request with THIS
+    // generateText automatically — no nested `.provide` needed.
+    generateText,
     // onTransition sees ONLY the root (parent) machine's transitions.
     ...(options?.onTransition ? { onTransition: options.onTransition } : {}),
     // inspect is the system-wide passthrough: it fires for every actor in the

--- a/readme.md
+++ b/readme.md
@@ -31,25 +31,24 @@ A refund agent in one machine: the model decides, a **guard** owns the $100 auto
 
 ```ts
 import { z } from 'zod';
-import { createAgentSchemas, runAgent, sendDecision, setupAgent } from '@statelyai/agent';
+import { runAgent, sendDecision, setupAgent, WAIT_TAG } from '@statelyai/agent';
 import { createAiSdkExecutors } from '@statelyai/agent/ai-sdk';
 import { openai } from '@ai-sdk/openai';
 
+// Model ids here are placeholders — use any model your provider offers.
 const models = { quick: openai('gpt-5.4-mini') } as const;
 
 const agent = setupAgent({
   models,
-  schemas: createAgentSchemas({
-    context: z.object({ request: z.string(), amount: z.number() }),
-    input: z.object({ request: z.string(), amount: z.number() }),
-    output: z.object({ refunded: z.boolean() }),
-    events: {
-      AUTO_APPROVE: z.object({}),
-      NEEDS_REVIEW: z.object({ reason: z.string() }),
-      APPROVE: z.object({}),
-      DENY: z.object({}),
-    },
-  }),
+  context: z.object({ request: z.string(), amount: z.number() }),
+  input: z.object({ request: z.string(), amount: z.number() }),
+  output: z.object({ refunded: z.boolean() }),
+  events: {
+    AUTO_APPROVE: z.object({}),
+    NEEDS_REVIEW: z.object({ reason: z.string() }),
+    APPROVE: z.object({}),
+    DENY: z.object({}),
+  },
 });
 
 const machine = agent.createMachine({
@@ -77,6 +76,8 @@ const machine = agent.createMachine({
     },
     awaitingHuman: {
       // No invoke: runAgent settles { status: 'idle', snapshot } here.
+      // WAIT_TAG marks the wait as intentional so the idle settle is deterministic.
+      tags: [WAIT_TAG],
       on: {
         APPROVE: { target: 'refunded' },
         DENY: { target: 'denied' },

--- a/src/ai-sdk/index.test.ts
+++ b/src/ai-sdk/index.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+
+// The language-model stream-part type, derived from the mock's `doStream`
+// result rather than importing `@ai-sdk/provider` directly (not a direct dep).
+type MockDoStream = NonNullable<ConstructorParameters<typeof MockLanguageModelV3>[0]>["doStream"];
+type MockStreamResult = Extract<MockDoStream, { stream: unknown }>;
+type LanguageModelStreamPart =
+  MockStreamResult extends { stream: ReadableStream<infer P> } ? P : never;
 import type { AgentDecisionRequest } from "../decision.js";
 import type { AgentEventDescriptor } from "../events.js";
 import {
+  createAiSdkExecutors,
   isStructuredOutputRequest,
   toAiSdkCallSettings,
   toAiSdkEventTools,
@@ -290,5 +299,154 @@ describe("onResult metadata enrichment", () => {
     expect(result.event).toEqual({ type: "GO" });
     expect(result.usage).toMatchObject({ inputTokens: 5, outputTokens: 2 });
     expect(result.finishReason).toBe("tool-calls");
+  });
+
+  test("decide: the event's own type always wins over a `type` field in the tool input", async () => {
+    const { MockLanguageModelV3 } = await import("ai/test");
+    const { createAiSdkExecutors } = await import("./index.js");
+
+    const model = new MockLanguageModelV3({
+      doGenerate: {
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "choose_GO",
+            // Model returns a stray `type` in the tool input — it must NOT
+            // override the chosen event's own type.
+            input: JSON.stringify({ type: "WRONG", note: "hi" }),
+          },
+        ],
+        finishReason: { unified: "tool-calls", raw: "tool_calls" },
+        usage: {
+          inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 1, text: 1, reasoning: 0 },
+        },
+        warnings: [],
+      },
+    });
+
+    const executors = createAiSdkExecutors({ models: { m: model } });
+    const result = await executors.decide({
+      kind: "decision",
+      id: "d1",
+      model: "m",
+      prompt: "choose",
+      events: [{ type: "GO", toolName: "choose_GO" }],
+      attempts: [],
+    });
+
+    expect(result.event).toEqual({ type: "GO", note: "hi" });
+  });
+});
+
+describe("metadata.maxSteps (multi-step tool loops)", () => {
+  const streamUsage = {
+    inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+    outputTokens: { total: 1, text: 1, reasoning: 0 },
+  };
+  const toolCallStreamChunks = (id: string): LanguageModelStreamPart[] => [
+    { type: "stream-start", warnings: [] },
+    { type: "tool-call", toolCallId: id, toolName: "ping", input: "{}" },
+    { type: "finish", finishReason: { unified: "tool-calls", raw: "tool_calls" }, usage: streamUsage },
+  ];
+  const finalTextStreamChunks: LanguageModelStreamPart[] = [
+    { type: "stream-start", warnings: [] },
+    { type: "text-start", id: "t1" },
+    { type: "text-delta", id: "t1", delta: "done" },
+    { type: "text-end", id: "t1" },
+    { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage: streamUsage },
+  ];
+
+  const pingTool = {
+    ping: {
+      description: "ping",
+      inputSchema: z.object({}),
+      execute: async () => "pong",
+    },
+  };
+
+  test("streamText honors metadata.maxSteps (loops the tool call, matching generateText)", async () => {
+    let calls = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        calls++;
+        return {
+          stream: simulateReadableStream({
+            chunks: calls < 3 ? toolCallStreamChunks(`call-${calls}`) : finalTextStreamChunks,
+          }),
+        };
+      },
+    });
+    const { streamText } = createAiSdkExecutors({ models: { m: model } });
+
+    const result = await streamText({
+      model: "m",
+      prompt: "hi",
+      metadata: { maxSteps: 5 },
+      tools: pingTool,
+    });
+
+    expect(calls).toBe(3);
+    expect(result.output).toBe("done");
+  });
+
+  test("streamText stays single-step when maxSteps is absent (regression: was ignored)", async () => {
+    let calls = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        calls++;
+        return {
+          stream: simulateReadableStream({ chunks: toolCallStreamChunks(`call-${calls}`) }),
+        };
+      },
+    });
+    const { streamText } = createAiSdkExecutors({ models: { m: model } });
+
+    await streamText({ model: "m", prompt: "hi", tools: pingTool });
+
+    // Without maxSteps, the tool loop is not entered — exactly one model call.
+    expect(calls).toBe(1);
+  });
+
+  test("generateText honors metadata.maxSteps (symmetry check)", async () => {
+    let calls = 0;
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => {
+        calls++;
+        const finishReason = { unified: "tool-calls" as const, raw: "tool_calls" };
+        const usage = {
+          inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 1, text: 1, reasoning: 0 },
+        };
+        if (calls < 3) {
+          return {
+            content: [
+              { type: "tool-call" as const, toolCallId: `call-${calls}`, toolName: "ping", input: "{}" },
+            ],
+            finishReason,
+            usage,
+            warnings: [],
+          };
+        }
+        return {
+          content: [{ type: "text" as const, text: "done" }],
+          finishReason: { unified: "stop" as const, raw: "stop" },
+          usage,
+          warnings: [],
+        };
+      },
+    });
+    const { generateText } = createAiSdkExecutors({ models: { m: model } });
+
+    const result = await generateText({
+      model: "m",
+      prompt: "hi",
+      metadata: { maxSteps: 5 },
+      tools: pingTool,
+    });
+
+    expect(calls).toBe(3);
+    expect(result.output).toBe("done");
   });
 });

--- a/src/ai-sdk/index.ts
+++ b/src/ai-sdk/index.ts
@@ -77,6 +77,16 @@ export function toAiSdkTools(tools: AgentTools) {
   return Object.fromEntries(entries);
 }
 
+// Multi-step tool loops: `metadata` is the host-owned per-call channel (see
+// AgentTextRequest.metadata). `metadata.maxSteps` bounds the AI SDK tool-call
+// loop for a request; default stays single-step. Shared by generateText and
+// streamText so both honor it symmetrically.
+function maxStepsSetting(request: AgentTextRequest): { stopWhen?: ReturnType<typeof stepCountIs> } {
+  return typeof request.metadata?.maxSteps === "number"
+    ? { stopWhen: stepCountIs(request.metadata.maxSteps) }
+    : {};
+}
+
 // Permissive fallback StandardSchemaV1/FlexibleSchema used for tools/events with no declared input schema.
 const unknownSchema = {
   "~standard": {
@@ -233,12 +243,7 @@ export function createAiSdkExecutors<TModels extends AiSdkModelMap>(
       model,
       abortSignal: info?.signal,
       ...toAiSdkCallSettings(request),
-      // Multi-step tool loops: `metadata` is the host-owned per-call channel
-      // (see AgentTextRequest.metadata). `metadata.maxSteps` bounds the AI
-      // SDK tool-call loop for this request; default stays single-step.
-      ...(typeof request.metadata?.maxSteps === "number"
-        ? { stopWhen: stepCountIs(request.metadata.maxSteps) }
-        : {}),
+      ...maxStepsSetting(request),
     };
 
     if (isStructuredOutputRequest(request)) {
@@ -276,6 +281,7 @@ export function createAiSdkExecutors<TModels extends AiSdkModelMap>(
       model,
       abortSignal: info?.signal,
       ...toAiSdkCallSettings(request),
+      ...maxStepsSetting(request),
     });
 
     for await (const chunk of result.textStream) {
@@ -296,6 +302,7 @@ export function createAiSdkExecutors<TModels extends AiSdkModelMap>(
 
     const result = await aiGenerateText({
       model,
+      abortSignal: request.signal,
       system: request.system,
       ...(messages ? { messages } : { prompt: request.prompt ?? "" }),
       tools,
@@ -321,6 +328,11 @@ export function createAiSdkExecutors<TModels extends AiSdkModelMap>(
     }
 
     return {
+      // The event's own `type` (from the chosen event descriptor) is spread
+      // LAST so it always wins: a stray `type` key in the model's tool input
+      // can never override the machine event type. Payloads are flat under the
+      // event object, so a payload field named `type` is unrepresentable — the
+      // event discriminant owns that slot.
       event: {
         ...(toolCall.input && typeof toolCall.input === "object" ? toolCall.input : {}),
         type: chosenEvent.type,

--- a/src/decision.ts
+++ b/src/decision.ts
@@ -467,6 +467,13 @@ export interface AgentDecisionRequest {
   seed?: number;
   stopSequences?: string[];
   metadata?: Record<string, unknown>;
+  /**
+   * Abort signal for the underlying model call, threaded through by
+   * {@link resolveDecision} from its `options.signal` so a `decide` executor
+   * can cancel the in-flight request (symmetric with the text executors'
+   * `info.signal`). Runtime-only — never serialized into a provider request.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -579,7 +586,13 @@ export async function resolveDecision<TEvent extends ChosenEvent = ChosenEvent>(
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     options.signal?.throwIfAborted();
-    const { event } = await executor({ ...request, attempts: [...attempts] });
+    const { event } = await executor({
+      ...request,
+      attempts: [...attempts],
+      // Thread the run's abort signal onto the request so the executor can
+      // cancel its in-flight model call (adapters read `request.signal`).
+      signal: options.signal,
+    });
 
     const descriptor = eventsByType.get(event.type);
     if (!descriptor) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export {
   resolveAgentStep,
   transitionAgentStep,
 } from "./steps.js";
-export { runAgent } from "./run-agent.js";
+export { IllegalResumeEventError, runAgent, WAIT_TAG } from "./run-agent.js";
 export { getStateMeta, persistSnapshot, validateSchemaSync } from "./utils.js";
 export { assistantMessage, systemMessage, toolMessage, userMessage } from "./utils.js";
 

--- a/src/openai-compat/index.test.ts
+++ b/src/openai-compat/index.test.ts
@@ -359,4 +359,53 @@ describe("decide (tool_choice required, over fake fetch)", () => {
 
     await expect(decide(decisionRequest())).rejects.toThrow(/unknown tool 'send_event_BOGUS'/);
   });
+
+  test("the event's own type always wins over a `type` field in the tool arguments", async () => {
+    const { fetch } = fakeFetch(() =>
+      jsonResponse({
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  type: "function",
+                  function: {
+                    name: "send_event_GUESS",
+                    // Stray `type` in the parsed arguments must not override the event type.
+                    arguments: JSON.stringify({ type: "WRONG", guess: "a cat" }),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+    const { decide } = createOpenAiCompatExecutors({ baseUrl: "http://x/v1", fetch });
+
+    const result = await decide(decisionRequest());
+    expect(result.event).toEqual({ type: "GUESS", guess: "a cat" });
+  });
+
+  test("forwards request.signal to fetch and rejects when it is aborted", async () => {
+    // fetch that honors the abort signal, like the real one.
+    const fetch: FetchLike = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        const signal = init.signal;
+        if (signal?.aborted) {
+          reject(new DOMException("Aborted", "AbortError"));
+          return;
+        }
+        signal?.addEventListener("abort", () =>
+          reject(new DOMException("Aborted", "AbortError")),
+        );
+      });
+    const { decide } = createOpenAiCompatExecutors({ baseUrl: "http://x/v1", fetch });
+
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      decide(decisionRequest({ signal: controller.signal } as Partial<AgentDecisionRequest>)),
+    ).rejects.toThrow(/Aborted/);
+  });
 });

--- a/src/openai-compat/index.ts
+++ b/src/openai-compat/index.ts
@@ -402,7 +402,7 @@ export function createOpenAiCompatExecutors(
       }),
     };
 
-    const response = await post(body);
+    const response = await post(body, request.signal);
     const json = (await response.json()) as WireResponse;
     const choice = json.choices?.[0];
     const toolCall = choice?.message?.tool_calls?.[0];
@@ -429,6 +429,10 @@ export function createOpenAiCompatExecutors(
     }
 
     return {
+      // The event's own `type` is spread LAST so it always wins: a stray
+      // `type` key in the model's parsed tool arguments can never override the
+      // machine event type. Event payloads are flat under the event object, so
+      // a payload field named `type` is unrepresentable by construction.
       event: {
         ...(args && typeof args === "object" ? args : {}),
         type: chosenEvent.type,

--- a/src/run-agent.test.ts
+++ b/src/run-agent.test.ts
@@ -5,9 +5,11 @@ import { createDecisionLogic } from "./decision.js";
 import {
   createAgentSchemas,
   createTextLogic,
+  IllegalResumeEventError,
   runAgent,
   sendDecision,
   setupAgent,
+  WAIT_TAG,
   type AgentDecisionRequest,
   type AgentTextRequest,
   type AgentTools,
@@ -739,43 +741,45 @@ describe("runAgent", () => {
         });
       };
 
-      test("(1) an UNBOUND child request throws at bind time naming the child + request", async () => {
+      test("(1) an UNBOUND child request inherits the parent generateText and runs to done", async () => {
         const parentMachine = makeParentMachine(makeChildMachine(false));
-
-        await expect(
-          runAgent(parentMachine, {
-            input: { topic: "agents" },
-            generateText: async () => ({ output: "x" }),
-          }),
-        ).rejects.toThrow(/child machine.*child.*researchTopic/s);
-
-        // Message must point at the nested-.provide remedy and say executors
-        // are not inherited.
-        await expect(
-          runAgent(parentMachine, {
-            input: { topic: "agents" },
-            generateText: async () => ({ output: "x" }),
-          }),
-        ).rejects.toThrow(/do NOT inherit|withExecutor/);
-      });
-
-      test("(2) a properly-bound child (nested .provide + .withExecutor) runs to done", async () => {
-        const parentMachine = makeParentMachine(makeChildMachine(true));
 
         const result = await runAgent(parentMachine, {
           input: { topic: "agents" },
-          // No decide/streamText; parent generateText is NOT what runs the
-          // child request — the child's own bound executor does.
-          generateText: async () => ({ output: "unused" }),
+          // The child's `researchTopic` request has no executor of its own; it
+          // inherits THIS generateText via runAgent's host-backed wrapper.
+          generateText: async ({ prompt }) => ({ output: `parent-ran: ${prompt}` }),
+        });
+
+        expect(result.status).toBe("done");
+        expect(result.status === "done" ? result.output : undefined).toEqual({
+          research: "parent-ran: agents",
+        });
+      });
+
+      test("(2) a child with its own .withExecutor keeps it (parent generateText NOT called for it)", async () => {
+        const parentMachine = makeParentMachine(makeChildMachine(true));
+
+        let parentCalls = 0;
+        const result = await runAgent(parentMachine, {
+          // Explicit binding shadows inheritance: the child's own bound
+          // executor runs the request, so this parent generateText is never
+          // called for it.
+          generateText: async () => {
+            parentCalls += 1;
+            return { output: "unused" };
+          },
+          input: { topic: "agents" },
         });
 
         expect(result.status).toBe("done");
         expect(result.status === "done" ? result.output : undefined).toEqual({
           research: "Research: agents",
         });
+        expect(parentCalls).toBe(0);
       });
 
-      test("(3) grandchild depth: an unbound request in a child-of-child throws", async () => {
+      test("(3) grandchild depth: an unbound request in a child-of-child inherits and runs to done", async () => {
         // Grandchild (depth 2) has an unbound request; child (depth 1)
         // invokes the grandchild; parent invokes the child.
         const grandchild = makeChildMachine(false, 2);
@@ -814,12 +818,17 @@ describe("runAgent", () => {
           midMachine as unknown as ReturnType<typeof makeChildMachine>,
         );
 
-        await expect(
-          runAgent(parentMachine, {
-            input: { topic: "agents" },
-            generateText: async () => ({ output: "x" }),
-          }),
-        ).rejects.toThrow(/researchTopic/);
+        // The grandchild's unbound `researchTopic` inherits the top-level
+        // generateText through parent > mid > grandchild (all string-keyed).
+        const result = await runAgent(parentMachine, {
+          input: { topic: "agents" },
+          generateText: async ({ prompt }) => ({ output: `depth: ${prompt}` }),
+        });
+
+        expect(result.status).toBe("done");
+        expect(result.status === "done" ? result.output : undefined).toEqual({
+          research: "depth: agents",
+        });
       });
 
       test("(4) a recursively self-invoking machine does not infinite-loop the bind walk", async () => {
@@ -862,6 +871,80 @@ describe("runAgent", () => {
           generateText: async () => ({ output: "x" }),
         });
         expect(["done", "idle", "error"]).toContain(result.status);
+      });
+
+      test("(5) child requests count toward maxModelCalls and appear in onTrace", async () => {
+        const parentMachine = makeParentMachine(makeChildMachine(false));
+
+        // The child's single inherited model call shows up in onTrace with the
+        // child request's own src.
+        const trace: AgentTraceEvent<typeof parentMachine>[] = [];
+        const ok = await runAgent(parentMachine, {
+          input: { topic: "agents" },
+          generateText: async () => ({ output: "y" }),
+          onTrace: (event) => trace.push(event),
+        });
+        expect(ok.status).toBe("done");
+        expect(
+          trace
+            .filter((event) => event.type === "request.start")
+            .map((event) => (event.request as { src?: string }).src),
+        ).toContain("researchTopic");
+
+        // ...and it draws from the SAME shared budget: capping at 0 makes the
+        // child's model call exceed it, settling a max-model-calls error.
+        const capped = await runAgent(parentMachine, {
+          input: { topic: "agents" },
+          maxModelCalls: 0,
+          generateText: async () => ({ output: "y" }),
+        });
+        expect(capped.status).toBe("error");
+        expect(capped.status === "error" ? capped.cause : undefined).toBe("max-model-calls");
+      });
+
+      test("(6) a missing streamText for a child STREAM request throws at bind naming the chain", async () => {
+        const streamResearch = createTextLogic({
+          mode: "stream",
+          schemas: { input: z.object({ topic: z.string() }), output: z.string() },
+          model: "test-model",
+          prompt: ({ input }) => input.topic,
+        });
+        const childAgent = setupAgent({
+          context: z.object({ topic: z.string(), research: z.string().nullable() }),
+          input: z.object({ topic: z.string() }),
+          output: z.object({ research: z.string() }),
+          actorSources: { streamResearch },
+        });
+        const streamChild = childAgent.createMachine({
+          id: "stream-child",
+          context: ({ input }) => ({ topic: input.topic, research: null }),
+          initial: "researching",
+          states: {
+            researching: {
+              invoke: {
+                src: "streamResearch",
+                input: ({ context }) => ({ topic: context.topic }),
+                onDone: ({ output }) => ({ target: "done", context: { research: output } }),
+              },
+            },
+            done: {
+              type: "final",
+              output: ({ context }) => ({ research: context.research ?? "" }),
+            },
+          },
+        });
+        const parentMachine = makeParentMachine(
+          streamChild as unknown as ReturnType<typeof makeChildMachine>,
+        );
+
+        // generateText is present but streamText is not — the child's stream
+        // request has no executor to inherit, so bind fails naming the chain.
+        await expect(
+          runAgent(parentMachine, {
+            input: { topic: "agents" },
+            generateText: async () => ({ output: "x" }),
+          }),
+        ).rejects.toThrow(/child machine.*streamText/s);
       });
     });
   });
@@ -1587,5 +1670,400 @@ describe("inspect passthrough (system-wide visibility)", () => {
       .map((entry) => entry.value);
     expect(childValues).toContain("working");
     expect(childValues).toContain("finished");
+  });
+});
+
+describe("Feature A: explicit suspension detection (WAIT_TAG / isSuspended)", () => {
+  test("a WAIT_TAG wait state settles idle and resumes to done", async () => {
+    const agent = setupAgent({
+      context: z.object({}),
+      input: z.object({}),
+      output: z.object({ approved: z.boolean() }),
+      events: { APPROVE: z.object({}) },
+    });
+    const machine = agent.createMachine({
+      context: {},
+      initial: "reviewing",
+      states: {
+        reviewing: {
+          tags: [WAIT_TAG],
+          on: { APPROVE: { target: "done" } },
+        },
+        done: { type: "final", output: () => ({ approved: true }) },
+      },
+    });
+
+    const first = await runAgent(machine, {
+      input: {},
+      generateText: async () => ({ output: {} }),
+    });
+    expect(first.status).toBe("idle");
+    if (first.status !== "idle") throw new Error("expected idle");
+    expect(first.snapshot.value).toBe("reviewing");
+
+    const second = await runAgent(machine, {
+      snapshot: first.snapshot,
+      event: { type: "APPROVE" },
+      generateText: async () => ({ output: {} }),
+    });
+    expect(second.status).toBe("done");
+    expect(second.status === "done" ? second.output : undefined).toEqual({ approved: true });
+  });
+
+  test("a WAIT_TAG region does not settle early while a sibling still has work in flight", async () => {
+    const agent = setupAgent({
+      context: z.object({ summary: z.string().nullable() }),
+      input: z.object({}),
+      output: z.object({ summary: z.string() }),
+      events: { APPROVE: z.object({}) },
+      requests: {
+        summarize: {
+          schemas: { input: z.object({}), output: z.string() },
+          model: "m",
+          prompt: () => "summarize",
+        },
+      },
+    });
+    const machine = agent.createMachine({
+      context: { summary: null },
+      type: "parallel",
+      states: {
+        review: {
+          initial: "waiting",
+          states: {
+            waiting: { tags: [WAIT_TAG], on: { APPROVE: { target: "approved" } } },
+            approved: { type: "final" },
+          },
+        },
+        work: {
+          initial: "summarizing",
+          states: {
+            summarizing: {
+              invoke: {
+                id: "sum",
+                src: "summarize",
+                input: {},
+                onDone: ({ output }) => ({ target: "summarized", context: { summary: output } }),
+              },
+            },
+            summarized: { type: "final" },
+          },
+        },
+      },
+    });
+
+    const result = await runAgent(machine, {
+      input: {},
+      // Async model call: if the WAIT_TAG region settled the run early, the
+      // summary would still be null. It must be present, proving the sibling
+      // work completed before the idle settle.
+      generateText: () =>
+        new Promise((res) => setTimeout(() => res({ output: "done-summary" }), 10)),
+    });
+
+    expect(result.status).toBe("idle");
+    if (result.status !== "idle") throw new Error("expected idle");
+    expect((result.snapshot.context as { summary: string | null }).summary).toBe("done-summary");
+  });
+
+  test("a custom isSuspended detector is used instead of the WAIT_TAG default", async () => {
+    const agent = setupAgent({
+      context: z.object({}),
+      input: z.object({}),
+      output: z.object({}),
+      events: { GO: z.object({}) },
+    });
+    // No WAIT_TAG anywhere: the default detector would never fire.
+    const machine = agent.createMachine({
+      context: {},
+      initial: "paused",
+      states: {
+        paused: { on: { GO: { target: "done" } } },
+        done: { type: "final", output: () => ({}) },
+      },
+    });
+
+    const seen: string[] = [];
+    const result = await runAgent(machine, {
+      input: {},
+      generateText: async () => ({ output: {} }),
+      isSuspended: (snapshot) => {
+        seen.push(JSON.stringify(snapshot.value));
+        return snapshot.matches("paused");
+      },
+    });
+
+    expect(result.status).toBe("idle");
+    expect(result.status === "idle" ? result.snapshot.value : undefined).toBe("paused");
+    // The custom detector was consulted (proving it replaced the default).
+    expect(seen).toContain('"paused"');
+  });
+
+  test("untagged machines still settle idle via the fallback heuristic (unchanged)", async () => {
+    const agent = setupAgent({
+      context: z.object({}),
+      input: z.object({}),
+      output: z.object({}),
+      events: { APPROVE: z.object({}) },
+    });
+    const machine = agent.createMachine({
+      context: {},
+      initial: "reviewing",
+      states: {
+        // No tags, no custom detector — pure heuristic path.
+        reviewing: { on: { APPROVE: { target: "done" } } },
+        done: { type: "final", output: () => ({}) },
+      },
+    });
+
+    const result = await runAgent(machine, {
+      input: {},
+      generateText: async () => ({ output: {} }),
+    });
+    expect(result.status).toBe("idle");
+    expect(result.status === "idle" ? result.snapshot.value : undefined).toBe("reviewing");
+  });
+});
+
+describe("Feature B: illegal resume event throws", () => {
+  const agent = setupAgent({
+    context: z.object({ ok: z.boolean() }),
+    input: z.object({}),
+    output: z.object({}),
+    events: { APPROVE: z.object({}), REJECT: z.object({ reason: z.string() }), SUBMIT: z.object({}) },
+  });
+  const machine = agent.createMachine({
+    context: { ok: false },
+    initial: "reviewing",
+    states: {
+      reviewing: {
+        on: {
+          APPROVE: { target: "done" },
+          REJECT: { target: "done" },
+          // Type-legal but guard-narrowed: rejected while ok === false.
+          SUBMIT: ({ context }) => (context.ok ? { target: "done" } : undefined),
+        },
+      },
+      done: { type: "final", output: () => ({}) },
+    },
+  });
+
+  const generateText = async () => ({ output: {} });
+
+  test("resuming with an event the restored state cannot take throws IllegalResumeEventError with acceptedTypes", async () => {
+    const first = await runAgent(machine, { input: {}, generateText });
+    expect(first.status).toBe("idle");
+    if (first.status !== "idle") throw new Error("expected idle");
+
+    let caught: unknown;
+    try {
+      await runAgent(machine, {
+        snapshot: first.snapshot,
+        event: { type: "NOPE" } as never,
+        generateText,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IllegalResumeEventError);
+    const err = caught as IllegalResumeEventError;
+    expect(err.eventType).toBe("NOPE");
+    expect(err.acceptedTypes.slice().sort()).toEqual(["APPROVE", "REJECT", "SUBMIT"]);
+  });
+
+  test("onIllegalResumeEvent: 'ignore' restores the older silent-drop behavior", async () => {
+    const first = await runAgent(machine, { input: {}, generateText });
+    if (first.status !== "idle") throw new Error("expected idle");
+
+    const second = await runAgent(machine, {
+      snapshot: first.snapshot,
+      event: { type: "NOPE" } as never,
+      onIllegalResumeEvent: "ignore",
+      generateText,
+    });
+
+    // No throw: the event is silently dropped and the run settles idle again.
+    expect(second.status).toBe("idle");
+    expect(second.status === "idle" ? second.snapshot.value : undefined).toBe("reviewing");
+  });
+
+  test("a type-legal event a guard rejects does not throw (settles per normal semantics)", async () => {
+    const first = await runAgent(machine, { input: {}, generateText });
+    if (first.status !== "idle") throw new Error("expected idle");
+
+    // SUBMIT is a declared, type-legal event; its guard rejects it here. This
+    // is NOT an illegal resume event — no throw, machine takes no transition.
+    const second = await runAgent(machine, {
+      snapshot: first.snapshot,
+      event: { type: "SUBMIT" },
+      generateText,
+    });
+
+    expect(second.status).toBe("idle");
+    expect(second.status === "idle" ? second.snapshot.value : undefined).toBe("reviewing");
+  });
+});
+
+describe("runAgent error cause split", () => {
+  // Builds a decision machine whose `decide` always returns an unknown event,
+  // so resolveDecision exhausts its retries and throws DecisionExhaustedError.
+  function exhaustingDecisionMachine(withOnError: boolean) {
+    const schemas = createAgentSchemas({
+      context: z.object({}),
+      input: z.object({}),
+      events: { ATTACK: z.object({}), HEAL: z.object({}) },
+    });
+    const chooseMove = createDecisionLogic({
+      model: "test-model",
+      prompt: "Choose a move.",
+      allowedEvents: ["ATTACK", "HEAL"] as const,
+    });
+    const agent = setupAgent({ schemas, actorSources: { chooseMove } });
+    return agent.createMachine({
+      context: {},
+      initial: "choosing",
+      states: {
+        choosing: {
+          invoke: {
+            id: "choosing",
+            src: "chooseMove",
+            input: {},
+            onDone: sendDecision(),
+            ...(withOnError ? { onError: { target: "fumbled" } } : {}),
+          },
+          on: { ATTACK: { target: "attacked" }, HEAL: { target: "healed" } },
+        },
+        attacked: { type: "final" },
+        healed: { type: "final" },
+        fumbled: {},
+      },
+    });
+  }
+
+  const alwaysUnknown = async (): Promise<{ event: ChosenEvent }> => ({
+    event: { type: "BOGUS" },
+  });
+
+  test("unhandled DecisionExhaustedError settles cause 'decision-exhausted'", async () => {
+    const result = await runAgent(exhaustingDecisionMachine(false), {
+      input: {},
+      generateText: async () => ({ output: {} }),
+      decide: alwaysUnknown,
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.status === "error" ? result.cause : undefined).toBe("decision-exhausted");
+  });
+
+  test("a DecisionExhaustedError handled by onError does NOT settle an error", async () => {
+    const result = await runAgent(exhaustingDecisionMachine(true), {
+      input: {},
+      generateText: async () => ({ output: {} }),
+      decide: alwaysUnknown,
+    });
+
+    // onError routed it to `fumbled` — the run settles idle, not error.
+    expect(result.status).not.toBe("error");
+    expect(result.status === "idle" ? result.snapshot.value : undefined).toBe("fumbled");
+  });
+
+  test("a plain executor throw (not decision-exhausted) still settles cause 'machine'", async () => {
+    const schemas = createAgentSchemas({
+      context: z.object({}),
+      input: z.object({}),
+      output: z.object({}),
+    });
+    const step = createTextLogic({
+      schemas: { input: z.object({}), output: z.object({}) },
+      model: "test-model",
+    });
+    const agent = setupAgent({ schemas, actorSources: { step } });
+    const machine = agent.createMachine({
+      context: {},
+      initial: "working",
+      states: {
+        working: { invoke: { id: "step", src: "step", input: {}, onDone: { target: "done" } } },
+        done: { type: "final" },
+      },
+    });
+
+    const result = await runAgent(machine, {
+      input: {},
+      generateText: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.status === "error" ? result.cause : undefined).toBe("machine");
+  });
+});
+
+describe("runAgent dev-mode serialization guard", () => {
+  test("warns once, naming the path, when idle context holds a non-JSON value (Date)", async () => {
+    const schemas = createAgentSchemas({
+      context: z.object({ createdAt: z.date() }),
+      input: z.object({}),
+      events: { GO: z.object({}) },
+    });
+    const agent = setupAgent({ schemas });
+    const machine = agent.createMachine({
+      context: () => ({ createdAt: new Date() }),
+      initial: "waiting",
+      states: {
+        waiting: { on: { GO: { target: "done" } } },
+        done: { type: "final" },
+      },
+    });
+
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      const result = await runAgent(machine, {
+        input: {},
+        generateText: async () => ({ output: {} }),
+      });
+      expect(result.status).toBe("idle");
+    } finally {
+      console.warn = original;
+    }
+
+    const serializationWarnings = warnings.filter((w) => w.includes("persist/resume"));
+    expect(serializationWarnings).toHaveLength(1);
+    expect(serializationWarnings[0]).toContain("context.createdAt (Date)");
+  });
+
+  test("does not warn when idle context is fully JSON-serializable", async () => {
+    const schemas = createAgentSchemas({
+      context: z.object({ topic: z.string() }),
+      input: z.object({}),
+      events: { GO: z.object({}) },
+    });
+    const agent = setupAgent({ schemas });
+    const machine = agent.createMachine({
+      context: () => ({ topic: "cats" }),
+      initial: "waiting",
+      states: {
+        waiting: { on: { GO: { target: "done" } } },
+        done: { type: "final" },
+      },
+    });
+
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      await runAgent(machine, { input: {}, generateText: async () => ({ output: {} }) });
+    } finally {
+      console.warn = original;
+    }
+
+    expect(warnings.filter((w) => w.includes("persist/resume"))).toHaveLength(0);
   });
 });

--- a/src/run-agent.ts
+++ b/src/run-agent.ts
@@ -15,6 +15,7 @@ import {
   type SnapshotFrom,
 } from "xstate";
 import type { AgentTools, ChosenEvent } from "./types.js";
+import { findNonSerializableContextPaths } from "./utils.js";
 import { getAcceptedEvents, sanitizeEventToolName, type AgentSchemas } from "./events.js";
 import {
   isTextLogic,
@@ -27,6 +28,7 @@ import {
   type TextLogic,
 } from "./text-logic.js";
 import {
+  DecisionExhaustedError,
   isDecisionLogic,
   isPlanLogic,
   PLAN_DONE_EVENT_TYPE,
@@ -53,6 +55,40 @@ import {
 // agent actor sources, runs the actor to completion or idle, and reports a
 // `done | idle | error` result. There is no continuation callback — idle
 // always settles and the caller resumes by snapshot (§3.4).
+
+/**
+ * xstate state tag marking a state that intentionally waits for an external
+ * event (a human approval, an inbound webhook, …). Put it on such states —
+ * `states: { reviewing: { tags: [WAIT_TAG], on: { APPROVE: ... } } }` — and
+ * runAgent settles that snapshot idle deterministically (see
+ * {@link RunAgentOptions.isSuspended}), instead of relying on the timing
+ * heuristic used for untagged machines. Tags are serializable and appear in
+ * the Stately visualizer.
+ */
+export const WAIT_TAG = "agent.wait" as const;
+
+/**
+ * Thrown by {@link runAgent} when resuming with a `snapshot` + `event` whose
+ * `type` the restored state cannot accept (a type-level check via
+ * {@link getAcceptedEvents}). A programmer/integration error, in the same
+ * class as runAgent's bind-time throws — it throws rather than settling an
+ * `error` result. A type-legal event a guard rejects is NOT this error (the
+ * machine simply takes no transition). Opt out with
+ * {@link RunAgentOptions.onIllegalResumeEvent} `'ignore'`.
+ */
+export class IllegalResumeEventError extends Error {
+  readonly eventType: string;
+  readonly acceptedTypes: string[];
+  constructor(eventType: string, acceptedTypes: string[]) {
+    super(
+      `runAgent: cannot resume with event '${eventType}' — the restored state does not accept ` +
+        `it. Accepted event types: ${acceptedTypes.length > 0 ? acceptedTypes.join(", ") : "(none)"}.`,
+    );
+    this.name = "IllegalResumeEventError";
+    this.eventType = eventType;
+    this.acceptedTypes = acceptedTypes;
+  }
+}
 
 /** Handler for `agent.userInput` invokes passed as {@link RunAgentOptions.userInput}. */
 export interface AgentUserInputExecutor {
@@ -102,7 +138,7 @@ export type AgentTraceEvent<TMachine extends AnyStateMachine = AnyStateMachine> 
       | {
           type: "run.end";
           status: "error";
-          cause: "aborted" | "max-model-calls" | "machine";
+          cause: RunAgentErrorCause;
           error: unknown;
           snapshot: SnapshotFrom<TMachine>;
         }
@@ -134,6 +170,15 @@ export interface RunAgentOptions<TMachine extends AnyStateMachine>
   snapshot?: Snapshot<unknown>;
   /** An event to send immediately after starting/resuming the actor (e.g. the human's answer to an idle-state prompt). */
   event?: EventFromLogic<TMachine>;
+  /**
+   * How to handle a resume `event` the restored state cannot accept (a
+   * type-level check via {@link getAcceptedEvents}, only applied when resuming
+   * from a `snapshot`). `'throw'` (default) throws {@link IllegalResumeEventError}
+   * before delivering the event; `'ignore'` restores the older silent behavior
+   * (the event is sent and the machine drops it). A type-legal event a guard
+   * rejects is never an illegal resume event.
+   */
+  onIllegalResumeEvent?: "throw" | "ignore";
 
   // implementations — sugar for machine.provide({ actorSources }) before the run
   /** Actor source implementations, merged onto the machine before binding — sugar for `machine.provide({ actorSources })` ahead of the run. */
@@ -149,6 +194,21 @@ export interface RunAgentOptions<TMachine extends AnyStateMachine>
    * back as `snapshot` together with a `userInput` handler that answers it.
    */
   userInput?: AgentUserInputExecutor;
+
+  /**
+   * Detects a snapshot that is an INTENTIONAL wait for an external event — the
+   * deterministic replacement for the timing heuristic runAgent uses to settle
+   * idle. Default: `(s) => s.hasTag(WAIT_TAG)`. When it returns true and
+   * nothing is in flight (no live requests/plans/invokes; the `agent.userInput`
+   * placeholder exemption still applies), runAgent settles idle immediately,
+   * without the `setTimeout` heuristic. It does NOT force-settle while agent
+   * work is in flight, and whole-machine idle semantics are unchanged;
+   * untagged machines (detector false) fall back to the heuristic exactly as
+   * before.
+   *
+   * Provisional name — may change before 2.0.
+   */
+  isSuspended?: (snapshot: AnyMachineSnapshot) => boolean;
 
   // observation — all void; no callback controls the run
   /** Fires for each streamed chunk of a `mode: 'stream'` text request, alongside the {@link AgentRequest} that produced it (parallel states can interleave multiple streams). Purely observational. */
@@ -202,9 +262,10 @@ export interface RunAgentOptions<TMachine extends AnyStateMachine>
  * runs). `done`: a final state was reached (`output` is the machine's
  * `OutputFrom`). `idle`: the run settled with no in-flight work — resume by
  * calling `runAgent` again with `{ snapshot, event }`. `error`: a run-level
- * failure, discriminated by `cause` (`'aborted'`, `'max-model-calls'`, or
- * `'machine'` for a machine error state / decision-exhausted / external
- * stop). Every variant carries the final `snapshot`, and the underlying
+ * failure, discriminated by `cause` (`'aborted'`, `'max-model-calls'`,
+ * `'decision-exhausted'`, `'machine'` for any other machine error state, or
+ * `'stopped'` for an external stop — see {@link RunAgentErrorCause}). Every
+ * variant carries the final `snapshot`, and the underlying
  * actor is stopped on every settle path — there is no live actor to resume;
  * resume is always by snapshot.
  */
@@ -231,10 +292,26 @@ export type RunAgentResult<TMachine extends AnyStateMachine> =
     }
   | {
       status: "error";
-      cause: "aborted" | "max-model-calls" | "machine";
+      cause: RunAgentErrorCause;
       error: unknown;
       snapshot: SnapshotFrom<TMachine>;
     };
+
+/**
+ * Discriminates a {@link RunAgentResult} `error`:
+ * - `'aborted'` — the run's `signal` fired.
+ * - `'max-model-calls'` — the `maxModelCalls` budget was exceeded.
+ * - `'decision-exhausted'` — the machine reached an error state whose error is
+ *   (or wraps) a {@link DecisionExhaustedError} that no `onError` handled.
+ * - `'machine'` — any other machine error state.
+ * - `'stopped'` — the actor was stopped externally (`status === 'stopped'`).
+ */
+export type RunAgentErrorCause =
+  | "aborted"
+  | "max-model-calls"
+  | "decision-exhausted"
+  | "machine"
+  | "stopped";
 
 // Thrown internally by consumeModelCall() past the budget; caught by runAgent's settle loop to produce a 'max-model-calls' error result.
 let nextRunAgentTraceId = 1;
@@ -244,6 +321,20 @@ class MaxModelCallsExceededError extends Error {
     super("runAgent exceeded maxModelCalls.");
     this.name = "MaxModelCallsExceededError";
   }
+}
+
+// True when `error` is a DecisionExhaustedError or wraps one via its `cause`
+// chain (an onError re-throw, or a machine error that carries the original as
+// its cause). Bounded so a cyclic cause chain can't loop forever.
+function wrapsDecisionExhausted(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 10 && current != null; depth++) {
+    if (current instanceof DecisionExhaustedError) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 /**
@@ -308,16 +399,16 @@ function isStateMachine(logic: unknown): logic is AnyStateMachine {
  * Fails fast (throws) at bind time — before any actor runs — when the
  * machine invokes an agent actor `runAgent` cannot execute. See §3.2 point 2.
  *
- * Recurses into invoked child state machines (arbitrarily deep), because a
- * child machine's own agent requests do NOT inherit the parent runAgent's
- * `generateText`/`streamText`/`decide` executors at runtime — the runtime
- * only wraps the parent machine's own sources, treating an invoked child as
- * one opaque actor. So a child request must carry its own executor
- * (`.withExecutor(...)`, tracked in `executorBoundLogics`) or be bound as a
- * string-keyed source inside the child (via nested `.provide`). Anything
- * unbound would silently settle the parent in its invoking state at runtime;
- * this walk turns that into a loud bind-time error naming the child and the
- * request, with the nested-`.provide` fix.
+ * Recurses into invoked child state machines (arbitrarily deep). A child
+ * machine's agent requests reached through string-keyed invoke srcs DO inherit
+ * the parent runAgent's `generateText`/`streamText`/`decide` executors —
+ * runAgent rebinds them with the same host-backed wrappers (see
+ * {@link rebindChildMachine}) — so the only remaining bind-time errors are: a
+ * required executor kind missing entirely (naming the invoke chain and src),
+ * and an unbound request reached through a direct-object invoke src that can't
+ * be rebound ({@link unrebindableChildRequestError}). A request that carries
+ * its own executor (`.withExecutor(...)`, tracked in `executorBoundLogics`)
+ * always runs itself; explicit binding shadows inheritance.
  */
 function assertBindable(
   machine: AnyStateMachine,
@@ -327,17 +418,23 @@ function assertBindable(
   assertMachineBindable(machine, effectiveSources, options, {
     isChild: false,
     childPath: "",
+    rebindable: true,
     visited: new Set([machine]),
   });
 }
 
 /** Recursion frame for {@link assertBindable}. `isChild` flips the error
- * messages to the nested-`.provide` remedy (child requests can't inherit
- * parent executors); `childPath` names the invoke chain (`parent > child`);
- * `visited` guards against a machine invoking itself recursively. */
+ * messages to name the child invoke chain; `childPath` names that chain
+ * (`parent > child`); `rebindable` is true while every link back to the root
+ * is a string-keyed source (so runAgent can rebind the request with its own
+ * executors) and false once a direct-object invoke src is crossed (those
+ * cannot be swapped via `.provide`, so an unbound request under one must
+ * carry its own executor); `visited` guards against a machine invoking itself
+ * recursively. */
 interface BindWalkContext {
   isChild: boolean;
   childPath: string;
+  rebindable: boolean;
   visited: Set<AnyStateMachine>;
 }
 
@@ -407,12 +504,13 @@ function assertMachineBindable(
       if (executorBoundLogics.has(logic as object)) {
         continue;
       }
-      if (ctx.isChild) {
-        throw unboundChildRequestError(ctx.childPath, stateName, src, "decision");
+      // Reachable only under a direct-object invoke src that can't be rebound.
+      if (!ctx.rebindable) {
+        throw unrebindableChildRequestError(ctx.childPath, stateName, src, "decision");
       }
       if (!options.hasDecide) {
         throw new Error(
-          `runAgent: state '${stateName}' invokes decision source '${src}' but no ` +
+          `runAgent: ${where} '${stateName}' invokes decision source '${src}' but no ` +
             `'decide' executor was provided to runAgent(...).`,
         );
       }
@@ -421,12 +519,12 @@ function assertMachineBindable(
 
     if (isPlanLogic(logic)) {
       // Plans resolve steps through the same `decide` executor.
-      if (ctx.isChild) {
-        throw unboundChildRequestError(ctx.childPath, stateName, src, "plan");
+      if (!ctx.rebindable) {
+        throw unrebindableChildRequestError(ctx.childPath, stateName, src, "plan");
       }
       if (!options.hasDecide) {
         throw new Error(
-          `runAgent: state '${stateName}' invokes plan source '${src}' but no ` +
+          `runAgent: ${where} '${stateName}' invokes plan source '${src}' but no ` +
             `'decide' executor was provided to runAgent(...).`,
         );
       }
@@ -439,10 +537,9 @@ function assertMachineBindable(
       if (executorBoundLogics.has(logic as object)) {
         continue;
       }
-      if (ctx.isChild) {
-        // Child requests never inherit parent executors — the only fix is to
-        // bind the child's request with its own executor.
-        throw unboundChildRequestError(
+      // Reachable only under a direct-object invoke src that can't be rebound.
+      if (!ctx.rebindable) {
+        throw unrebindableChildRequestError(
           ctx.childPath,
           stateName,
           src,
@@ -451,13 +548,13 @@ function assertMachineBindable(
       }
       if (logic.mode === "stream" && !options.hasStreamText) {
         throw new Error(
-          `runAgent: state '${stateName}' invokes streaming text source '${src}' but ` +
+          `runAgent: ${where} '${stateName}' invokes streaming text source '${src}' but ` +
             `no 'streamText' executor was provided to runAgent(...).`,
         );
       }
       if (logic.mode !== "stream" && !options.hasGenerateText) {
         throw new Error(
-          `runAgent: state '${stateName}' invokes text source '${src}' but ` +
+          `runAgent: ${where} '${stateName}' invokes text source '${src}' but ` +
             `no 'generateText' executor was provided to runAgent(...).`,
         );
       }
@@ -498,18 +595,29 @@ function assertChildMachineBindable(
 
   const childSources = childMachine.implementations.actorSources as Record<string, AnyActorLogic>;
 
+  // A child is rebindable only when it is reached through string-keyed invoke
+  // srcs all the way from the root: those can be swapped via `.provide`, so
+  // runAgent rebinds the child's unbound requests with its own executors. A
+  // direct-object invoke src (typeof childSrc !== "string") can't be swapped,
+  // so nothing under it inherits.
+  const rebindable = ctx.rebindable && typeof childSrc === "string";
+
   assertMachineBindable(childMachine, childSources, options, {
     isChild: true,
     childPath,
+    rebindable,
     visited: new Set([...ctx.visited, childMachine]),
   });
 }
 
-/** The loud bind-time error for an unbound agent request reached inside an
- * invoked child machine. Names the child invoke chain AND the request src,
- * and spells out the nested-`.provide`/`.withExecutor` remedy — child machine
- * requests do NOT inherit the parent runAgent's executors. */
-function unboundChildRequestError(
+/** The loud bind-time error for an unbound agent request reached under a
+ * direct-object invoke src, which runAgent cannot rebind (only string-keyed
+ * sources can be swapped via `.provide`). Names the invoke chain AND the
+ * request src, and spells out the `.withExecutor`/string-keyed remedy. Note:
+ * requests reachable through string-keyed srcs at any depth DO inherit
+ * runAgent's executors — this error is only for the unrebindable direct-object
+ * case. */
+function unrebindableChildRequestError(
   childPath: string,
   stateName: string,
   requestSrc: string,
@@ -517,14 +625,13 @@ function unboundChildRequestError(
 ): Error {
   return new Error(
     `runAgent: child machine '${childPath}' (state '${stateName}') invokes ${kind} ` +
-      `source '${requestSrc}', which has no host execution. Child machine requests do ` +
-      `NOT inherit the parent runAgent's generateText/streamText/decide executors — the ` +
-      `child must be bound before it is invoked. Bind it via ` +
-      `parentMachine.provide({ actorSources: { <child>: childMachine.provide({ ` +
-      `actorSources: { '${requestSrc}': requestLogic.withExecutor(...) } }) } }), or pass ` +
-      `that same nested-provided child as runAgent(parentMachine, { actorSources: { ` +
-      `<child>: childMachine.provide({ actorSources: { '${requestSrc}': ` +
-      `requestLogic.withExecutor(...) } }) } }).`,
+      `source '${requestSrc}', which has no host execution and is reached through a ` +
+      `direct-object invoke src that runAgent cannot rebind. Requests reached through ` +
+      `string-keyed actor sources inherit runAgent's generateText/streamText/decide ` +
+      `executors automatically; a direct-object child machine does not. Either bind the ` +
+      `request with its own executor (requestLogic.withExecutor(...)), or register the ` +
+      `child as a string-keyed actor source (machine.provide({ actorSources: { <child>: ` +
+      `childMachine } })) and invoke it by name.`,
   );
 }
 
@@ -550,6 +657,20 @@ function selfIdAndSrc(self: unknown): { id: string; src: string } {
     id: typeof ref?.id === "string" ? ref.id : "",
     src: typeof ref?.src === "string" ? ref.src : "",
   };
+}
+
+/**
+ * The machine actor that INVOKED a decision/plan request — the actor whose
+ * live snapshot supplies the candidate events and drives `canTake`/`send`.
+ * For a top-level request this is the root actor (identity-equal to
+ * `runCtx.actorHolder.actorRef`); for a request inside an invoked child
+ * machine it is that child's actor, so a child decision/plan reads and drives
+ * the CHILD's snapshot — not the root's. Read off `self._parent`, with the
+ * root actor as a fallback.
+ */
+function invokingActorOf(self: unknown, runCtx: RunAgentBindContext): AnyActorRef | undefined {
+  const parent = (self as { _parent?: AnyActorRef } | undefined)?._parent;
+  return parent ?? runCtx.actorHolder.actorRef;
 }
 
 function wrapTextLogicForRunAgent(logic: TextLogic, runCtx: RunAgentBindContext): TextLogic {
@@ -668,7 +789,7 @@ function createRunAgentDecisionLogic(
       // lets `update()` finish first, so the read below sees the committed,
       // current snapshot.
       await Promise.resolve();
-      const actorRef = runCtx.actorHolder.actorRef;
+      const actorRef = invokingActorOf(self, runCtx);
       const events = actorRef
         ? getAcceptedEvents(actorRef.getSnapshot() as AnyMachineSnapshot, {
             schemas: runCtx.schemas,
@@ -681,10 +802,8 @@ function createRunAgentDecisionLogic(
       return resolveDecision(request, createCountingDecide(runCtx), {
         maxRetries: logic.maxRetries,
         signal,
-        canTake: (event) => {
-          const actorRef = runCtx.actorHolder.actorRef;
-          return actorRef ? (actorRef.getSnapshot() as AnyMachineSnapshot).can(event) : true;
-        },
+        canTake: (event) =>
+          actorRef ? (actorRef.getSnapshot() as AnyMachineSnapshot).can(event) : true,
       });
     },
   });
@@ -729,8 +848,13 @@ function createRunAgentPlanLogic(logic: PlanLogic, runCtx: RunAgentBindContext):
       // transition commit before the first snapshot read.
       await Promise.resolve();
 
+      // The invoking machine actor (child at any depth, else root) — its
+      // snapshot drives candidates/canTake, and each chosen event is sent to
+      // it, so a plan inside a child machine drives the CHILD.
+      const invokingActor = invokingActorOf(self, runCtx);
+
       while (steps.length < maxSteps) {
-        const actorRef = runCtx.actorHolder.actorRef;
+        const actorRef = invokingActor;
         if (!actorRef || signal.aborted) {
           break;
         }
@@ -779,8 +903,9 @@ function createRunAgentPlanLogic(logic: PlanLogic, runCtx: RunAgentBindContext):
             if (event.type === PLAN_DONE_EVENT_TYPE || stopOn.has(event.type)) {
               return true;
             }
-            const ref = runCtx.actorHolder.actorRef;
-            return ref ? (ref.getSnapshot() as AnyMachineSnapshot).can(event) : true;
+            return invokingActor
+              ? (invokingActor.getSnapshot() as AnyMachineSnapshot).can(event)
+              : true;
           },
         });
 
@@ -809,6 +934,65 @@ function createRunAgentPlanLogic(logic: PlanLogic, runCtx: RunAgentBindContext):
     request: logic.request,
     allowedEventTypes: logic.allowedEventTypes,
   }) as PlanLogic;
+}
+
+/**
+ * Recursively rebinds an invoked child machine's own agent sources with the
+ * SAME host-backed wrappers runAgent applies to the top-level machine, so a
+ * child's text/stream/decision/plan requests inherit runAgent's executors and
+ * participate in maxModelCalls counting, onTrace/onChunk/onResult exactly like
+ * parent requests. Returns the child machine to invoke: a `.provide`-rebound
+ * copy when any inner source needed wrapping, else the original untouched.
+ *
+ * Only string-keyed sources are visited — a direct-object invoke src cannot be
+ * swapped via `.provide` (assertBindable already rejected an unbound request
+ * under one). A source that already carries its own executor
+ * (`executorBoundLogics`) is left as-is: explicit binding shadows inheritance.
+ * Cycle-safe via `visited` (a machine that invokes itself is returned as-is).
+ */
+function rebindChildMachine(
+  childMachine: AnyStateMachine,
+  runCtx: RunAgentBindContext,
+  visited: Set<AnyStateMachine>,
+): AnyStateMachine {
+  if (visited.has(childMachine)) {
+    return childMachine;
+  }
+  const childVisited = new Set([...visited, childMachine]);
+  const sources = childMachine.implementations.actorSources as Record<string, AnyActorLogic>;
+  const wrapped: Record<string, AnyActorLogic> = {};
+
+  for (const [key, logic] of Object.entries(sources)) {
+    if (isDecisionLogic(logic)) {
+      if (!executorBoundLogics.has(logic as object)) {
+        wrapped[key] = createRunAgentDecisionLogic(logic, runCtx);
+      }
+      continue;
+    }
+    if (isPlanLogic(logic)) {
+      wrapped[key] = createRunAgentPlanLogic(logic, runCtx);
+      continue;
+    }
+    if (isTextLogic(logic)) {
+      if (!executorBoundLogics.has(logic as object)) {
+        wrapped[key] = wrapTextLogicForRunAgent(logic, runCtx);
+      }
+      continue;
+    }
+    if (isStateMachine(logic)) {
+      const rebound = rebindChildMachine(logic, runCtx, childVisited);
+      if (rebound !== logic) {
+        wrapped[key] = rebound;
+      }
+      continue;
+    }
+    // Non-agent actors, `agent.userInput`, and placeholders pass through
+    // untouched (child userInput is not given the top-level HITL placeholder).
+  }
+
+  return Object.keys(wrapped).length > 0
+    ? (childMachine.provide({ actorSources: wrapped as never }) as AnyStateMachine)
+    : childMachine;
 }
 
 /**
@@ -857,6 +1041,9 @@ export async function runAgent<TMachine extends AnyStateMachine>(
   const maxModelCalls = options.maxModelCalls ?? 100;
   let modelCallCount = 0;
   let budgetExceeded = false;
+  // Dev-only serialization guard: warn at most once per run when idle context
+  // holds values that won't survive snapshot persist/resume (see settleIdle).
+  let warnedNonSerializable = false;
   const runId = `run_${nextRunAgentTraceId++}`;
   let traceSeq = 0;
 
@@ -878,6 +1065,30 @@ export async function runAgent<TMachine extends AnyStateMachine>(
       budgetExceeded = true;
       throw new MaxModelCallsExceededError();
     }
+  };
+
+  // Dev-only: on idle settle, warn once if the snapshot's context holds values
+  // that won't round-trip through JSON persistence. Skipped in production and
+  // after the first warning. Guarded so a getter/exotic context can't throw.
+  const warnNonSerializableContext = (snapshot: AnyMachineSnapshot) => {
+    if (warnedNonSerializable || process.env.NODE_ENV === "production") {
+      return;
+    }
+    let offending: string[] = [];
+    try {
+      offending = findNonSerializableContextPaths((snapshot as { context?: unknown }).context);
+    } catch {
+      return;
+    }
+    if (offending.length === 0) {
+      return;
+    }
+    warnedNonSerializable = true;
+    console.warn(
+      `runAgent: context holds value(s) that will not survive snapshot ` +
+        `persist/resume (JSON round-trip): ${offending.join(", ")}. Persist only ` +
+        `JSON-serializable context, or convert these before the run settles.`,
+    );
   };
 
   // §3.2 step 1: bind implementations. Conceptually `machine.provide({
@@ -909,8 +1120,10 @@ export async function runAgent<TMachine extends AnyStateMachine>(
   };
 
   // §3.2 step 2: wrap every effective TextLogic/DecisionLogic (and the
-  // agent.* builtins) with a host-backed executor. Every other source (plain
-  // actors, non-agent logic) passes through untouched.
+  // agent.* builtins) with a host-backed executor. Invoked child machines are
+  // recursively rebound so their requests inherit the same executors at any
+  // depth (see rebindChildMachine). Every other source (plain actors,
+  // non-agent logic) passes through untouched.
   // True when unhandled `agent.userInput` invokes are bound as pending
   // placeholders: they wait indefinitely and must not block idle detection.
   let userInputIsPlaceholder = false;
@@ -957,6 +1170,17 @@ export async function runAgent<TMachine extends AnyStateMachine>(
       }
       continue;
     }
+
+    if (isStateMachine(logic)) {
+      // An invoked child machine (string-keyed): recursively rebind its own
+      // agent sources with the same host-backed wrappers, so requests at any
+      // depth inherit runAgent's executors. Skipped if nothing needed wrapping.
+      const rebound = rebindChildMachine(logic, runCtx, new Set<AnyStateMachine>([machine]));
+      if (rebound !== logic) {
+        wrappedSources[key] = rebound;
+      }
+      continue;
+    }
     // Non-agent actors and already-unreachable placeholders pass through
     // untouched — assertBindable already rejected reachable placeholders.
   }
@@ -965,10 +1189,41 @@ export async function runAgent<TMachine extends AnyStateMachine>(
     actorSources: wrappedSources as never,
   }) as TMachine;
 
+  const isSuspended = options.isSuspended ?? ((s: AnyMachineSnapshot) => s.hasTag(WAIT_TAG));
+
+  // Feature B: reject a resume `event` the restored state cannot take. Checked
+  // here (before the actor starts, like the bind-time throws) against the
+  // type-level legal set of the restored snapshot — a live-but-unstarted actor
+  // exposes it via getAcceptedEvents. A guard-rejected-but-type-legal event
+  // still appears here, so it is never treated as illegal. Opt out with
+  // onIllegalResumeEvent: 'ignore' (the older silent behavior).
+  if (
+    options.snapshot !== undefined &&
+    options.event !== undefined &&
+    (options.onIllegalResumeEvent ?? "throw") === "throw"
+  ) {
+    const restoredSnapshot = createActor(boundMachine, {
+      snapshot: options.snapshot,
+    } as never).getSnapshot() as AnyMachineSnapshot;
+    const acceptedTypes = getAcceptedEvents(restoredSnapshot, { schemas: runCtx.schemas }).map(
+      (descriptor) => descriptor.type,
+    );
+    const eventType = (options.event as { type: string }).type;
+    if (!acceptedTypes.includes(eventType)) {
+      throw new IllegalResumeEventError(eventType, acceptedTypes);
+    }
+  }
+
   return new Promise<RunAgentResult<TMachine>>((resolvePromise) => {
     let settled = false;
     let idleTimer: ReturnType<typeof setTimeout> | undefined;
     let actor: ReturnType<typeof createActor<TMachine>>;
+    // True only during the resumed actor's initial (restore) transition, while
+    // an `event` is still pending delivery. The restored state may itself be a
+    // suspended/idle snapshot; without this guard, Feature A's immediate settle
+    // would fire during `start()` and settle idle BEFORE the resume event is
+    // sent. Cleared right before `actor.send(options.event)`.
+    let deliveringResumeEvent = options.event !== undefined;
 
     const settle = (result: RunAgentResult<TMachine>) => {
       if (settled) {
@@ -995,6 +1250,29 @@ export async function runAgent<TMachine extends AnyStateMachine>(
       });
     };
 
+    const settleIdle = (current: AnyMachineSnapshot) => {
+      // Idle is the moment persistence matters: the caller resumes from this
+      // snapshot by JSON round-trip. In dev, walk the context once and warn on
+      // any value that would silently corrupt (Date, Map, Set, function,
+      // undefined, class instance, circular). Never throws.
+      warnNonSerializableContext(current);
+      const pendingUserInputs = userInputIsPlaceholder ? collectPendingUserInputs(current) : [];
+      settle({
+        status: "idle",
+        snapshot: current as SnapshotFrom<TMachine>,
+        ...(pendingUserInputs.length > 0
+          ? {
+              pendingUserInputs,
+              persistedSnapshot: actor.getPersistedSnapshot() as Snapshot<unknown>,
+            }
+          : {}),
+      });
+    };
+
+    // Fallback for untagged machines: defer one macrotask so in-flight work
+    // that starts synchronously with a transition registers first, then settle
+    // idle if the snapshot is at rest. Feature A short-circuits this for
+    // detector-positive (suspended) snapshots — see the inspect handler.
     const scheduleIdleCheck = () => {
       if (idleTimer !== undefined) {
         clearTimeout(idleTimer);
@@ -1006,17 +1284,7 @@ export async function runAgent<TMachine extends AnyStateMachine>(
         }
         const current = actor.getSnapshot() as AnyMachineSnapshot;
         if (isIdleSnapshot(current, { ignoreUserInputChildren: userInputIsPlaceholder })) {
-          const pendingUserInputs = userInputIsPlaceholder ? collectPendingUserInputs(current) : [];
-          settle({
-            status: "idle",
-            snapshot: current as SnapshotFrom<TMachine>,
-            ...(pendingUserInputs.length > 0
-              ? {
-                  pendingUserInputs,
-                  persistedSnapshot: actor.getPersistedSnapshot() as Snapshot<unknown>,
-                }
-              : {}),
-          });
+          settleIdle(current);
         }
       }, 0);
     };
@@ -1060,9 +1328,17 @@ export async function runAgent<TMachine extends AnyStateMachine>(
         }
 
         if (snapshot.status === "error") {
+          // Reaching an error state means no `onError` transition handled the
+          // failure (a handled one transitions away instead of erroring). So a
+          // DecisionExhaustedError surfacing here is genuinely unhandled.
+          const cause: RunAgentErrorCause = budgetExceeded
+            ? "max-model-calls"
+            : wrapsDecisionExhausted(snapshot.error)
+              ? "decision-exhausted"
+              : "machine";
           settle({
             status: "error",
-            cause: budgetExceeded ? "max-model-calls" : "machine",
+            cause,
             error: snapshot.error,
             snapshot: snapshot as SnapshotFrom<TMachine>,
           });
@@ -1072,10 +1348,25 @@ export async function runAgent<TMachine extends AnyStateMachine>(
         if (snapshot.status === "stopped") {
           settle({
             status: "error",
-            cause: "machine",
+            cause: "stopped",
             error: new Error("Actor stopped externally."),
             snapshot: snapshot as SnapshotFrom<TMachine>,
           });
+          return;
+        }
+
+        // Feature A: an intentional wait (detector-positive) with nothing in
+        // flight settles idle immediately and deterministically — no
+        // setTimeout race. `deliveringResumeEvent` suppresses this during a
+        // resume's restore transition so the pending event is delivered first.
+        // Everything else (untagged machines, or a suspended snapshot with
+        // sibling work still running) falls through to the timing heuristic.
+        if (
+          !deliveringResumeEvent &&
+          isSuspended(snapshot) &&
+          isIdleSnapshot(snapshot, { ignoreUserInputChildren: userInputIsPlaceholder })
+        ) {
+          settleIdle(snapshot);
           return;
         }
 
@@ -1125,6 +1416,8 @@ export async function runAgent<TMachine extends AnyStateMachine>(
 
     actor.start();
     if (options.event) {
+      // Restore transition is done; allow the post-event transition to settle.
+      deliveringResumeEvent = false;
       actor.send(options.event as never);
     }
   });

--- a/src/setup-agent.test.ts
+++ b/src/setup-agent.test.ts
@@ -619,6 +619,50 @@ describe("setupAgent", () => {
     ).rejects.toThrow("expected string");
   });
 
+  test("request output is validated and typed in invoke.onDone (no parseOutput needed)", () => {
+    const agent = setupAgent({
+      context: z.object({ prompt: z.string(), answer: z.string().nullable() }),
+      input: z.object({ prompt: z.string() }),
+      requests: {
+        answer: {
+          schemas: {
+            input: z.object({ prompt: z.string() }),
+            output: z.object({ answer: z.string() }),
+          },
+          model: "test-model",
+          prompt: ({ input }) => input.prompt,
+        },
+      },
+    });
+
+    agent.createMachine({
+      context: ({ input }) => ({ prompt: input.prompt, answer: null }),
+      initial: "answering",
+      states: {
+        answering: {
+          invoke: {
+            id: "answer",
+            src: "answer",
+            input: ({ context }) => ({ prompt: context.prompt }),
+            onDone: ({ output }) => {
+              // `output` is typed as the request's output schema type
+              // (`{ answer: string }`) — already validated, no parseOutput.
+              const answer: string = output.answer;
+              // @ts-expect-error `output` has no `missing` property (proves it
+              // is the typed object, not `unknown`/`any`).
+              void output.missing;
+              return { target: "done", context: { answer } };
+            },
+          },
+        },
+        done: {
+          type: "final",
+          output: ({ context }) => ({ answer: context.answer ?? "" }),
+        },
+      },
+    });
+  });
+
   test("setupAgent preserves typed action guard and delay names", () => {
     const schemas = createAgentSchemas({
       context: z.object({ prompt: z.string(), ready: z.boolean() }),
@@ -2663,5 +2707,48 @@ describe("per-state context schemas (setupAgent({ states }))", () => {
     await toPromise(actor);
 
     expect(actor.getSnapshot().output).toEqual({ answer: "about states" });
+  });
+});
+
+describe("setupAgent reserved agent.* actor keys", () => {
+  const schemas = createAgentSchemas({
+    context: z.object({}),
+    input: z.object({}),
+  });
+  const someLogic = createAsyncLogic({ run: async () => ({}) });
+
+  test("throws when actorSources tries to redefine a builtin agent.* key", () => {
+    expect(() =>
+      setupAgent({
+        schemas,
+        actorSources: { "agent.decide": someLogic } as never,
+      }),
+    ).toThrow(/reserved builtin agent actor/);
+  });
+
+  test("throws when requests tries to claim a reserved agent.* key", () => {
+    expect(() =>
+      setupAgent({
+        schemas,
+        requests: {
+          "agent.plan": { schemas: { input: z.object({}), output: z.object({}) }, model: "m" },
+        } as never,
+      }),
+    ).toThrow(/reserved builtin agent actor/);
+  });
+
+  test("the reserved-key error points users to machine.provide for deliberate overrides", () => {
+    expect(() =>
+      setupAgent({
+        schemas,
+        actorSources: { "agent.generateText": someLogic } as never,
+      }),
+    ).toThrow(/machine\.provide/);
+  });
+
+  test("a non-reserved actorSources key is accepted", () => {
+    expect(() =>
+      setupAgent({ schemas, actorSources: { myActor: someLogic } }),
+    ).not.toThrow();
   });
 });

--- a/src/setup-agent.ts
+++ b/src/setup-agent.ts
@@ -658,6 +658,45 @@ function assertNoActorKeyCollisions(
   }
 }
 
+// The builtin `agent.*` actor keys — reserved so a user `actorSources`/
+// `requests` entry cannot silently clobber a builtin via spread order.
+const RESERVED_AGENT_ACTOR_KEYS: readonly string[] = [
+  ...Object.keys(builtinTextActors),
+  USER_INPUT_ACTOR,
+  DECIDE_ACTOR,
+  PLAN_ACTOR,
+];
+
+/**
+ * Rejects a user-supplied `actorSources`/`requests` key in the reserved
+ * `agent.*` builtin namespace. Without this, the builtins-first spread in
+ * {@link createAgentActorSources} lets such a key overwrite the builtin
+ * (`agent.decide`, `agent.plan`, …) silently. Deliberate override of a builtin
+ * is still possible after the machine is created, via
+ * `machine.provide({ actorSources: { 'agent.decide': ... } })`.
+ */
+function assertNoReservedAgentKeys(
+  actorSources: Record<string, unknown> | undefined,
+  requests: Record<string, unknown>,
+): void {
+  const groups: [string, Record<string, unknown> | undefined][] = [
+    ["actorSources", actorSources],
+    ["requests", requests],
+  ];
+  for (const [groupName, group] of groups) {
+    for (const key of Object.keys(group ?? {})) {
+      if (RESERVED_AGENT_ACTOR_KEYS.includes(key)) {
+        throw new Error(
+          `setupAgent: '${groupName}' key '${key}' is a reserved builtin agent actor and ` +
+            `cannot be redefined here (it would silently clobber the builtin). Reserved keys: ` +
+            `${RESERVED_AGENT_ACTOR_KEYS.join(", ")}. To deliberately override a builtin, do it ` +
+            `on the created machine instead: machine.provide({ actorSources: { '${key}': ... } }).`,
+        );
+      }
+    }
+  }
+}
+
 // Merges the four builtin `agent.*` actors with user `actors` and generated request actors, after checking for key collisions.
 function createAgentActorSources<
   TActors extends { [K in keyof TActors]: AnyActorLogic },
@@ -668,6 +707,10 @@ function createAgentActorSources<
   requestActors: RequestActors<TRequestSchemas>,
 ): SetupActors<AgentSetupActors<AgentAllActors<TActors, TRequestSchemas>, string, TModel>> {
   assertNoActorKeyCollisions(
+    actorSources as Record<string, unknown> | undefined,
+    requestActors as Record<string, unknown>,
+  );
+  assertNoReservedAgentKeys(
     actorSources as Record<string, unknown> | undefined,
     requestActors as Record<string, unknown>,
   );

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import { z } from "zod";
 import { createActor } from "xstate";
 import { getStateMeta, persistSnapshot, setupAgent } from "./index.js";
+import { findNonSerializableContextPaths } from "./utils.js";
 
 const metaSchema = z.object({
   interaction: z
@@ -107,5 +108,68 @@ describe("persistSnapshot", () => {
     });
 
     expect(persisted).toEqual({ keep: 1 });
+  });
+});
+
+describe("findNonSerializableContextPaths", () => {
+  test("returns [] for a fully JSON-safe context", () => {
+    expect(
+      findNonSerializableContextPaths({
+        topic: "cats",
+        count: 3,
+        ok: true,
+        nested: { list: [1, "two", { deep: null }] },
+        empty: null,
+      }),
+    ).toEqual([]);
+  });
+
+  test("flags a Date value, naming its path", () => {
+    const paths = findNonSerializableContextPaths({ createdAt: new Date() });
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).toMatch(/^context\.createdAt \(Date\)$/);
+  });
+
+  test("flags Map, Set, function, undefined, bigint, and class instances", () => {
+    class Widget {
+      x = 1;
+    }
+    const paths = findNonSerializableContextPaths(
+      {
+        map: new Map(),
+        set: new Set(),
+        fn: () => 1,
+        undef: undefined,
+        big: 10n,
+        inst: new Widget(),
+      },
+      10,
+    );
+    expect(paths).toEqual([
+      "context.map (Map)",
+      "context.set (Set)",
+      "context.fn (function)",
+      "context.undef (undefined)",
+      "context.big (bigint)",
+      "context.inst (Widget)",
+    ]);
+  });
+
+  test("flags a value nested inside plain objects/arrays with a dotted path", () => {
+    const paths = findNonSerializableContextPaths({ a: { b: [{ when: new Date() }] } });
+    expect(paths).toEqual(["context.a.b[0].when (Date)"]);
+  });
+
+  test("flags a circular reference instead of recursing forever", () => {
+    const obj: Record<string, unknown> = { self: null };
+    obj.self = obj;
+    const paths = findNonSerializableContextPaths(obj);
+    expect(paths).toEqual(["context.self (circular)"]);
+  });
+
+  test("does not flag a shared (DAG) reference as circular", () => {
+    const shared = { ok: true };
+    const paths = findNonSerializableContextPaths({ a: shared, b: shared });
+    expect(paths).toEqual([]);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,72 @@ export function persistSnapshot<TSnapshot>(snapshot: TSnapshot): TSnapshot {
   return JSON.parse(JSON.stringify(snapshot)) as TSnapshot;
 }
 
+/**
+ * Walks a context value and returns the dot-paths of the first few values that
+ * would NOT survive a JSON persist/resume round-trip (see {@link persistSnapshot}):
+ * `Date`, `Map`, `Set`, `RegExp`, functions, `undefined`, `bigint`, class
+ * instances (non-plain objects), and circular references. Plain objects,
+ * arrays, and JSON primitives are walked/allowed. Returns `[]` for a
+ * fully-JSON-safe value. Cheap and bounded (stops after `limit` findings) —
+ * intended for a dev-only warning at the moment persistence matters.
+ */
+export function findNonSerializableContextPaths(context: unknown, limit = 5): string[] {
+  const paths: string[] = [];
+  const seen = new WeakSet<object>();
+
+  const walk = (value: unknown, path: string): void => {
+    if (paths.length >= limit) {
+      return;
+    }
+    if (value === null) {
+      return;
+    }
+    const type = typeof value;
+    if (type === "string" || type === "number" || type === "boolean") {
+      return;
+    }
+    if (type === "undefined" || type === "bigint" || type === "function" || type === "symbol") {
+      paths.push(`${path} (${type})`);
+      return;
+    }
+    // Objects. `seen` holds only the current ancestor chain: a value revisited
+    // while still on the chain is a true cycle; a shared (DAG) reference is
+    // not — JSON.stringify duplicates those fine — so entries are removed
+    // again after their children are walked.
+    const obj = value as object;
+    if (seen.has(obj)) {
+      paths.push(`${path} (circular)`);
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      seen.add(obj);
+      value.forEach((item, index) => walk(item, `${path}[${index}]`));
+      seen.delete(obj);
+      return;
+    }
+
+    const proto = Object.getPrototypeOf(value);
+    if (proto === Object.prototype || proto === null) {
+      // Plain object — walk its entries.
+      seen.add(obj);
+      for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+        walk(item, `${path}.${key}`);
+      }
+      seen.delete(obj);
+      return;
+    }
+
+    // Any other object (Date, Map, Set, RegExp, class instance, …) does not
+    // round-trip through JSON.
+    const ctorName = (value as { constructor?: { name?: string } }).constructor?.name ?? "object";
+    paths.push(`${path} (${ctorName})`);
+  };
+
+  walk(context, "context");
+  return paths;
+}
+
 /** Builds a {@link UserMessage} from a string or multimodal content parts. */
 export function userMessage(content: string | Array<TextPart | ImagePart | FilePart>): UserMessage {
   return { role: "user", content };


### PR DESCRIPTION
## Context

Output of a DX pressure-test from the complex-agent-workflows persona (vs hand-rolling and LangGraph JS); full findings + decisions in `.scratch/dx-pressure-test.md`. This PR ships the P0 API changes, sharp-edge fixes, and doc hygiene/positioning. Fan-out lands separately via xstate (statelyai/xstate#5602) and is adopted here afterwards.

## API changes

- **Executor inheritance by default.** `runAgent`'s `generateText`/`streamText`/`decide` now flow into invoked child machines at any depth, with the same host-backed wrapping (maxModelCalls counting, onTrace/onChunk/onResult). Explicit `.withExecutor` bindings shadow inheritance. Direct-object invoke srcs (unrebindable via `.provide`) keep a loud bind-time error with the remedy. Kills the nested-`.provide` ceremony (subflows example shrank accordingly). Also fixes a latent bug: child decisions/plans previously read/sent against the **root** actor, not the invoking child.
- **`WAIT_TAG` + `isSuspended`.** Tag intentional wait states (`tags: [WAIT_TAG]`) for deterministic, immediate idle settling; custom detector via `isSuspended: (s) => boolean`. Untagged machines keep the existing heuristic unchanged. Name is provisional (noted in changeset).
- **Illegal resume events throw.** `runAgent(machine, { snapshot, event })` with an event the restored state can't accept throws `IllegalResumeEventError` (carries `eventType` + `acceptedTypes`); `onIllegalResumeEvent: 'ignore'` restores the old silent drop. Guard-rejected-but-type-legal events are not errors. machine-as-tool's hand-rolled `assertEventLegal` is deleted.
- **`error.cause` split**: `'machine' | 'decision-exhausted' | 'stopped'` (plus existing `'aborted'` / `'max-model-calls'`).
- **Reserved `agent.*` keys** in `setupAgent({ requests, actorSources })` now throw instead of silently clobbering builtins.

## Fixes

- ai-sdk `streamText` now honors `metadata.maxSteps` (was unbounded streaming tool loops).
- openai-compat `decide` is abortable (`AgentDecisionRequest.signal` threaded by `resolveDecision`; both adapters forward it).
- Dev-only warning when idle-settled context holds values that won't survive JSON persist/resume (Date/Map/Set/function/undefined/bigint/class/circular), with correct DAG handling.
- Audited `type`-clobber claim in decision adapters: **false** — event `type` already wins; regression tests added.
- Confirmed request outputs are validated **and** typed in `invoke.onDone` on both the runAgent and step paths (pinned by a type test); `parseOutput` removed from doc happy paths, kept once as a host-code escape hatch.

## Docs

- **Canonical authoring form** everywhere: models registry + flat schemas (`setupAgent({ models, context, input, output, events, requests })`), with one "Which authoring form when" table in machines.md; pack form / string refs + `resolveModel` / `createTextLogic` / `withExecutor` reframed as escape hatches.
- **New**: `docs/comparison.md` (honest head-to-head vs LangGraph JS incl. where it's ahead today, and vs a hand-rolled switch-loop) and `docs/from-a-loop.md` (incremental migration from a while-loop agent).
- Consolidated the two-waiting-styles chooser in human-in-the-loop.md; fixed leaked template markup in xstate-as-agent-workflow.md; host-actors.md frontmatter; placeholder note for fictional model ids.

## Testing

- 279 tests passing (45 files; +~30 new incl. inheritance depth/shadowing, wait-tag/idle determinism, illegal-resume, cause split, serialization guard, adapter regressions, onDone type pins).
- `pnpm run typecheck` green (src + examples).
- Changesets: 2 minor + 1 patch.