### PR TITLE
Add suspension predicate support to setupAgent.fromConfig

### DIFF
--- a/.changeset/from-config-suspension-predicate.md
+++ b/.changeset/from-config-suspension-predicate.md
@@ -1,0 +1,18 @@
+---
+"@statelyai/agent": minor
+---
+
+`setupAgent.fromConfig(...)` machines can now declare a suspension predicate, so JSON-authored agents settle idle deterministically instead of via `runAgent`'s timing heuristic (which logs a warning):
+
+- **`suspendedTags` in the workflow config** (declarative, serializable): a list of state tags marking intentional waits for an external event. `fromConfig` lowers it into a `snapshot.hasTag(...)` predicate. Every listed tag must appear in some state's `tags` — an unused entry throws at build time. The published `schemas/agent-workflow.json` gains the optional `suspendedTags` property (backward compatible).
+
+```jsonc
+{
+  "suspendedTags": ["awaiting-approval"],
+  "states": {
+    "awaitingApproval": { "tags": ["awaiting-approval"], "on": { "APPROVE": { "target": "resolved" } } }
+  }
+}
+```
+
+- **`isSuspended` on `FromConfigOptions`** (host-side function, for predicates JSON can't express): registered the same machine-carried way as `setupAgent({ isSuspended })`, surviving `machine.provide(...)`. Takes precedence over the config's `suspendedTags`; a `runAgent({ isSuspended })` host override beats both.

--- a/docs/machines-as-data.md
+++ b/docs/machines-as-data.md
@@ -260,6 +260,22 @@ result = await runAgent(machine, { snapshot, event: { type: "APPROVE" }, executo
 
 > **Note:** An idle state is any state with no `invoke`: nothing runs, so the machine waits for an external event via `on`. A state with an `invoke` is doing work (a decision, a text request, or an `agent.userInput` pause).
 
+### Suspension declaration
+
+Without a declared suspension predicate, `runAgent` settles idle via a best-effort timing heuristic (and warns). A config declares one with `suspendedTags` — the declarative form of `setupAgent({ isSuspended })`, since JSON cannot carry a function:
+
+```yaml
+suspendedTags: [awaiting-approval]
+states:
+  awaitingApproval:
+    tags: [awaiting-approval]
+    on:
+      APPROVE: { target: resolved }
+```
+
+- `fromConfig(...)` lowers the list into a `snapshot.hasTag(...)` predicate; every listed tag must appear in some state's `tags` (an unused entry is a build-time error).
+- For predicates a tag list cannot express, pass a function instead: `setupAgent.fromConfig(config, { isSuspended })`. It takes precedence over `suspendedTags`; a `runAgent({ isSuspended })` host override beats both.
+
 > **Note:** Two `prompt`-shaped fields sit at different layers. A `requests` entry's `prompt` is the text sent to the model. An `invoke`'s `input` is the data passed to the invoked source: a request's typed input, or an `agent.decide` inline input carrying its own `model`/`prompt`/`allowedEvents`.
 
 ## Expressions

--- a/examples/email-drafter/agent-logic.ts
+++ b/examples/email-drafter/agent-logic.ts
@@ -178,6 +178,9 @@ export const emailDrafterActors = {
 const agentSetup = setupAgent({
   schemas: emailDrafterSchemas,
   models,
+  // The machine's own wait signal: the `awaiting-user` tag. Every state that
+  // needs the human carries it, so `runAgent` settles idle deterministically.
+  isSuspended: (snapshot) => snapshot.hasTag("awaiting-user"),
   actors: emailDrafterActors,
 });
 
@@ -194,6 +197,7 @@ export const emailDrafter = agentSetup.createMachine({
   initial: "prompting",
   states: {
     prompting: {
+      tags: ["awaiting-user"],
       meta: {
         interaction: {
           type: "text",
@@ -239,6 +243,7 @@ export const emailDrafter = agentSetup.createMachine({
     },
 
     needsMoreInfo: {
+      tags: ["awaiting-user"],
       meta: {
         interaction: {
           type: "select",
@@ -304,6 +309,7 @@ export const emailDrafter = agentSetup.createMachine({
     },
 
     reviewing: {
+      tags: ["awaiting-user"],
       meta: {
         interaction: {
           type: "select",
@@ -355,6 +361,7 @@ export const emailDrafter = agentSetup.createMachine({
     },
 
     sent: {
+      tags: ["awaiting-user"],
       meta: {
         display: ["Email sent."],
         interaction: {

--- a/examples/file-snapshot-store/index.ts
+++ b/examples/file-snapshot-store/index.ts
@@ -63,6 +63,9 @@ const agentSetup = setupAgent({
     APPROVE: z.object({}),
     REJECT: z.object({ reason: z.string() }),
   },
+  // The machine's own wait signal: the `awaiting-review` tag. `runAgent` settles
+  // idle deterministically whenever a resting snapshot carries it.
+  isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
   requests: {
     writeDraft: {
       schemas: { input: z.object({ topic: z.string() }), output: z.string() },
@@ -102,6 +105,7 @@ export const draftMachine = agentSetup.createMachine({
       },
     },
     reviewing: {
+      tags: ["awaiting-review"],
       meta: {
         interaction: {
           label: "Approve the draft to publish it, or type the revision you want.",

--- a/examples/json-agent/index.ts
+++ b/examples/json-agent/index.ts
@@ -14,9 +14,13 @@
  *   - `draftReply` (drafting): a plain text request, same as any
  *     `setupAgent({ requests: {...} })` request.
  *   - `awaitingApproval`: an idle state — no invoke, nothing left to do
- *     until a human sends APPROVE/REJECT. `runAgent` settles
- *     `{ status: 'idle', snapshot }`; the host persists that snapshot and
- *     resumes with `runAgent(machine, { snapshot, event, executors })`.
+ *     until a human sends APPROVE/REJECT. The config's `suspendedTags:
+ *     ["awaiting-approval"]` (matching the state's `tags`) is the declarative
+ *     form of `setupAgent({ isSuspended })` — `fromConfig` lowers it to a
+ *     `hasTag` predicate, so `runAgent` settles `{ status: 'idle', snapshot }`
+ *     deterministically (no timing heuristic, no warning); the host persists
+ *     that snapshot and resumes with `runAgent(machine, { snapshot, event,
+ *     executors })`.
  *
  * `fromConfig(...)` requires a `compileSchema` option — the library does not
  * bundle a JSON Schema engine, so the config's JSON Schemas (context/events/

--- a/examples/json-agent/workflow.json
+++ b/examples/json-agent/workflow.json
@@ -73,6 +73,7 @@
     }
   },
   "initial": "triaging",
+  "suspendedTags": ["awaiting-approval"],
   "states": {
     "triaging": {
       "invoke": {
@@ -112,6 +113,7 @@
     },
     "awaitingApproval": {
       "description": "Idle: nothing left to do until a human approves or rejects the drafted reply.",
+      "tags": ["awaiting-approval"],
       "meta": {
         "interaction": {
           "label": "Nothing left to do until you approve or reject the drafted reply.",

--- a/examples/machine-as-tool/index.ts
+++ b/examples/machine-as-tool/index.ts
@@ -80,6 +80,9 @@ const agentSetup = setupAgent({
     APPROVE: z.object({}),
     REJECT: z.object({ reason: z.string() }),
   },
+  // The machine's own wait signal: the `awaiting-approval` tag. `runAgent`
+  // settles idle deterministically whenever a resting snapshot carries it.
+  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
   requests: {
     // Stands in for a real validation model call (fraud check, policy, …).
     validateRefund: {
@@ -123,6 +126,7 @@ export const refundMachine = agentSetup.createMachine({
       },
     },
     awaitingApproval: {
+      tags: ["awaiting-approval"],
       // No invoke: runAgent settles idle here. `meta.interaction` is the
       // typed contract the harness renders as a tool result.
       meta: {

--- a/examples/sql-agent/index.ts
+++ b/examples/sql-agent/index.ts
@@ -107,6 +107,9 @@ const agentSetup = setupAgent({
     APPROVE: z.object({}),
     REJECT: z.object({}),
   },
+  // The machine's own wait signal: the `awaiting-approval` tag. `runAgent`
+  // settles idle deterministically whenever a resting snapshot carries it.
+  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
   actors: {
     runQuery: createAsyncLogic<number, { plan: QueryPlan }>({
       run: async ({ input }) => executeQuery(input.plan),
@@ -184,6 +187,7 @@ export const sqlAgentMachine = agentSetup.createMachine({
     // No invoke: runAgent settles idle here. The host reads meta.interaction
     // (via getStateMeta) and resumes with APPROVE / REJECT.
     awaitingApproval: {
+      tags: ["awaiting-approval"],
       meta: {
         interaction: {
           label: "Run this query against the orders table?",

--- a/examples/suspension.test.ts
+++ b/examples/suspension.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Registry-level guard: every demo-runnable example machine that waits on a
+ * human must declare *how* it suspends.
+ *
+ * A state with `meta.interaction` is this repo's marker for "a person answers
+ * here" — the demo renders it as a prompt. When such a state rests, `runAgent`
+ * has to decide the run is idle; without a declared predicate it falls back to
+ * a timing heuristic and logs a warning. The fix is one line on `setupAgent`:
+ *
+ *     isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval")
+ *
+ * plus the matching `tags: [...]` on the waiting state. This test fails when a
+ * new example forgets it.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { AnyStateMachine, StateNode } from "xstate";
+import { getMachineSuspensionPredicate } from "../src/internal/registry.js";
+
+const examplesDir = fileURLToPath(new URL(".", import.meta.url));
+
+/**
+ * Machines that legitimately cannot carry a predicate today. Keep each entry
+ * justified — this is an escape hatch, not a backlog.
+ */
+const EXCLUDED: Record<string, string> = {
+  // Its waiting states are already tagged `waiting`, but declaring the
+  // predicate makes the settle path drop the invoked player actor's
+  // accumulated context (library bug, see the NOTE in the example). Re-enable
+  // `(s) => s.hasTag("waiting")` there once that is fixed.
+  "game-loop-agent#gameMachine": "library bug: isSuspended settle path loses child state",
+};
+
+/** An XState machine, duck-typed — instanceof is unreliable across module graphs. */
+function isMachine(value: unknown): value is AnyStateMachine {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as { transition?: unknown; root?: unknown; config?: unknown };
+  if (typeof candidate.transition !== "function" || !candidate.root) return false;
+  const config = candidate.config;
+  return !!config && typeof config === "object" && ("states" in config || "initial" in config);
+}
+
+/**
+ * States that rest waiting for a person: `meta.interaction` (the human prompt)
+ * plus event handlers and nothing of its own left to do — no invoke, no
+ * `after`, no `always`.
+ */
+function humanWaitStates(machine: AnyStateMachine): string[] {
+  const found: string[] = [];
+  const walk = (node: StateNode<any, any>) => {
+    const config = node.config as { after?: object; always?: unknown };
+    const waits =
+      node.type !== "final" &&
+      Object.keys(node.on ?? {}).length > 0 &&
+      (node.invoke ?? []).length === 0 &&
+      !config?.always &&
+      !(config?.after && Object.keys(config.after).length > 0);
+    if (waits && (node.meta as { interaction?: unknown } | undefined)?.interaction) {
+      found.push(node.id);
+    }
+    for (const child of Object.values(node.states ?? {})) walk(child as StateNode<any, any>);
+  };
+  walk(machine.root);
+  return found;
+}
+
+/** The demo lists every `examples/*` folder with an `index.ts`, minus `"manual": true`. */
+function runnableExampleIds(): string[] {
+  return readdirSync(examplesDir)
+    .filter((id) => existsSync(path.join(examplesDir, id, "index.ts")))
+    .filter((id) => {
+      const metadataPath = path.join(examplesDir, id, "metadata.json");
+      if (!existsSync(metadataPath)) return true;
+      return JSON.parse(readFileSync(metadataPath, "utf-8")).manual !== true;
+    })
+    .sort();
+}
+
+describe("example suspension predicates", () => {
+  it("declares deterministic suspension for every human-waiting machine", async () => {
+    const undeclared: string[] = [];
+    const declared: string[] = [];
+
+    for (const id of runnableExampleIds()) {
+      const module = (await import(path.join(examplesDir, id, "index.ts"))) as Record<
+        string,
+        unknown
+      >;
+      for (const [exportName, value] of Object.entries(module)) {
+        if (!isMachine(value)) continue;
+        const key = `${id}#${exportName}`;
+        if (!humanWaitStates(value).length || key in EXCLUDED) continue;
+        (getMachineSuspensionPredicate(value) ? declared : undeclared).push(key);
+      }
+    }
+
+    // A miss here means `runAgent` guesses with a timing heuristic (and warns).
+    // Fix the example, don't extend EXCLUDED, unless a library gap blocks it.
+    expect(undeclared).toEqual([]);
+    expect(declared.length).toBeGreaterThan(15);
+  }, 60_000);
+
+  it("keeps the excluded machines honest", async () => {
+    for (const key of Object.keys(EXCLUDED)) {
+      const [id, exportName] = key.split("#") as [string, string];
+      const module = (await import(path.join(examplesDir, id, "index.ts"))) as Record<
+        string,
+        unknown
+      >;
+      const machine = module[exportName];
+      expect(isMachine(machine), `${key} no longer exists`).toBe(true);
+      // Still a human-waiting machine, still undeclared — drop the exclusion
+      // once either stops being true.
+      expect(humanWaitStates(machine as AnyStateMachine).length).toBeGreaterThan(0);
+      expect(getMachineSuspensionPredicate(machine as AnyStateMachine)).toBeUndefined();
+    }
+  }, 60_000);
+});

--- a/examples/swarm-handoff/index.ts
+++ b/examples/swarm-handoff/index.ts
@@ -72,6 +72,9 @@ const agentSetup = setupAgent({
     // Hand the mic to the other specialist and give them the next message.
     HANDOFF: z.object({ to: agentName, message: z.string() }),
   },
+  // The machine's own wait signal: the `waiting` tag. `runAgent` settles idle
+  // deterministically at the turn boundary whenever a snapshot carries it.
+  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
   requests: {
     travelReply: {
       schemas: {
@@ -138,6 +141,7 @@ export const swarmHandoffMachine = agentSetup.createMachine({
     // No invoke: runAgent settles idle here. A HANDOFF switches the active
     // agent and re-routes; the host persists the snapshot in between.
     waiting: {
+      tags: ["waiting"],
       meta: {
         interaction: {
           // `{activeAgent}` resolves against context when the label is shown.

--- a/schemas/agent-workflow.json
+++ b/schemas/agent-workflow.json
@@ -71,6 +71,14 @@
         "$ref": "#/$defs/State"
       }
     },
+    "suspendedTags": {
+      "description": "State tags that mark an intentional wait for an external event (a human approval, an inbound webhook, ...). Lowered by setupAgent.fromConfig(...) into a snapshot.hasTag(...) suspension predicate so runAgent settles those states idle deterministically. Every listed tag must appear in some state's 'tags'.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
     "meta": {
       "$ref": "#/$defs/JsonObject"
     }

--- a/src/internal/registry.ts
+++ b/src/internal/registry.ts
@@ -17,9 +17,10 @@ export const agentExecutionOptions = new WeakMap<object, AgentExecutionOptions>(
  * object. `config` is shared by reference across `machine.provide(...)` (unlike
  * the machine object itself), so a predicate registered here travels with the
  * machine through `.provide` — which is why it is keyed on `config`, not the
- * machine. Set by `setupAgent({ isSuspended })` in `createMachine`, read by
- * `runAgent` (below the host `options.isSuspended` override, above the timing
- * heuristic).
+ * machine. Set by `setupAgent({ isSuspended })` in `createMachine` and by
+ * `setupAgent.fromConfig` (its `isSuspended` option or the config's
+ * `suspendedTags`), read by `runAgent` (below the host `options.isSuspended`
+ * override, above the timing heuristic).
  */
 export const machineSuspensionPredicates = new WeakMap<
   object,

--- a/src/setup-agent.test.ts
+++ b/src/setup-agent.test.ts
@@ -1,5 +1,5 @@
 import Ajv from "ajv";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { createActor, createAsyncLogic, initialTransition, toPromise, waitFor } from "xstate";
 import { createDecisionLogic } from "./decision.js";
@@ -35,6 +35,7 @@ import {
 import { executeAgentRequest, resolveDecision, type AgentRequest } from "./index.js";
 import { getAgentOutputMode, parseOutput } from "./index.js";
 import { isStructuredOutputSchema } from "./text-logic.js";
+import { getMachineSuspensionPredicate } from "./internal/registry.js";
 
 /**
  * ~15-line Ajv-to-StandardSchema adapter — the recipe for a real
@@ -2570,6 +2571,88 @@ describe("setupAgent", () => {
         { compileSchema: ajvCompiler() },
       ),
     ).toThrow(/action type 'notify'.*no\s+implementation/s);
+  });
+
+  // A minimal human-wait config: `reviewing` rests on tags until APPROVE.
+  const suspensionConfig = {
+    schemas: {
+      context: { type: "object", properties: {} },
+      events: { APPROVE: { type: "object", properties: {} } },
+    },
+    context: {},
+    initial: "reviewing",
+    states: {
+      reviewing: {
+        tags: ["waiting"],
+        on: { APPROVE: { target: "done" } },
+      },
+      done: { type: "final" as const },
+    },
+  };
+
+  test("fromConfig lowers suspendedTags into a machine-carried hasTag predicate", () => {
+    const { machine } = setupAgent.fromConfig(
+      { id: "suspended-tags", suspendedTags: ["waiting"], ...suspensionConfig },
+      { compileSchema: ajvCompiler() },
+    );
+
+    const predicate = getMachineSuspensionPredicate(machine);
+    expect(predicate).toBeDefined();
+    // Keyed on the root config, so it survives further `.provide(...)` rebinding.
+    expect(getMachineSuspensionPredicate(machine.provide({}))).toBe(predicate);
+
+    const actor = createActor(machine).start();
+    expect(predicate!(actor.getSnapshot())).toBe(true);
+    actor.send({ type: "APPROVE" });
+    expect(predicate!(actor.getSnapshot())).toBe(false);
+  });
+
+  test("fromConfig registers options.isSuspended, which wins over suspendedTags", () => {
+    const hostPredicate = () => false;
+    const { machine } = setupAgent.fromConfig(
+      { id: "issuspended-option", suspendedTags: ["waiting"], ...suspensionConfig },
+      { compileSchema: ajvCompiler(), isSuspended: hostPredicate },
+    );
+    expect(getMachineSuspensionPredicate(machine)).toBe(hostPredicate);
+  });
+
+  test("fromConfig rejects a suspendedTags entry that no state declares", () => {
+    expect(() =>
+      setupAgent.fromConfig(
+        {
+          id: "bad-suspended-tags",
+          schemas: { context: { type: "object", properties: {} } },
+          context: {},
+          initial: "start",
+          suspendedTags: ["waiting"],
+          states: { start: { type: "final" } },
+        },
+        { compileSchema: ajvCompiler() },
+      ),
+    ).toThrow(/suspendedTags.*'waiting'.*no state declares/s);
+  });
+
+  test("fromConfig + runAgent: suspendedTags settles idle without the heuristic warning", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { machine } = setupAgent.fromConfig(
+        { id: "suspended-tags-run", suspendedTags: ["waiting"], ...suspensionConfig },
+        { compileSchema: ajvCompiler() },
+      );
+
+      const result = await runAgent(machine, { input: {}, executors: {} });
+      expect(result.status).toBe("idle");
+      expect(warn).not.toHaveBeenCalled();
+
+      const resumed = await runAgent(machine, {
+        snapshot: result.status === "idle" ? result.snapshot : undefined,
+        event: { type: "APPROVE" },
+        executors: {},
+      });
+      expect(resumed.status).toBe("done");
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/src/workflow-config.ts
+++ b/src/workflow-config.ts
@@ -14,6 +14,7 @@
 import {
   createMachineFromConfig,
   type AnyActorLogic,
+  type AnyMachineSnapshot,
   type AnyStateMachine,
   type AsyncActorLogic,
   type MachineJSON,
@@ -25,6 +26,7 @@ import { type AgentRequestMode } from "./text-logic.js";
 import {
   agentExecutionOptions,
   machineStaticTransitionTargets,
+  machineSuspensionPredicates,
   missingActor,
 } from "./internal/registry.js";
 import {
@@ -155,6 +157,17 @@ export interface AgentWorkflowConfig {
   actors?: Record<string, AgentWorkflowActorConfig>;
   initial: string;
   states: Record<string, AgentWorkflowStateConfig>;
+  /**
+   * State tags that mark an INTENTIONAL wait for an external event (a human
+   * approval, an inbound webhook, …) — the declarative form of `setupAgent({
+   * isSuspended })`, since a config cannot carry a function. Lowered to a
+   * `snapshot.hasTag(...)`-any-of predicate so `runAgent` settles those
+   * snapshots idle deterministically instead of using its timing heuristic.
+   * Every listed tag must appear in some state's `tags` — an unused tag is a
+   * build-time error. A `fromConfig(config, { isSuspended })` option takes
+   * precedence; a `runAgent({ isSuspended })` host override beats both.
+   */
+  suspendedTags?: string[];
   meta?: Record<string, unknown>;
 }
 
@@ -883,6 +896,49 @@ function translateWorkflowConfig(
   return json as unknown as MachineJSON;
 }
 
+// Recursively collects every tag declared by any state in the config.
+function collectDeclaredStateTags(
+  states: Record<string, AgentWorkflowStateConfig> | undefined,
+  tags = new Set<string>(),
+): Set<string> {
+  for (const state of Object.values(states ?? {})) {
+    for (const tag of state.tags ?? []) {
+      tags.add(tag);
+    }
+    collectDeclaredStateTags(state.states, tags);
+  }
+  return tags;
+}
+
+// Resolves the machine-carried suspension predicate for a fromConfig machine:
+// the host `options.isSuspended` function when given, else the config's
+// declarative `suspendedTags` lowered to a hasTag-any-of predicate. A
+// `suspendedTags` entry no state declares is a typo'd silent no-op — the
+// machine would never test as suspended there — so it throws at build time.
+function resolveSuspensionPredicate(
+  config: AgentWorkflowConfig,
+  options: FromConfigOptions,
+): ((snapshot: AnyMachineSnapshot) => boolean) | undefined {
+  if (options.isSuspended) {
+    return options.isSuspended;
+  }
+  const suspendedTags = config.suspendedTags ?? [];
+  if (!suspendedTags.length) {
+    return undefined;
+  }
+  const declaredTags = collectDeclaredStateTags(config.states);
+  const unknown = suspendedTags.filter((tag) => !declaredTags.has(tag));
+  if (unknown.length) {
+    throw new Error(
+      `setupAgent.fromConfig: 'suspendedTags' lists ${unknown
+        .map((tag) => `'${tag}'`)
+        .join(", ")}, which no state declares in its 'tags'. Tag the waiting state(s) — e.g. ` +
+        `"tags": ["${unknown[0]}"] — or remove the entry.`,
+    );
+  }
+  return (snapshot) => suspendedTags.some((tag) => snapshot.hasTag(tag));
+}
+
 // Implementation backing the public `setupAgent.fromConfig(...)` namespace member (see setup-agent.ts) — translates an AgentWorkflowConfig into MachineJSON and builds the machine through xstate's createMachineFromConfig.
 export function setupAgentFromConfig(
   config: AgentWorkflowConfig,
@@ -949,6 +1005,13 @@ export function setupAgentFromConfig(
   if (machine.config) {
     machineStaticTransitionTargets.set(machine.config as object, translation.transitionTargets);
   }
+  // The wait-state predicate (options.isSuspended, or the config's declarative
+  // `suspendedTags`), carried on the root config like setupAgent's — so it
+  // survives further `machine.provide(...)` executor rebinding.
+  const isSuspended = resolveSuspensionPredicate(config, options);
+  if (isSuspended && machine.config) {
+    machineSuspensionPredicates.set(machine.config as object, isSuspended);
+  }
   return { machine, schemas };
 }
 
@@ -999,4 +1062,14 @@ export interface FromConfigOptions {
    * implementation here is a build-time error.
    */
   actions?: Record<string, (params: any) => unknown>;
+  /**
+   * Detects a snapshot that is an INTENTIONAL wait for an external event —
+   * the same machine-carried predicate `setupAgent({ isSuspended })` declares
+   * for TS-authored machines, registered here because a function cannot live
+   * in the workflow config itself. Takes precedence over the config's
+   * declarative {@link AgentWorkflowConfig.suspendedTags}; a
+   * `runAgent({ isSuspended })` host override beats both. Travels with the
+   * machine through `machine.provide(...)`.
+   */
+  isSuspended?: (snapshot: AnyMachineSnapshot) => boolean;
 }


### PR DESCRIPTION
## Problem

`setupAgent.fromConfig(...)` had no way to declare a suspension predicate, so JSON-authored machines (e.g. `examples/json-agent`) always settled idle via `runAgent`'s timing heuristic, with a dev-mode warning. A predicate is a function, so it can't live in the workflow JSON itself.

## Changes

- **`suspendedTags` in the workflow config** (declarative, serializable): a top-level list of state tags marking intentional waits for an external event. `fromConfig` lowers it into a `snapshot.hasTag(...)`-any-of predicate, registered machine-carried (keyed on the root config, same as `setupAgent({ isSuspended })`) so it survives `.provide(...)`. A listed tag no state declares throws at build time. The published `schemas/agent-workflow.json` gains the optional `suspendedTags` property — purely additive, backward compatible.
- **`isSuspended` on `FromConfigOptions`** for predicates a tag list can't express. Precedence: `runAgent({ isSuspended })` > `fromConfig(config, { isSuspended })` > config `suspendedTags`.
- **json-agent example** declares `suspendedTags: ["awaiting-approval"]` (plus matching state `tags`) and is removed from the `examples/suspension.test.ts` exclusion list.
- **Docs**: "Suspension declaration" section in `docs/machines-as-data.md`; changeset (minor).

## Ported in-flight work

`examples/suspension.test.ts` (the registry guard requiring every human-waiting example machine to declare a predicate) and the `isSuspended`/`tags` declarations in five examples (email-drafter, file-snapshot-store, machine-as-tool, sql-agent, swarm-handoff) are ported verbatim from uncommitted work in the shared checkout — the test depends on them. Only edit on top: the json-agent exclusion is dropped.

## Tests

- New fromConfig tests in `src/setup-agent.test.ts`: predicate lowering + survival across `.provide`, option precedence, unknown-tag rejection, and an end-to-end `runAgent` idle-settle asserting no heuristic warning.
- Full suite: `pnpm vitest run` — 96 files, 725 passed / 1 skipped. `pnpm typecheck`, lint, and format:check clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/agent/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->