### PR TITLE
Alpha API consistency pass + docs restyle

### DIFF
--- a/.changeset/alpha-api-consistency-pass.md
+++ b/.changeset/alpha-api-consistency-pass.md
@@ -1,0 +1,40 @@
+---
+"@statelyai/agent": minor
+---
+
+**Alpha API consistency pass.** Breaking renames and removals to settle the surface before 2.0 stable.
+
+Renames:
+
+- `isSuspended` → `isIdle` and `suspendedTags` → `idleTags`, matching `status: 'idle'`.
+- `canReach` returns `{ reachable, witness }` (was `{ canReach, witness }`).
+- `AgentEventLogConflictError.actualLength` → `actualIndex`.
+- `createLoopMachine({ maxIterations })` → `maxTurns`; `createToolLoopMachine({ maxTurns })` → `maxSteps`.
+- Budget breach error code `max-model-calls-exceeded` → `max-model-calls`, thrown as the exported `AgentMaxModelCallsExceededError` so `onError` can branch on `event.error.code`.
+
+Removals:
+
+- `persistSnapshot`: use XState-native `actor.getPersistedSnapshot()`, `machine.getPersistedSnapshot(snapshot)`, or `result.persistedSnapshot`.
+- `verifyReplay`: use `replay(machine, events, { verify: 'strict' })`.
+- `assertAgentMachine`: use `lintAgentMachine(machine, { throw: true })`.
+- `explorePaths({ textOutputs })`: use the `text`, `invokes`, and `userInput` channels.
+- `fork({ atEventId })`: `upToIndex` (exclusive) is the only fork address.
+- `runAgent({ onIllegalResumeEvent })`: illegal resume events always reject.
+- `runAgent({ machineVersion })`: `createMachine({ version })` is the single source, with a structural hash fallback for unversioned machines. A machine declaring XState-native `migrate` owns version mismatches.
+- `runSeam` `{ model }` seam form: seams are addressed by `{ request, occurrence }`; the implicit last-entry repeat is now opt-in `repeatLast: true`.
+- The tool-loop preset's `interruptOn` metadata convention (core never acted on it; tool-call gating is on the roadmap).
+
+Behavior changes:
+
+- `'*'` transitions now receive `@agent.usage` (plain XState wildcard semantics). Model-facing `allowedEvents` still excludes `@agent.*`.
+- `provideExecutors` binds executors recursively into child agent machines, same as `runAgent`.
+- `decide` executors take `(request, info)` like the text executors, and `resolveDecision(request, executors, options)` takes the executor set (`missing-decide-executor` error code).
+- Requests take a typed top-level `maxSteps` (the AI SDK adapter still reads `metadata.maxSteps` as a fallback).
+- `setupAgent` throws for any `requests`/`actors` key starting with `agent.` (reserved prefix).
+- All scripted queues throw when they run dry; `createScriptedExecutors` and `simulateAgent` scripts gain a `userInput` queue.
+- `getStateMeta` merges deterministically: deeper states win, and equal-depth parallel siblings merge by state id.
+
+New:
+
+- `validateAgentConfig(config)` at `@statelyai/agent/validate` (Ajv is an optional peer; the root bundle stays dependency-free).
+- `getSnapshotRequests(snapshot, options)` and `getSnapshotNodes(snapshot)` replace reading `snapshot._nodes` when hosting request interpretation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+`@statelyai/agent` is a control-flow library. This page describes what belongs in the core package and how to work on it.
+
+## Core criteria
+
+A feature belongs in core when a machine cannot otherwise express portable intent, or cannot hand that intent to an arbitrary host without framework-specific glue. Core candidates improve one of these areas:
+
+- Authoring typed, inspectable control flow.
+- Describing external work without executing it.
+- Binding that work in any host.
+- Suspending, persisting, and resuming without changing the machine.
+- Stepping and replaying deterministically.
+- Observing a run without coupling it to one telemetry or evaluation vendor.
+
+A feature does not belong in core only because common agent applications need it. Search clients, vector stores, browser automation, code sandboxes, skills, prompt registries, eval scorers, and deployment servers evolve independently as specialized libraries.
+
+For the full ownership table, see [Scope and ecosystem boundaries](docs/scope.md).
+
+## Development
+
+This repo uses pnpm.
+
+```bash
+pnpm install
+pnpm vitest run
+pnpm check       # typecheck, lint, format check, knip
+pnpm docs:check  # typechecks fenced snippets in docs/
+```
+
+- Run tests non-interactively. Do not use watch mode in CI or in a submitted change.
+- Add a changeset for any user-visible change: `pnpm changeset`.
+- Docs live in `docs/`. Fenced `ts` blocks are typechecked by `scripts/check-docs-snippets.ts`. Fence a block as `ts no-check` to skip it.
+- Examples live in `examples/`, one flat directory per example with an `index.ts` entrypoint. Each example is self-contained, with no shared harness and no local imports.
+
+## Issues
+
+Open an issue at [github.com/statelyai/agent/issues](https://github.com/statelyai/agent/issues). The API is in alpha, so reports about API shape and ergonomics are as useful as bug reports.

--- a/demo/src/agents/approval.ts
+++ b/demo/src/agents/approval.ts
@@ -8,7 +8,7 @@
  * APPROVE publishes.
  *
  * A direct port of examples/human-in-the-loop: the idle snapshot round-trips
- * through persistSnapshot on every resume, so the two halves can run in
+ * through a persisted snapshot on every resume, so the two halves can run in
  * different requests.
  */
 import { z } from "zod";
@@ -23,7 +23,7 @@ const agentSetup = setupAgent({
     APPROVE: z.object({}),
     REJECT: z.object({ reason: z.string() }),
   },
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-review"),
   requests: {
     writeDraft: {
       schemas: { input: z.object({ topic: z.string() }), output: z.string() },

--- a/demo/src/agents/refund.ts
+++ b/demo/src/agents/refund.ts
@@ -52,7 +52,7 @@ const agentSetup = setupAgent({
   },
   // `awaitingApproval` is an idle human-wait state — declare it as the suspend
   // signal so runAgent settles idle deterministically instead of timing out.
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-approval"),
 });
 
 export const refundMachine = agentSetup.createMachine({

--- a/demo/src/lib/agent-runner.ts
+++ b/demo/src/lib/agent-runner.ts
@@ -12,7 +12,6 @@
  * network.
  */
 import {
-  persistSnapshot,
   runAgent,
   type AgentRequestExecutors,
   type RunAgentResult,
@@ -213,7 +212,7 @@ function toResult(
   if (result.status === "idle") {
     base.idle = {
       ...describeIdle(machineFor(scenarioId), result.snapshot),
-      snapshot: persistSnapshot(result.snapshot) as unknown as Json,
+      snapshot: result.persistedSnapshot as unknown as Json,
     };
   }
   return base;
@@ -254,8 +253,8 @@ export async function resumeScenarioRun(
 ): Promise<ScenarioResult> {
   const { trace, onTransition } = createTraceRecorder();
   const machine = machineFor(scenarioId);
-  // `onIllegalResumeEvent: "throw"` (the default) rejects an event the restored
-  // state cannot accept — the snapshot-level validation the task requires.
+  // runAgent rejects an event the restored state cannot accept — the
+  // snapshot-level validation the task requires.
   const result = await runAgent(machine, {
     snapshot,
     event,

--- a/demo/src/lib/example-library.server.ts
+++ b/demo/src/lib/example-library.server.ts
@@ -77,8 +77,8 @@ type ExampleMetadata = {
   budgetMs?: number;
   /**
    * State tag that marks human-wait states, for plain XState machines that
-   * can't carry a setupAgent isSuspended predicate. The demo passes
-   * `runAgent(machine, { isSuspended: (s) => s.hasTag(tag) })` so idle
+   * can't carry a setupAgent isIdle predicate. The demo passes
+   * `runAgent(machine, { isIdle: (s) => s.hasTag(tag) })` so idle
    * settles deterministically instead of via the timing heuristic.
    */
   suspendedTag?: string;

--- a/demo/src/lib/machine-chat.server.ts
+++ b/demo/src/lib/machine-chat.server.ts
@@ -13,9 +13,9 @@
 import {
   getAcceptedEvents,
   getAgentSchemas,
+  getSnapshotNodes,
   getStateMeta,
   parseAgentEvent,
-  persistSnapshot,
   runAgent,
   type AgentRequestExecutors,
   type RunAgentResult,
@@ -215,7 +215,7 @@ export function resolveLabel(label: string, context: unknown): string {
  * it is the next-best idle prompt.
  */
 function activeDescription(snapshot: AnyMachineSnapshot): string | null {
-  const nodes = (snapshot as { _nodes?: Array<{ description?: string }> })._nodes ?? [];
+  const nodes = getSnapshotNodes(snapshot);
   for (let index = nodes.length - 1; index >= 0; index -= 1) {
     const description = nodes[index]?.description;
     if (typeof description === "string" && description.trim()) return description;
@@ -288,7 +288,7 @@ export type RunLimits = {
   budgetMs?: number;
   /**
    * Human-wait state tag from metadata `suspendedTag` — deterministic idle
-   * for plain XState machines with no setupAgent isSuspended predicate.
+   * for plain XState machines with no setupAgent isIdle predicate.
    */
   suspendedTag?: string;
   /** Raw source passed to Viz so v6 function transitions remain visible. */
@@ -297,7 +297,7 @@ export type RunLimits = {
 
 export const DEFAULT_RUN_BUDGET_MS = 120_000;
 
-/** metadata `suspendedTag` → an isSuspended predicate, or undefined. */
+/** metadata `suspendedTag` → an isIdle predicate, or undefined. */
 function suspendedPredicate(
   limits: RunLimits,
 ): ((snapshot: AnyMachineSnapshot) => boolean) | undefined {
@@ -447,7 +447,7 @@ function toChatResult(
       // Resume from the run's persisted snapshot, not the live one — it
       // round-trips invoked children WITH their state (a long-lived agent
       // keeps its context across chat turns).
-      idle: { ...idle, snapshot: persistSnapshot(result.persistedSnapshot) as unknown as Json },
+      idle: { ...idle, snapshot: result.persistedSnapshot as unknown as Json },
     };
   }
   const error = (result as { error?: unknown }).error;
@@ -517,7 +517,7 @@ export async function startMachineChat(
     input: input as never,
     executors: live.executors,
     signal: runSignal(limits),
-    isSuspended: suspendedPredicate(limits),
+    isIdle: suspendedPredicate(limits),
     onTransition,
     inspect: maybeCreateRunInspection(machine, limits.machineSource),
   });
@@ -560,8 +560,8 @@ export async function resumeMachineChat(
   );
   // Validate the wire event against the restored snapshot's accepted events
   // (and payload schema, when registered) before delivering it. If the
-  // snapshot can't be rehydrated for validation, runAgent's own
-  // onIllegalResumeEvent guard still rejects illegal event types.
+  // snapshot can't be rehydrated for validation, runAgent still rejects an
+  // event the restored state cannot accept.
   let parsed: { type: string } & Record<string, unknown> = event;
   try {
     const restored = machine.resolveState(
@@ -578,7 +578,7 @@ export async function resumeMachineChat(
     event: parsed as never,
     executors: live.executors,
     signal: runSignal(limits),
-    isSuspended: suspendedPredicate(limits),
+    isIdle: suspendedPredicate(limits),
     onTransition,
     inspect: maybeCreateRunInspection(machine, limits.machineSource),
   });

--- a/demo/src/lib/run-demo-agent.ts
+++ b/demo/src/lib/run-demo-agent.ts
@@ -36,7 +36,7 @@ const startInput = z.object({
 
 const resumeInput = z.object({
   scenarioId,
-  // The persisted snapshot is opaque JSON produced by persistSnapshot.
+  // The persisted snapshot is the opaque JSON an idle settle hands back.
   snapshot: z.custom<Snapshot<unknown>>((value) => value != null && typeof value === "object"),
   event: z.union([
     z.object({ kind: z.literal("interpret"), text: z.string().trim().min(1).max(4000) }),

--- a/docs/any-stack.md
+++ b/docs/any-stack.md
@@ -5,13 +5,16 @@ description: One agent machine runs unchanged in a local script, an HTTP route, 
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-An agent machine is a portable blueprint: **the machine decides, the host executes.** The machine never names a provider, a server, or a runtime, so the same definition runs unchanged locally, behind an HTTP route, or on the edge. The only host-specific part is the [executors](hosts.md), the functions that call a model.
+An agent machine does not name a provider, a server, or a runtime. The same definition runs locally, behind an HTTP route, or on an edge runtime. The only host-specific part is the [executors](hosts.md), the functions that call a model.
 
-This page authors one machine, runs it both ways a host can, then drops it into two real stacks.
+This page defines one machine, runs it in both controlled and uncontrolled mode, and then runs it in two production stacks. Each walkthrough is labeled with the stack and the mode it uses: Express with `runAgent` (controlled), and a Cloudflare Durable Object with `provideExecutors` (uncontrolled). Stack and mode are independent choices. Express can run uncontrolled, and a Durable Object can call `runAgent`.
 
 ## Machine definition
 
-A draft-and-review announcer: write a draft, settle idle for a human, publish on approval. Nothing here is host-aware.
+This machine drafts an announcement, settles idle for human review, and publishes on approval. None of it is host-aware.
+
+<!-- viz: announce machine: drafting (invoke writeDraft) -> reviewing -> APPROVE -> published (final); REJECT returns to drafting with the revision reason appended -->
+
 
 ```ts
 import { z } from "zod";
@@ -68,12 +71,12 @@ export const announceMachine = agentSetup.createMachine({
 
 ## Controlled and uncontrolled
 
-Every host binds executors one of two ways:
+Every host binds executors in one of two ways:
 
-- **Controlled (`runAgent`):** the library owns the loop. It drives the machine to a settle point (`done` | `idle` | `error`), handles idle pauses, and descends into child machines. Best when the host wants a request/response boundary and snapshot persistence.
-- **Uncontrolled (`provideExecutors` + `createActor`):** you bind executors onto the machine and run it as a plain XState actor. No run loop, no idle settling; the machine drives itself and you observe it. Best when the host already owns an actor lifecycle (a React component, a Durable Object).
+- Controlled, with `runAgent`. The library owns the loop. It drives the machine to a settle point of `done`, `idle`, or `error`, handles idle pauses, and descends into child machines. Use it when the host wants a request/response boundary and snapshot persistence.
+- Uncontrolled, with `provideExecutors` and `createActor`. You bind executors onto the machine and run it as a plain XState actor. There is no run loop and no idle settling. The actor runs itself and you observe it. Use it when the host already owns an actor lifecycle, such as a React component or a Durable Object.
 
-Same machine, same executors either way.
+The machine and the executors are the same in both modes.
 
 ```ts
 import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
@@ -86,7 +89,7 @@ const executors = createAiSdkExecutors({ models });
 
 ## Controlled host
 
-Run the machine end to end with `runAgent`, handling the idle pause inline:
+Run the machine with `runAgent` and handle the idle pause inline.
 
 ```ts
 import { runAgent } from "@statelyai/agent";
@@ -109,7 +112,7 @@ if (result.status === "idle") {
 
 ## Uncontrolled host
 
-Run the same machine as a plain XState actor:
+Run the same machine as a plain XState actor.
 
 ```ts
 import { createActor } from "xstate";
@@ -125,19 +128,24 @@ actor.subscribe((snapshot) => {
 actor.start();
 ```
 
-For fully external control with no live actor at all, XState's pure `transition(…)` / `initialTransition(…)` functions step the machine one event at a time. That is the lowest-level uncontrolled form, and it is what durable hosts build on; see [The step path](steps.md).
+For external control with no live actor, use XState's pure `transition(…)` and `initialTransition(…)` functions, which step the machine one event at a time. This is the lowest-level uncontrolled form, and durable hosts build on it. See [The step path](steps.md).
 
 ## Host walkthroughs
 
-The same machine, dropped into real stacks with zero machine changes.
+These hosts run the same machine without changing it.
 
 ### Express (controlled)
 
-`runAgent` per request. The process holds no live actor between requests, so any worker can pick up the resume: an idle settle plus a persisted snapshot **is** human-in-the-loop over HTTP.
+This host calls `runAgent` once per request. The process holds no live actor between requests, so any worker can handle the resume. An idle settle plus a persisted snapshot is how human-in-the-loop works over HTTP.
+
+The `snapshots` map below is module-level and therefore per-process. Replace it with shared storage such as Redis or a database before any worker can serve a resume. The route reports the human's options with [`getAcceptedEvents`](human-in-the-loop.md#the-humans-choices).
+
+<!-- viz: sequence diagram: client POST /agent -> runAgent -> model -> idle settle -> 202 with snapshot id; client POST /agent/:id/resume with APPROVE -> runAgent from snapshot -> done output -->
+
 
 ```ts no-check
 import express from "express";
-import { getAcceptedEvents, persistSnapshot, runAgent } from "@statelyai/agent";
+import { getAcceptedEvents, runAgent } from "@statelyai/agent";
 import type { Snapshot } from "xstate";
 import { announceMachine } from "./announce-machine.js";
 import { executors } from "./executors.js"; // as built above
@@ -154,7 +162,7 @@ app.post("/agent", async (req, res) => {
   });
   if (result.status === "idle") {
     const id = crypto.randomUUID();
-    snapshots.set(id, persistSnapshot(result.snapshot));
+    snapshots.set(id, result.persistedSnapshot ?? result.snapshot);
     const { draft } = result.snapshot.context;
     const accepted = getAcceptedEvents(result.snapshot).map((e) => e.type);
     return res.status(202).json({ id, draft, acceptedEvents: accepted });
@@ -179,11 +187,11 @@ app.post("/agent/:id/resume", async (req, res) => {
 app.listen(3000);
 ```
 
-The full reference, with revision loops and typed state meta, is [examples/express-host](../examples/express-host/index.ts). The same shape ports directly to [Hono](../examples/hono-host/index.ts), [Next.js](../examples/next-host), and [TanStack Start](../examples/tanstack-start-host).
+For the full reference, including revision loops and typed state meta, see [examples/express-host](../examples/express-host/index.ts). The same structure applies to [Hono](../examples/hono-host/index.ts), [Next.js](../examples/next-host), and [TanStack Start](../examples/tanstack-start-host).
 
 ### Cloudflare Durable Object (uncontrolled)
 
-A Durable Object already owns a long-lived actor and its own persistence, so bind executors with `provideExecutors` and run a plain `createActor`. The persisted snapshot lives in Durable Object state, so a run survives hibernation and resumes where it left off. Model resolution is injected from the environment binding, so the class stays provider-agnostic.
+A Durable Object owns a long-lived actor and its own persistence, so bind executors with `provideExecutors` and run a plain `createActor`. The persisted snapshot lives in Durable Object state, so a run survives hibernation and resumes where it stopped. On restore the snapshot wins: `createActor(machine, { snapshot, input })` ignores `input` entirely whenever a snapshot is present, so the `input` below applies only to a first start. Model resolution comes from the environment binding, so the class does not name a provider.
 
 ```ts no-check
 import { Agent, type Connection } from "agents";
@@ -232,15 +240,15 @@ export class AnnounceAgent extends Agent<Env, State> {
 }
 ```
 
-The shipped [cloudflare-agent-host](../examples/cloudflare-agent-host/index.ts) is a drop-in Durable Object class, with the `wrangler.toml` and subclass wiring spelled out. For one-turn-per-request Workers, [cloudflare-workers-ai-host](../examples/cloudflare-workers-ai-host/index.ts) drives the lower-level [step path](steps.md) against a raw Workers AI binding.
+The [cloudflare-agent-host](../examples/cloudflare-agent-host/index.ts) example is a Durable Object class you can use directly, with the `wrangler.toml` and subclass wiring included. For Workers that handle one turn per request, [cloudflare-workers-ai-host](../examples/cloudflare-workers-ai-host/index.ts) drives the [step path](steps.md) against a raw Workers AI binding.
 
 ## What changes per host
 
-The machine is **imported, never edited**. Only three things change:
+You import the machine and do not edit it. Three things change per host:
 
-- how executors are built (AI SDK locally, injected model resolution on the edge);
-- controlled (`runAgent`) or uncontrolled (`provideExecutors` + `createActor`);
-- where the snapshot is persisted (in-memory map, Durable Object state, or nothing for a straight-through local run).
+- How executors are built. Use the AI SDK locally and injected model resolution on the edge.
+- Whether the host is controlled with `runAgent` or uncontrolled with `provideExecutors` and `createActor`.
+- Where the snapshot is persisted. Options include an in-memory map, Durable Object state, or nowhere for a local run that never pauses.
 
 ## Related
 

--- a/docs/choosing-a-run-mode.md
+++ b/docs/choosing-a-run-mode.md
@@ -5,34 +5,47 @@ description: Three ways to execute the same agent machine, what each one owns, a
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
+This page describes the three ways to execute an agent machine and how to choose between them.
+
 ## Three ways to execute one machine
 
-An agent machine is a blueprint. It declares states, requests, and decisions; it never runs itself and never talks to a model. Something has to drive it, and there are three drivers:
+An agent machine declares states, requests, and decisions. It does not run itself and does not call a model. A host drives it. There are three hosts to choose from:
 
-- **`runAgent`** (controlled): the library owns the actor and the loop.
-- **`provideExecutors` + `createActor`** (uncontrolled): you own the actor; XState drives it.
-- **The step path** (`getAgentEffects` / `executeAgentRequest` / `replay`): you own the loop and the persistence.
+- `runAgent` (controlled). The library owns the actor and the run loop.
+- `provideExecutors` with `createActor` (uncontrolled). You own the actor and XState drives it.
+- The step path (`getAgentEffects`, `executeAgentRequest`, `replay`). You own the loop and the persistence.
 
-**The machine does not change between them.** The same file runs under all three, and the same tests cover it either way. Only the host changes.
+The machine is the same in all three modes. The same file runs under each one, and the same tests cover it. Only the host changes.
+
+<!-- viz: one machine feeding three hosts: runAgent (library-owned actor + loop), provideExecutors + createActor (user-owned actor), step path (user-owned loop + event log) -->
+
 
 ## Decision table
 
-| Mode                   | You own                                             | The library owns                                                    | Idle handling                                                         | Durability                                                  | Reach for it when                                                                                                 |
-| ---------------------- | --------------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **`runAgent`**         | The call site and the executors                     | The actor, the run loop, request retries, usage aggregation, traces | Settles `idle` with a snapshot to resume from                         | Snapshot per settle, plus a replayable `result.events` log  | Default. Scripts, HTTP handlers, workers, anything with a request/response boundary                               |
-| **`provideExecutors`** | `createActor`, the actor lifecycle, subscriptions   | Executor binding for agent sources only                             | None: the actor just sits in the waiting state                        | Whatever you persist off the actor (`getPersistedSnapshot`) | A host that already owns an actor lifecycle: React, a Durable Object, a long-lived process                        |
-| **Step path**          | The loop, the event log, when to persist, the clock | Pure effect derivation, request execution, replay, verification     | Explicit: no async effect owed means idle, and you persist and return | Event-sourced. Append before continue, resume by `replay`   | Serverless per turn, queue-driven work, durable execution engines, crash recovery that cannot re-bill model calls |
+| Mode                   | You own                                             | The library owns                                                    | Durability                                                  | Reach for it when                                                                                                 |
+| ---------------------- | --------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **`runAgent`**         | The call site and the executors                     | The actor, the run loop, request retries, usage aggregation, traces | Snapshot per settle, plus a replayable `result.events` log  | Scripts, HTTP handlers, workers, and anything with a request/response boundary                                    |
+| **`provideExecutors`** | `createActor`, the actor lifecycle, subscriptions   | Executor binding for agent sources only                             | Whatever you persist off the actor (`getPersistedSnapshot`) | A host that already owns an actor lifecycle, such as React, a Durable Object, or a long-lived process             |
+| **Step path**          | The loop, the event log, when to persist, the clock | Pure effect derivation, request execution, replay, verification     | Event-sourced. Append before continue, resume by `replay`   | Serverless per turn, queue-driven work, durable execution engines, and crash recovery that cannot re-bill model calls |
+
+### Idle handling
+
+Each mode reaches the point where the machine waits for an outside event differently:
+
+- `runAgent` settles with status `idle` and returns a snapshot to resume from.
+- `provideExecutors` does not settle. The actor stays alive in its current state until you send it an event.
+- On the step path, you detect idle yourself. When no asynchronous effect is owed, persist and return.
 
 ## Start with `runAgent`
 
-`runAgent` is the default and answers most needs. It binds executors, drives the machine to a settle point, and returns `{ status, output?, snapshot, events, usage }`.
+`runAgent` is the default mode. It binds executors, drives the machine to a settle point, and returns `{ status, output?, snapshot, events, usage }`.
 
-Move off it when one of these is true:
+Choose another mode when one of these is true:
 
-- The host already owns an actor and a render loop, and a second loop inside it is redundant. Go **uncontrolled**.
-- Each turn is a separate process invocation, or a crash between two model calls must not re-run the completed one. Go to the **step path**.
+- The host already owns an actor and a render loop. Use the uncontrolled mode instead of running a second loop inside it.
+- Each turn is a separate process invocation, or a crash between two model calls must not re-run the completed call. Use the step path.
 
-Everything else, including human-in-the-loop pauses that span days, is `runAgent` plus a persisted snapshot.
+Everything else uses `runAgent` with a persisted snapshot, including human-in-the-loop pauses that last days.
 
 ## Controlled: `runAgent`
 
@@ -46,14 +59,21 @@ if (result.status === "idle") {
 }
 ```
 
-- Settles `done` | `idle` | `error`, and stops its actor on every settle path, so resume is always by snapshot.
-- Descends into invoked child machines, rebinding executors as it goes.
-- Aggregates token usage into `result.usage` and emits the full trace stream through `onTrace`.
-- Returns `result.events`, a JSON-safe `AgentLogEntry[]` you can hand straight to `replay`.
-- `generateResult(machine, options)` is the go-straight-through variant: it resolves with the done result and throws `AgentIdleError` if the machine pauses.
-- For a **long-lived session** (chat turns, sockets, device events) that keeps the event log, budgets, and traces without settling and restoring each turn, `createAgentActor` is the same engine with an actor that survives idle settles: `session.actor.send(event)` re-opens the cycle, `await session.settled()` resolves at the next quiescence.
+- `runAgent` settles with status `done`, `idle`, or `error`. It stops its actor on every settle path, so you always resume from a snapshot.
+- It descends into invoked child machines and rebinds executors as it goes.
+- It aggregates token usage into `result.usage` and emits the trace stream through `onTrace`.
+- It returns `result.events`, a JSON-safe `AgentLogEntry[]` that you can pass to `replay`.
 
-Full surface: [Hosts and executors](hosts.md).
+<!-- viz: runAgent lifecycle: start/resume -> run loop (request -> executor -> transition) -> settle as done | idle | error, with snapshot + events emitted at each settle -->
+
+### Variants of the controlled mode
+
+Two entry points run the same engine as `runAgent` with a different call shape. They are variants of the controlled mode, not separate modes.
+
+- `generateResult(machine, options)` resolves with the done result and throws `AgentIdleError` if the machine pauses. Use it when an idle settle is a failure for the caller.
+- `createAgentActor(machine, options)` returns an actor that survives idle settles. Use it for long-lived sessions such as chat turns, sockets, or device events, where the event log, budgets, and traces persist across turns. Call `session.actor.send(event)` to re-open the cycle, and `await session.settled()` to resolve at the next quiescence.
+
+Read more about [Hosts and executors](hosts.md).
 
 ## Uncontrolled: `provideExecutors`
 
@@ -66,13 +86,13 @@ actor.subscribe((snapshot) => snapshot.status === "done" && console.log(snapshot
 actor.start();
 ```
 
-- Returns a machine with every agent source bound. From there it is a plain XState actor, nothing more.
-- No run loop and **no idle settling**: the actor simply waits in its current state until you send it an event.
-- **Does not descend into invoked child machines.** A child machine gets no executors unless you bind it yourself.
-- `agent.userInput` is left unbound; supply it through the third argument, `{ actors }`.
-- Tracing composes: pass `onTrace` to `provideExecutors` and `traceTransitions(onTrace)` to the actor's `inspect` for one merged stream.
+- `provideExecutors` returns a machine with every agent source bound. The result is a plain XState actor.
+- There is no run loop and no idle settling. The actor waits in its current state until you send it an event.
+- `provideExecutors` descends into registered child machines, at any depth, and binds each with its own schemas. A child invoked as a direct object is not bound, the same as under `runAgent`.
+- `agent.userInput` is left unbound. Supply it through the third argument, `{ actors }`.
+- To trace an uncontrolled run, pass `onTrace` to `provideExecutors` and pass `traceTransitions(onTrace)` to the actor's `inspect` option. The two produce one merged stream.
 
-Worked hosts: [Use in any stack](any-stack.md#controlled-and-uncontrolled).
+Read more about [Use in any stack](any-stack.md#controlled-and-uncontrolled).
 
 ## Owning the loop: the step path
 
@@ -88,21 +108,23 @@ const entry = createReplayEntry(machine, entries, effects[0].toDoneEvent(output)
 await store.append({ threadId, expectedIndex: entries.length, entries: [entry] });
 ```
 
-- No actor at all. `getAgentEffects` lowers the current frontier into an ordered `AgentEffect[]`; you resolve one, append, and fold.
-- The **event log is the source of truth**. `replay(machine, entries)` reconstructs the snapshot and the still-owed effects without executing anything.
-- Append before you continue: an optimistic `expectedIndex` append is the commit point, so two workers on one thread resolve to exactly one winner.
-- Every owed effect carries a replay-stable `requestId` to use as an idempotency key.
-- The host owns the clock (`delay` effects) and the runtime for plain `task` effects.
-- `verifyReplay` re-checks recorded hashes, so a tampered or diverged log fails loudly.
+- There is no actor. `getAgentEffects` lowers the current frontier into an ordered `AgentEffect[]`. You resolve one effect, append its completion, and fold it back in.
+- The event log is the source of truth. `replay(machine, entries)` reconstructs the snapshot and the still-owed effects without executing anything.
+- Append before you continue. An optimistic `expectedIndex` append is the commit point, so two workers on one thread resolve to exactly one winner.
+- Every owed effect carries a replay-stable `requestId` that you can use as an idempotency key.
+- The host owns the clock for `delay` effects and the runtime for `task` effects.
+- `replay(machine, events, { verify: 'strict' })` re-checks recorded hashes, so a tampered or diverged log fails with an error.
 
-Full loop, per-effect handling, and known limits: [The step path](steps.md).
+<!-- viz: step path loop: replay(entries) -> frontier effects -> execute one -> append entry -> fold with transition -> repeat, with idle exit when nothing is owed -->
 
-## Modes are not exclusive
+Read more about [The step path](steps.md), including per-effect handling and known limits.
 
-- Nothing about the machine is mode-specific, so a machine authored against `runAgent` drops onto the step path unchanged, and back.
-- Tests do not follow the mode. `simulateAgent` walks the pure step path from a by-`src` script and `createScriptedExecutors` feeds any executor-taking host, so the same assertions cover a machine whichever way production runs it. See [Testing and verification](verify.md).
-- Modes can coexist in one deployment: an HTTP route uses `runAgent`, the same machine's long-running jobs go through the step path, and a React view runs it uncontrolled.
-- Moving between modes is a host change. The cost is the code you write around the machine, never a rewrite of the machine.
+## Combining modes
+
+- No part of the machine is mode-specific. A machine written for `runAgent` runs on the step path without changes, and the reverse is also true.
+- Tests do not depend on the mode. `simulateAgent` walks the step path from a script keyed by `src`, and `createScriptedExecutors` works with any host that takes executors. The same assertions cover the machine in every mode. See [Testing and verification](verify.md).
+- One deployment can use several modes. An HTTP route can use `runAgent`, long-running jobs for the same machine can use the step path, and a React view can run it uncontrolled.
+- Moving between modes changes only the host code around the machine.
 
 ## Related
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -5,11 +5,13 @@ description: Find out why an agent did the wrong thing, using the inspector, the
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-An agent machine fails in one of two places: the **machine** (a transition that was not legal, a guard that rejected, a state with no way out) or the **request** (the model picked badly, a tool threw, the output missed its schema). The debugging order below separates them.
+This page covers the tools for finding out why an agent run did the wrong thing, in the order to reach for them.
+
+An agent machine fails in one of two places. It fails in the **machine** when a transition is not legal, a guard rejects an event, or a state has no way out. It fails in the **request** when the model chooses badly, a tool throws, or the output does not match its schema. The steps below separate the two.
 
 ## 1. Inspect the run visually
 
-The [Stately Inspector](https://stately.ai/docs/inspector) renders your machine as a live state diagram: states highlight as they are entered, and every event and transition appears as it happens. Attach it to a run:
+The [Stately Inspector](https://stately.ai/docs/inspector) renders your machine as a live state diagram. States highlight as they are entered, and every event and transition appears as it happens. Attach it to a run.
 
 ```ts
 import { createInspector } from "@statelyai/sdk";
@@ -20,15 +22,17 @@ const inspector = createInspector(); // hosted relay by default; pass `url` for 
 await runAgent(machine, { input, executors, inspect: inspector.inspect });
 ```
 
-`inspect` is a raw XState inspection passthrough, so child machines appear too. What to look for:
+`inspect` is a raw XState inspection passthrough, so child machines appear too. Look for these symptoms.
 
-- The run stops in a state you did not expect: the transition you assumed exists is not there, or its guard returned `undefined`.
-- A state is entered repeatedly: a decision is retrying (see below) or a loop guard never flips.
-- The run never leaves a state with an `invoke`: the request is still pending or its `onError` is unhandled.
+- The run stops in a state you did not expect. The transition you assumed exists is missing, or its guard returned `undefined`.
+- A state is entered repeatedly. A decision is retrying, or a loop guard never flips.
+- The run never leaves a state with an `invoke`. The request is still pending, or its `onError` is unhandled.
+
+<!-- viz: debugging order as a flow: inspector -> trace stream -> scripted reproduction -> lint, with machine-side vs request-side failures branching -->
 
 ## 2. Read the trace stream
 
-`onTrace` is the whole ordered ledger for a run: `request.start` / `request.end` / `request.error`, `stream.chunk`, `machine.transition`, `emit`, and run boundaries. It is the fastest way to see exactly what went to the model and what came back.
+`onTrace` receives the whole ordered ledger for a run: `request.start`, `request.end`, `request.error`, `stream.chunk`, `machine.transition`, `emit`, and run boundaries. It shows exactly what went to the model and what came back.
 
 ```ts
 await runAgent(machine, {
@@ -42,21 +46,21 @@ await runAgent(machine, {
 });
 ```
 
-- `event.raw` on `request.end` is the executor's verbatim result: tool calls, tool results, usage.
-- `onResult(request, { raw })` is the same data if you only care about model calls.
-- Route on `request.name`, never on prompt text.
+- `event.raw` on `request.end` is the executor's verbatim result, including tool calls, tool results, and usage.
+- `onResult(request, { raw })` gives the same data if you only care about model calls.
+- Route on `request.name`, not on prompt text.
 
-Three observation hooks are available, from broadest to narrowest:
+Three observation hooks are available, from broadest to narrowest.
 
 - `onTrace`: every event in the run, in order.
 - `onTransition`: machine transitions only, in XState terms.
 - `on`: domain events the machine explicitly emits.
 
-Details and OTel export: [Observability](observability.md).
+Read more about the trace stream and OTel export in [Observability](observability.md).
 
 ## 3. Deterministic reproduction
 
-Once you know roughly where it went wrong, take the model out. `createScriptedExecutors` replays canned answers with no API key, so the failure becomes a test.
+Once you know roughly where the run went wrong, remove the model. `createScriptedExecutors` replays canned answers with no API key, which turns the failure into a test.
 
 ```ts
 import { createScriptedExecutors, runAgent } from "@statelyai/agent";
@@ -70,31 +74,31 @@ const result = await runAgent(machine, {
 });
 ```
 
-Queue semantics are in [Scripted executors](hosts.md#scripted-executors). Two of them matter while debugging:
+Read more about queue semantics in [Scripted executors](hosts.md#scripted-executors). Two behaviors matter while debugging.
 
-- A guard-rejected decision consumes an entry and retries with the next one, which is how you reproduce a retry loop exactly.
-- Running dry throws with `error.code === 'scripted-executors-exhausted'`, naming the pending request. That is itself a signal: the machine asked for more model calls than you expected.
+- A guard-rejected decision consumes an entry and retries with the next one. This reproduces a retry loop exactly.
+- Running dry throws with `error.code === 'scripted-executors-exhausted'` and names the pending request. This also tells you the machine asked for more model calls than you expected.
 
-For a playthrough without the run loop at all, `simulateAgent(machine, { input, script })` walks the pure step path with responses keyed by invoke `src`, returning `{ status, snapshot, trail }`. The `trail` shows every step taken, which answers "why did it end up here" without any async in the way. See [Testing and verification](verify.md).
+To replay without the run loop, call `simulateAgent(machine, { input, script })`. It walks the pure step path with responses keyed by invoke `src` and returns `{ status, snapshot, trail }`. The `trail` lists every step taken, with no async involved. See [Testing and verification](verify.md).
 
-To reproduce a run that already happened in production, feed `result.events` to `replay(machine, events)`; `verifyReplay` additionally requires every hash to match, so a divergence is pinpointed to an entry. See [The event log](event-log.md).
+To reproduce a run that already happened in production, pass `result.events` to `replay(machine, events)`. Add `{ verify: 'strict' }` to require every recorded hash to be present and match, which pinpoints a divergence to a single entry. See [The event log](event-log.md).
 
 ## 4. Machine lint
 
-Some wrong behavior is structural, and `lintAgentMachine(machine)` finds it with no run at all:
+Some wrong behavior is structural. `lintAgentMachine(machine)` finds it without running the machine.
 
 ```ts
-import { assertAgentMachine, lintAgentMachine } from "@statelyai/agent";
+import { lintAgentMachine } from "@statelyai/agent";
 
 console.log(lintAgentMachine(machine)); // AgentLintDiagnostic[]: { code, severity, path, message }
-assertAgentMachine(machine); // throws AgentLintError on any error-severity finding
+lintAgentMachine(machine, { throw: true }); // throws AgentLintError on any error-severity finding
 ```
 
-Diagnostic codes worth recognizing:
+Common diagnostic codes:
 
 | Code                     | What it means                                                   |
 | ------------------------ | --------------------------------------------------------------- |
-| `unreachable-state`      | No transition reaches the state; the model can never get there. |
+| `unreachable-state`      | No transition reaches the state, so the model can never get there. |
 | `decide-without-events`  | A decision whose candidate set is empty, so it can only fail.   |
 | `undeclared-event`       | A transition on an event the setup never declared.              |
 | `missing-final`          | No final state, so a run cannot settle `done`.                  |
@@ -105,7 +109,7 @@ Diagnostic codes worth recognizing:
 
 <!-- codes and classes from src/errors.ts, src/run-agent.ts, src/decision.ts, src/effects.ts, src/verify.ts, src/event-log-store.ts, src/scripted-executors.ts, src/seam.ts -->
 
-Every framework error extends `AgentError` and carries a stable kebab-case `code`. Branch on the code, not `instanceof`, which is unreliable across bundle and process boundaries:
+Every framework error extends `AgentError` and carries a stable kebab-case `code`. Branch on the code rather than `instanceof`. `instanceof` is unreliable across bundle and process boundaries.
 
 ```ts no-check
 if (error instanceof AgentError && error.code === "decision-exhausted") {
@@ -116,56 +120,67 @@ if (error instanceof AgentError && error.code === "decision-exhausted") {
 | Code                           | Thrown by                                                  | Meaning                                                                       | First fix                                                                           |
 | ------------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `agent-idle`                   | `generateResult`                                           | The machine paused for external input instead of completing.                  | Use `runAgent` and handle `status: 'idle'`; `error.acceptedTypes` resumes it.       |
-| `illegal-resume-event`         | `runAgent` (before start, with `snapshot` + `event`)       | The restored state does not accept that event type.                           | Pick from `getAcceptedEvents(snapshot)`, or pass `onIllegalResumeEvent: 'ignore'`.  |
+| `illegal-resume-event`         | `runAgent` (before start, with `snapshot` + `event`)       | The restored state does not accept that event type.                           | Pick the resume event from `getAcceptedEvents(snapshot)`.                           |
 | `snapshot-version-mismatch`    | `runAgent` (resume)                                        | The snapshot's stamped machine version differs from the current machine's.    | Supply `migrateSnapshot`, or set `onVersionMismatch` to `'warn'` / `'ignore'`.      |
-| `max-model-calls-exceeded`     | `runAgent` internals                                       | The `maxModelCalls` budget (default 100) was exceeded.                        | Raise the budget, or fix the loop guard that never terminates.                      |
+| `max-model-calls`              | `runAgent` internals                                       | The `maxModelCalls` budget (default 100) was exceeded.                        | Raise the budget, or fix the loop guard that never terminates.                      |
+| `missing-decide-executor`      | `resolveDecision`                                          | The executor set passed in has no `decide` function.                          | Pass the whole executor set, built with `createAiSdkExecutors({ models })`.         |
 | `decision-exhausted`           | `resolveDecision`                                          | Every attempt (`maxRetries + 1`) failed validation or a guard.                | Read `error.attempts[].failure`; reconcile `allowedEvents`, schema, and guard.      |
-| `lint-failed`                  | `assertAgentMachine`                                       | The machine has at least one error-severity lint finding.                     | Read `error.diagnostics`, or call `lintAgentMachine` for the full list.             |
-| `replay-machine-mismatch`      | `replay` / `verifyReplay`                                  | A log entry is stamped for a different machine id or version.                 | Replay against the machine that wrote the log, or set an explicit `machineVersion`. |
-| `replay-divergence`            | `replay` / `verifyReplay`                                  | Recomputed state, effects, or missing hashes disagree with the entry.         | `error.index` / `error.kind` name the entry; look for impurity at that step.        |
+| `lint-failed`                  | `lintAgentMachine(machine, { throw: true })`               | The machine has at least one error-severity lint finding.                     | Read `error.diagnostics`, or call `lintAgentMachine` for the full list.             |
+| `replay-machine-mismatch`      | `replay`                                                   | A log entry is stamped for a different machine id or version.                 | Replay against the machine that wrote the log, or set an explicit `machineVersion`. |
+| `replay-divergence`            | `replay`                                                   | Recomputed state, effects, or missing hashes disagree with the entry.         | `error.index` / `error.kind` name the entry; look for impurity at that step.        |
 | `non-serializable-event`       | `createReplayEntry`, `initEntry`, `store.append`, `replay` | A value JSON would drop or coerce (`undefined`, `Date`, `Map`, class, cycle). | `error.path` names the field; store a plain-JSON equivalent instead.                |
-| `event-log-conflict`           | `AgentEventLogStore.append`                                | A concurrent writer already advanced the thread past `expectedIndex`.         | Re-read with `store.length(threadId)` and retry the append.                         |
+| `event-log-conflict`           | `AgentEventLogStore.append`                                | A concurrent writer already advanced the thread past `expectedIndex`.         | Read `error.actualIndex`, or call `store.length(threadId)`, and retry the append.   |
 | `scripted-executors-exhausted` | `createScriptedExecutors`                                  | The canned script ran dry on a pending request.                               | Add entries, or ask why the machine wanted more model calls than you scripted.      |
-| `seam-script-exhausted`        | `runSeam`                                                  | No scripted answer left for a seam request.                                   | Add an entry to `scripts.<key>`; its last entry repeats.                            |
+| `seam-script-exhausted`        | `runSeam`                                                  | No scripted answer left for a seam request.                                   | Add an entry to `scripts.<key>`, or pass `repeatLast: true`.                        |
 
-`result.cause` on an `error` result is a separate, shorter union: `'aborted' | 'max-model-calls' | 'decision-exhausted' | 'machine' | 'stopped'`.
+Each code has a class, and every class extends `AgentError`.
+
+| Class                              | Code                       |
+| ---------------------------------- | -------------------------- |
+| `AgentIdleError`                   | `agent-idle`               |
+| `AgentIllegalResumeEventError`     | `illegal-resume-event`     |
+| `AgentSnapshotVersionMismatchError`| `snapshot-version-mismatch`|
+| `AgentDecisionExhaustedError`      | `decision-exhausted`       |
+| `AgentLintError`                   | `lint-failed`              |
+| `AgentReplayMachineMismatchError`  | `replay-machine-mismatch`  |
+| `AgentReplayDivergenceError`       | `replay-divergence`        |
+| `NonSerializableAgentEventError`   | `non-serializable-event`   |
+| `AgentEventLogConflictError`       | `event-log-conflict`       |
+| `AgentMaxModelCallsExceededError`  | `max-model-calls`          |
+
+`result.cause` is separate from these codes. It appears on an `error` result and is a shorter union: `'aborted' | 'max-model-calls' | 'decision-exhausted' | 'machine' | 'stopped'`. A thrown `AgentError` carries a `code`, while a settled `error` result carries a `cause`.
 
 ## Common failure modes
 
 <!-- errors and codes from src/decision.ts, src/run-agent.ts, src/effects.ts, src/verify.ts, src/event-log-store.ts -->
 
-**The model kept picking an illegal event.** `AgentDecisionExhaustedError` (`decision-exhausted`): every attempt (up to `maxRetries + 1`) failed one of three checks. Read `error.attempts`; each has a `failure`:
+Two failures need more than the table above.
+
+### The model kept picking an illegal event
+
+`decision-exhausted` means every attempt, up to `maxRetries + 1`, failed one of three checks. Read `error.attempts`. Each attempt has a `failure`:
 
 - `unknown-event`: the model named an event that is not a candidate. Usually `allowedEvents` disagrees with what the state accepts.
-- `invalid-payload`: the event type was right, the payload missed its schema. Tighten the prompt or loosen the schema.
-- `rejected-by-guard`: the machine said no. This is the system working; if it repeats, the guard and the prompt disagree about the rule.
+- `invalid-payload`: the event type was correct but the payload did not match its schema. Tighten the prompt or loosen the schema.
+- `rejected-by-guard`: the machine rejected the event. If this repeats, the guard and the prompt disagree about the rule.
 
-An unhandled `decision-exhausted` settles the run as `{ status: 'error', cause: 'decision-exhausted' }`. Handle it on the decision invoke's `onError` to route somewhere sane.
+An unhandled `decision-exhausted` settles the run as `{ status: 'error', cause: 'decision-exhausted' }`. Handle it on the decision invoke's `onError` to route elsewhere.
 
-**The run stopped early with no error state.** Check `result.cause` on an `error` result:
+### The run stopped early with no error state
+
+Check `result.cause` on an `error` result:
 
 - `'aborted'`: your `signal` fired.
-- `'max-model-calls'`: the `maxModelCalls` budget (default 100) was exceeded.
+- `'max-model-calls'`: the `maxModelCalls` budget, default 100, was exceeded.
 - `'stopped'`: the actor was stopped externally.
 - `'machine'`: any other machine error state.
 
-A budget exhaustion usually means a loop guard never terminates; look at `result.usage.modelCalls` and [Usage and budgets](usage-and-budgets.md).
-
-**`generateResult` threw instead of returning.** `AgentIdleError` (`agent-idle`): the machine paused for external input. `error.acceptedTypes` lists the events that resume it. Use `runAgent` when idle is expected. See [Human in the loop](human-in-the-loop.md).
-
-**Resuming a snapshot failed.**
-
-- `AgentIllegalResumeEventError` (`illegal-resume-event`): the restored state does not accept the event; `error.acceptedTypes` says what it does accept. `onIllegalResumeEvent: 'ignore'` opts out.
-- `AgentSnapshotVersionMismatchError` (`snapshot-version-mismatch`): the machine's structure changed since the snapshot was persisted. Supply `migrateSnapshot`, or set `onVersionMismatch` to `'warn'`/`'ignore'`.
-
-**Replay did not match.** `AgentReplayMachineMismatchError` (`replay-machine-mismatch`) means the log targets a different machine or version. `AgentReplayDivergenceError` (`replay-divergence`) names the entry index and whether state, effects, or verification hashes diverged.
-
-**The log would not persist.** `NonSerializableAgentEventError` (`non-serializable-event`) names the offending field path; `AgentEventLogConflictError` (`event-log-conflict`) means a concurrent writer won the append.
+Budget exhaustion usually means a loop guard never terminates. Check `result.usage.modelCalls` and see [Usage and budgets](usage-and-budgets.md).
 
 ## Related
 
 - [Observability](observability.md): the trace stream, the inspector, and OTel export.
 - [Testing and verification](verify.md): `lintAgentMachine`, `simulateAgent`, `canReach`.
-- [The event log](event-log.md): replay, `verifyReplay`, and forking a log.
+- [The event log](event-log.md): replay, strict verification, and forking a log.
 - [Usage and budgets](usage-and-budgets.md): model-call and token accounting.
 - [Decisions](decisions.md): retries, `allowedEvents`, and guard rejection.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7,15 +7,18 @@ description: Let the model choose one currently-legal machine event, validated a
 
 ## Overview
 
-A **decision** lets the model choose an event to send to the running machine. It chooses based on which events are enabled in the current state: the machine declares candidate events, guards decide which are legal, and the model picks among the survivors. Not free text, not an arbitrary tool call; an out-of-bounds choice is impossible, not merely discouraged by a prompt.
+A **decision** lets the model choose one event to send to the running machine. The machine declares the candidate events, guards determine which of them are legal in the current state, and the model picks one of the remaining candidates. The model does not produce free text or an arbitrary tool call. The machine rejects any event that is not legal in the current state.
 
-The snippets below are from [Twenty Questions](../examples/twenty-questions/index.ts), where each turn the model chooses `ASK` or `GUESS`.
+The snippets below come from [Twenty Questions](../examples/twenty-questions/index.ts), where the model chooses `ASK` or `GUESS` each turn.
+
+<!-- viz: sequence diagram for one decision: machine invokes agent.decide -> host coerces the model to one candidate event -> validation (unknown-event / invalid-payload / rejected-by-guard) -> retry or send the event to the machine -->
+
 
 ## Invoking an agent decision
 
 <!-- agent.decide builtin from src/setup-agent.ts and src/decision.ts -->
 
-Author a decision inline with the builtin `agent.decide` actor source, on the invoke that needs one. Its input takes:
+Author a decision inline on the invoke that needs one, using the builtin `agent.decide` actor source. Its input takes:
 
 - `model`: which model to use (a key from your models map).
 - `system` (optional): system prompt.
@@ -35,7 +38,7 @@ deciding: {
       prompt: `Questions remaining: ${context.questionsRemaining}`,
       allowedEvents: ['ASK', 'GUESS'],
     }),
-    // The model never made a valid choice (retries exhausted).
+    // Reached when retries are exhausted.
     onError: { target: 'failed' },
   },
   on: {
@@ -47,37 +50,41 @@ deciding: {
 // ...
 ```
 
-The `allowedEvents` list is strongly typed against the machine's event schema, so a typo is a compile error. Listing events explicitly also makes the candidate set reviewable in the machine.
+The `allowedEvents` list is typed against the machine's event schema, so a typo is a compile error. Listing events explicitly also makes the candidate set visible in the machine.
 
-> **Note:** `agent.decide` needs a **snapshot-aware host** (`runAgent` or the [step path](steps.md)) to know which events are currently legal. Under a bare `createActor(...)`, list `allowedEvents` explicitly; wildcards and the omitted default cannot expand there.
-
-> **Note:** `allowedEvents` narrows the _declared_ candidates; guards then decide what is actually legal from the current snapshot. A declared-but-currently-illegal choice does not get through.
+> **Note:** `agent.decide` needs a snapshot-aware host, either `runAgent` or the [step path](steps.md), to know which events are currently legal. In [uncontrolled mode](choosing-a-run-mode.md#uncontrolled-provideexecutors), under a bare `createActor(...)`, list `allowedEvents` explicitly. Wildcards and the omitted default cannot expand there.
 
 ### `allowedEvents` patterns
 
-The `allowedEvents` option accepts a single string or an array. Entries are exact event types or wildcard patterns, and the two can mix (`['todo.*', 'reset']`):
+The `allowedEvents` option accepts a single string or an array. Entries are exact event types or wildcard patterns, and the two can mix, as in `['todo.*', 'reset']`.
 
-- `['ASK', 'GUESS']`: exact types, typed against the event-schema keys (typo = compile error).
-- `'ASK'`: a single string, shorthand for a one-entry array.
-- `'*'`: every currently-legal event.
-- `'todo.*'`: a dotted namespace, every declared event under `todo.` (`todo.add`, `todo.toggle`, …). Typed against declared dotted types, so `'nope.*'` (matching nothing) is a compile error.
+| Value | Meaning |
+| ----- | ------- |
+| `['ASK', 'GUESS']` | Exact event types, typed against the event-schema keys. A typo is a compile error. |
+| `'ASK'` | A single string, shorthand for a one-entry array. |
+| `'*'` | Every currently-legal event. |
+| `'todo.*'` | Every declared event under the `todo.` namespace, such as `todo.add` and `todo.toggle`. Typed against declared dotted types, so a pattern matching nothing, such as `'nope.*'`, is a compile error. |
 
 ## Delivering the chosen event
 
-Delivery is automatic: when the decision resolves, the `agent.decide` actor sends the chosen event to the machine, and the matching `on:` transition runs. You handle the outcome with ordinary transitions, no special decision plumbing.
+Delivery is automatic. When the decision resolves, the `agent.decide` actor sends the chosen event to the machine, and the matching `on:` transition runs. You handle the outcome with ordinary transitions.
 
-> **Note:** The chosen event's transition typically exits the invoking state, cancelling the invoke, so `onDone` normally never fires. Declare `onDone` only when the chosen event's transition stays in-state; the invoke then completes with the chosen event as output. `onError` (retries exhausted, `AgentDecisionExhaustedError`) is unaffected.
+### When `onDone` fires
+
+The chosen event's transition usually exits the invoking state, which cancels the invoke, so `onDone` normally never fires. Declare `onDone` only when the chosen event's transition stays in the same state. The invoke then completes with the chosen event as its output. `onError` is unaffected and still fires when retries are exhausted with `AgentDecisionExhaustedError`.
 
 ## Guard enforcement
 
-Guards are transition functions returning `undefined` (see [transitions](machines.md#transitions)). Because a guard may read the event payload, candidates cannot be filtered upfront: a decision offers the full `allowedEvents` set (intersected with what the state statically accepts), and `snapshot.can(event)` is checked **after** the model picks. A chosen `ASK` on the final turn is rejected and the model asked again.
+Guards are transition functions that return `undefined`. See [Transitions](machines.md#transitions). A guard may read the event payload, so candidates cannot be filtered before the model picks.
 
-`runAgent` and the step path do this for you. When calling `resolveDecision` directly (uncontrolled mode), thread the check via `canTake`:
+The candidate set is the `allowedEvents` list intersected with the events the state statically accepts. After the model picks one, `snapshot.can(event)` decides whether it is legal in the current snapshot. A chosen `ASK` on the final turn is rejected, and the model is asked again.
+
+`runAgent` and the step path perform this check for you. When you call [`resolveDecision`](steps.md#standalone-decision-resolution) directly in [uncontrolled mode](choosing-a-run-mode.md#uncontrolled-provideexecutors), pass the check through `canTake`:
 
 ```ts
 import { resolveDecision } from "@statelyai/agent";
 
-const event = await resolveDecision(request, executors.decide, {
+const event = await resolveDecision(request, executors, {
   canTake: (e) => snapshot.can(e),
 });
 ```
@@ -88,30 +95,35 @@ const event = await resolveDecision(request, executors.decide, {
 
 Each attempt runs three checks in order. Each failure is typed and fed back to the model on the next attempt:
 
-- **`unknown-event`**: the type is not among the candidate events.
-- **`invalid-payload`**: the payload does not match that event's schema.
-- **`rejected-by-guard`**: type and payload are fine, but `snapshot.can(event)` returned `false`.
+| Failure | Cause |
+| ------- | ----- |
+| `unknown-event` | The event type is not among the candidate events. |
+| `invalid-payload` | The payload does not match that event's schema. |
+| `rejected-by-guard` | The type and payload are valid, but `snapshot.can(event)` returned `false`. |
 
 Retry behavior:
 
-- Default 2 retries, so up to 3 attempts. Set `maxRetries` on the decide input to change it.
-- Prior failed attempts ride on `request.attempts`, so the host can render "your last choice failed because X" into the next call. Core never rewrites the prompt itself; see [Hosts](hosts.md).
-- Exhausting retries throws `AgentDecisionExhaustedError` (carrying the attempts list), caught by the invoke's `onError`.
+- The default is 2 retries, so up to 3 attempts. Set `maxRetries` on the decide input to change it.
+- Prior failed attempts are carried on `request.attempts`, so the host can render the previous failure into the next call. Core does not rewrite the prompt itself. See [Hosts](hosts.md).
+- Exhausting retries throws `AgentDecisionExhaustedError`, which carries the attempts list and is caught by the invoke's `onError`.
 
 ## Coercion
 
-Core validates and retries; it never talks to a model. Coercing the model into choosing exactly one option (tool-per-event with forced tool choice, structured output over an event union, etc.) is the host's responsibility. The shipped `createAiSdkExecutors` provides a `decide` executor for the Vercel AI SDK; the raw-SDK examples force the choice with `tool_choice`. See [Hosts](hosts.md).
+Core validates and retries. It never calls a model. Coercing the model into choosing exactly one option is the host's responsibility. Hosts do this with one tool per event and a forced tool choice, or with structured output over an event union. The shipped `createAiSdkExecutors` provides a `decide` executor for the Vercel AI SDK. The raw-SDK examples force the choice with `tool_choice`. See [Hosts](hosts.md).
 
-> **Note:** Decisions are state-local: author them inline on the invoke. There is no reusable decision-logic object, because a decision's candidates and legality depend on the state it runs in.
+> **Note:** Decisions are state-local, so author them inline on the invoke. There is no reusable decision-logic object, because a decision's candidates and legality depend on the state it runs in.
 
-## Multi-event commands: the decide loop
+## The decide loop for multi-event commands
 
-A decision is one event. When one command needs several ("add X and Y" → two `ADD_TODO`), loop the decision in the machine. The loop, its exit, and the applied trail stay visible in the statechart:
+A decision produces one event. When one command needs several events, such as "add X and Y" producing two `ADD_TODO` events, loop the decision in the machine. The loop, its exit, and the trail of applied events stay visible in the statechart.
 
-- A `planning` state invokes `agent.decide` for **one** event.
-- Applying that event targets a turnaround state that immediately re-enters `planning`, starting the next step.
-- An explicit machine event (e.g. `DONE`) is among `allowedEvents` and targets somewhere outside the loop, so the model can end it.
+- A `planning` state invokes `agent.decide` for one event.
+- Applying that event targets a turnaround state that immediately re-enters `planning` and starts the next step.
+- An explicit machine event, such as `DONE`, is among `allowedEvents` and targets a state outside the loop, so the model can end the loop.
 - The trail of applied events lives in context and is appended to each step's prompt.
+
+<!-- viz: state diagram of the decide loop: planning (invoke agent.decide) -> applying (always -> planning) for ADD_TODO/TOGGLE_TODO, and DONE -> awaitingCommand -->
+
 
 ```ts no-check
 planning: {
@@ -134,10 +146,10 @@ planning: {
 applying: { always: { target: 'planning' } },
 ```
 
-Every step gets this page's validation/retry loop. Full example: [examples/todo-nl/index.ts](../examples/todo-nl/index.ts).
+Every step runs the validation and retry loop described above. For the full example, see [examples/todo-nl/index.ts](../examples/todo-nl/index.ts).
 
 ## Related
 
-- [Agent machines](machines.md): transitions, guards, and event schemas.
-- [Hosts](hosts.md): the decide executor and how the model is coerced into one event.
-- [Machines as data](machines-as-data.md): authoring decisions from JSON.
+- Read more about [Agent machines](machines.md), including transitions, guards, and event schemas.
+- Read more about [Hosts](hosts.md), including the decide executor and how the model is coerced into one event.
+- Read more about [Machines as data](machines-as-data.md), including authoring decisions from JSON.

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -5,26 +5,28 @@ description: Score agent runs on output, trajectory, and token budget using the 
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-An eval is a dataset, a task, and scorers. The hard part is usually the task: getting a repeatable run out of an agent, and getting enough out of that run to score more than its final string.
+This page describes how to score agent runs on output, trajectory, and token budget. It covers a plain vitest runner, a vendor harness, per-call seam evals, and datasets built from event logs.
 
-A machine gives you both for free. Nothing here is eval-specific instrumentation; it is what `runAgent` already returns.
+An eval is a dataset, a task, and scorers. The task is usually the hard part: getting a repeatable run out of an agent, and getting enough out of that run to score more than its final string. A machine provides both without eval-specific instrumentation, using what `runAgent` already returns.
 
 ## Machine evaluability
 
-- **Deterministic replay.** Every run produces `result.events`, a versioned JSON log of every external input it observed. Persist it and the run reproduces. A failing eval row is a file, not a screenshot.
-- **The trajectory is a first-class artifact.** The question "did the agent take the right path?" is not a heuristic over free text. The machine's states and the log's event types answer it directly.
-- **Keyless runs.** `createScriptedExecutors` swaps canned answers in for the model, so trajectory and budget logic are unit-testable in CI.
-- **Illegal paths are impossible.** The machine, not the prompt, decides what may happen next, so a scorer never has to check for actions that could not occur.
+- Every run produces `result.events`, a versioned JSON log of every external input the run observed. Persist it and the run reproduces, so a failing eval row is a file.
+- The trajectory is a durable artifact. The machine's states and the log's event types report which path the agent took, so no heuristic over free text is needed.
+- `createScriptedExecutors` substitutes canned answers for the model, so trajectory and budget logic are unit-testable in CI with no API key.
+- The machine decides what may happen next, not the prompt, so a scorer never has to check for actions that could not occur.
 
 ## The seams
 
+A **seam** is a point in a run where an eval can substitute its own behavior or read the run's state. Each seam below is either a place to inject scripted answers or a place to read a trajectory, an output, or a usage count. One kind of seam, a single model call, is covered in [Seam evals with `runSeam`](#seam-evals-with-runseam).
+
 | Seam                        | What it gives an eval                                                                                                                                                                                            |
 | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `createScriptedExecutors`   | Canned model answers from FIFO queues, keyless and deterministic. Entries can report `usage`, so budget scorers have numbers without a model. Full semantics: [Scripted executors](hosts.md#scripted-executors). |
-| `runSeam`                   | One model call under test, the rest scripted. Returns the seam's answer plus `before`/`after` trajectory slices, so a score is per-call instead of per-run.                                                      |
+| `createScriptedExecutors`   | Canned model answers from FIFO queues, keyless and deterministic. Entries can report `usage`, so budget scorers have numbers without a model. See [Scripted executors](hosts.md#scripted-executors). |
+| `runSeam`                   | Puts one model call under test and scripts the rest. Returns the seam's answer plus `before` and `after` trajectory slices, so a score is per call instead of per run.                                                      |
 | `simulateAgent`             | A scripted playthrough on the pure step path. Returns a `trail` of state values per step, with no actor and no I/O.                                                                                              |
-| `explorePaths` / `canReach` | Enumerate every branch a machine can take. Use it to check dataset coverage: which paths does the dataset never exercise?                                                                                        |
-| `result.events`             | The durable trajectory. `AgentLogEntry[]`: machine input, effect completions, user events, timer firings. JSON-safe, ordered, replayable.                                                                        |
+| `explorePaths` and `canReach` | Enumerate every branch a machine can take. `canReach` returns `{ reachable, witness }`. Use them to check which paths a dataset never exercises.                                                                                        |
+| `result.events`             | The durable trajectory, as `AgentLogEntry[]`: machine input, effect completions, user events, and timer firings. Ordered, JSON-safe, and replayable.                                                                        |
 | `onTransition`              | The live state path, one call per transition.                                                                                                                                                                    |
 | `result.usage`              | `modelCalls` plus token fields, per run. Counts only that run's calls, so sum across resume legs.                                                                                                                |
 | `result.output`             | The final state's typed output, schema-validated.                                                                                                                                                                |
@@ -33,7 +35,7 @@ See [Testing and verification](verify.md) for `simulateAgent`, `explorePaths`, a
 
 ## A dataset runner in plain vitest
 
-No vendor required. [Vitest](https://vitest.dev) is a plain JavaScript test runner; an eval here is just a dataset, a task that runs the machine, and scorers that are ordinary functions:
+An eval needs no vendor. [Vitest](https://vitest.dev) is a plain JavaScript test runner. An eval in vitest is a dataset, a task that runs the machine, and scorers that are ordinary functions.
 
 ```ts no-check
 import { expect, test } from "vitest";
@@ -68,16 +70,16 @@ test.each(dataset)("$name", async ({ input, script, expected }) => {
 });
 ```
 
-Swap `createScriptedExecutors` for `createAiSdkExecutors({ models })` and the same rows score a real model. That is the only line that changes.
+Replace `createScriptedExecutors` with `createAiSdkExecutors({ models })` and the same rows score a real model. That is the only line that changes.
 
 ### Trajectory scoring
 
-Two trajectories are available, and they answer different questions:
+Two trajectories are available, and they answer different questions.
 
-- **State path** (`onTransition`): where the machine went. Readable, and the natural thing to assert.
-- **Event trajectory** (`result.events`): what drove it there. Durable and JSON-safe, so it survives the process, and it is the same artifact that powers replay and crash recovery.
+- The state path, from `onTransition`, records where the machine went. It is readable and is the usual thing to assert.
+- The event trajectory, from `result.events`, records what drove the machine there. It is durable and JSON-safe, so it survives the process, and it is the same artifact that powers replay and crash recovery.
 
-Score them as an ordered subsequence rather than an exact match, so an extra retry loop does not fail a row that reached the right places in the right order. `matchesTrajectory` is that comparison, over either trajectory:
+Score a trajectory as an ordered subsequence rather than an exact match, so an extra retry loop does not fail a row that reached the right states in the right order. `matchesTrajectory` performs that comparison over either trajectory.
 
 ```ts
 import { matchesTrajectory } from "@statelyai/agent";
@@ -91,22 +93,34 @@ expect(path.matched, JSON.stringify(path.firstMiss)).toBe(true);
 matchesTrajectory(result.events, ["PROMPT_SUBMITTED", { type: "MORE_INFO" }, "SEND"]);
 ```
 
-- Ordered subsequence by default; `{ exact: true }` requires equality.
-- `score` is `matchedCount / expectedCount`, so a scorer gets partial credit for free.
-- `firstMiss` is `{ index, expected, searchedFrom }`: where it diverged, JSON-safe, so it doubles as scorer metadata and as a test failure message.
+- The comparison is an ordered subsequence by default. Pass `{ exact: true }` to require equality.
+- `score` is `matchedCount / expectedCount`, so a scorer gets partial credit.
+- `firstMiss` is `{ index, expected, searchedFrom }`, which reports where the trajectory diverged. It is JSON-safe, so it works as scorer metadata and as a test failure message.
 
 ### Human-in-the-loop rows
 
-A machine that pauses for a human settles `idle`. Resume with `{ snapshot, event }` and thread `events` through each leg so the final `result.events` is the whole run's log. Two things to remember:
+A machine that pauses for a human settles `idle`. Resume with `{ snapshot, event }` and pass `events` through each leg, so the final `result.events` holds the whole run's log. Two details matter.
 
-- `usage` is per leg. Sum it.
-- Drive the simulated user off the machine's current state or its `meta.interaction`, not a fixed transcript. A real model may branch differently, and a reactive user policy scores that run instead of crashing on it.
+```ts no-check
+const first = await runAgent(machine, { input, executors });
+const second = await runAgent(machine, {
+  snapshot: first.persistedSnapshot ?? first.snapshot,
+  event: { type: "APPROVE" },
+  events: first.events, // thread the log forward
+  executors,
+});
+// second.events is the whole run's log
+const modelCalls = first.usage.modelCalls + second.usage.modelCalls;
+```
+
+- `usage` is per leg. Sum it across legs.
+- Drive the simulated user from the machine's current state or its `meta.interaction`, not from a fixed transcript. A real model may branch differently, and a reactive user policy scores that run instead of failing on it.
 
 ## Braintrust
 
-[Braintrust](https://www.braintrust.dev) is a hosted eval platform: you hand it a dataset, a task function, and scorers, and it tracks scores across experiments.
+[Braintrust](https://www.braintrust.dev) is a hosted eval platform. You give it a dataset, a task function, and scorers, and it tracks scores across experiments.
 
-[`examples/braintrust-evals`](https://github.com/statelyai/agent/tree/main/examples/braintrust-evals) wires the real `braintrust` SDK over the unmodified email-drafter machine: a three-row dataset, a task that drives the machine to done, and four scorers over `result.output`, the state path, the `result.events` trajectory, and summed `result.usage`.
+[`examples/braintrust-evals`](https://github.com/statelyai/agent/tree/main/examples/braintrust-evals) wires the real `braintrust` SDK over the unmodified email-drafter machine. It has a three-row dataset, a task that drives the machine to done, and four scorers over `result.output`, the state path, the `result.events` trajectory, and summed `result.usage`.
 
 ```ts
 import { Eval } from "braintrust";
@@ -122,19 +136,22 @@ await Eval(
 );
 ```
 
-- `noSendLogs: true` runs the eval locally and prints a summary instead of creating an experiment, so it works with **no Braintrust account**.
-- Set `BRAINTRUST_API_KEY` to upload the experiment instead. That path needs an account.
-- Set `OPENAI_API_KEY` to score the real model. Unset, it runs scripted and keyless.
+- `noSendLogs: true` runs the eval locally and prints a summary instead of creating an experiment, so it needs no Braintrust account.
+- Set `BRAINTRUST_API_KEY` to upload the experiment instead. That path requires an account.
+- Set `OPENAI_API_KEY` to score the real model. Without it, the eval runs scripted and keyless.
 
-The same shape ports to any harness that takes a task function and scorers.
+The same structure works with any harness that takes a task function and scorers.
 
 ## Seam evals with `runSeam`
 
-An end-to-end score tells you a run got worse. It does not tell you **which model call** got worse. A machine agent is a chain of calls, and each one is a seam you can eval on its own without mocking the machine.
+An end-to-end score reports that a run got worse. It does not report which model call got worse. A machine agent is a chain of calls, and each call is a seam you can eval on its own without mocking the machine.
 
-The recipe: run the machine end to end, but route every request except one to a scripted answer. The seam under test gets the real model (or a candidate prompt). Everything after the seam is a real consequence of it, so the slice of the run after the seam is the score.
+To eval a seam, run the machine end to end but route every request except one to a scripted answer. The seam under test receives the real model or a candidate prompt. Everything after the seam is a consequence of it, so the slice of the run after the seam is what you score.
 
-`runSeam` is that recipe as one call. It routes the requests, drives a reactive simulated user through the idle pauses, and slices the run at the seam:
+`runSeam` does this in one call. It routes the requests, drives a reactive simulated user through the idle pauses, and slices the run at the seam.
+
+<!-- viz: seam eval: chain of model calls in one run, all scripted except the seam under test, with before/after trajectory slices marked at the seam's completion -->
+
 
 ```ts
 import { matchesTrajectory, runSeam } from "@statelyai/agent";
@@ -142,12 +159,12 @@ import { matchesTrajectory, runSeam } from "@statelyai/agent";
 const run = await runSeam(emailDrafter, {
   // The call plan: answers per request `name` or model key, in call order.
   scripts: {
-    promptEvaluator: [vagueAssessment, completeAssessment],
-    emailDrafter: [draft],
+    evaluatePrompt: [vagueAssessment, completeAssessment],
+    draftEmail: [draft],
   },
-  // The call under test: by request name, or by model key plus occurrence.
-  seam: { model: "promptEvaluator", occurrence: 0 },
-  // The seam's executor. Omit it and the seam is scripted too: keyless.
+  // The call under test: request name plus zero-based occurrence.
+  seam: { request: "evaluatePrompt", occurrence: 0 },
+  // The seam's executor. Omit it to script the seam as well.
   candidate: createAiSdkExecutors({ models }).generateText,
   // The simulated user, answering off the machine's own state.
   respond: ({ state }) =>
@@ -157,12 +174,13 @@ const run = await runSeam(emailDrafter, {
 });
 ```
 
-- `seam` addresses the call by request `name` (the `setupAgent({ requests })` key, the better handle) or by `model` key, plus a 0-based `occurrence`: `{ request: "draftEmail", occurrence: 1 }` is the revision, not the first draft.
-- `scripts` is the whole call plan, so the seam consumes its slot too: the candidate _replaces_ that answer, and every later scripted answer stays lined up. Each queue's **last entry repeats**, so a live seam that branches down a longer path never runs dry.
-- `respond` is called at every idle pause with `{ snapshot, state, meta, turn, result }` and returns the event to send, or `null` to stop.
-- `candidate` is just an executor, so a candidate prompt, a fine-tune, or a live model all plug in.
+- `seam` addresses the call by request `name` plus a zero-based `occurrence`. The name is the `setupAgent({ requests })` key, or the `name` passed to `createTextLogic`. For example, `{ request: "draftEmail", occurrence: 1 }` is the revision, not the first draft. A request the seam addresses must have a name.
+- `scripts` is the whole call plan, and the seam consumes its slot too. The candidate replaces that answer, and every later scripted answer stays lined up. A queue keys on a request `name` when one is scripted under it, and on a `model` key otherwise.
+- A queue that runs dry throws. Pass `repeatLast: true` to replay a queue's last entry instead, so a live seam that branches down a longer path still finds an answer.
+- `respond` is called at every idle pause with `{ snapshot, state, meta, turn, result }`. It returns the event to send, or `null` to stop.
+- `candidate` is an executor, so a candidate prompt, a fine-tuned model, or a live model all plug in.
 
-The result carries the seam's own answer and two slices, ready for `matchesTrajectory`:
+The result carries the seam's own answer and two slices, ready for `matchesTrajectory`.
 
 ```ts
 run.seamOutput; // what the seam call returned
@@ -175,11 +193,11 @@ matchesTrajectory(run.after.statePath, ["needsMoreInfo", "drafting", "reviewing"
 matchesTrajectory(run.after.events, ["MORE_INFO", "SEND", "END"]);
 ```
 
-The state slice splits where the state path stood when the seam answered; the event slice splits at the seam's own effect completion (the first `xstate.done.*` entry appended after the call was made). A run that never reaches the seam scores an empty `after` rather than throwing, which is itself a real result about the candidate.
+The state slice splits at the point the state path had reached when the seam answered. The event slice splits at the seam's own effect completion, which is the first `xstate.done.*` entry appended after the call was made. A run that never reaches the seam returns an empty `after` slice instead of throwing, which is itself a result about the candidate.
 
 ### One experiment per seam
 
-The email drafter has three seams. Give each its own `Eval()` so a vendor tracks per-seam scores over time instead of one blended number:
+The email drafter has three seams. Give each seam its own `Eval()` call, so a vendor tracks per-seam scores over time instead of one blended number.
 
 | Seam      | Call                      | The question the trajectory answers                      |
 | --------- | ------------------------- | -------------------------------------------------------- |
@@ -197,16 +215,16 @@ for (const seam of seams) {
 }
 ```
 
-A row is a Braintrust **test case** (Langfuse calls it a **dataset item**): `{ input, expected, metadata }`, where `input` carries the prompt, the simulated user's answers, and the call plan, and `expected` carries the post-seam trajectory.
+A row is a Braintrust test case, which Langfuse calls a dataset item. Its shape is `{ input, expected, metadata }`. `input` carries the prompt, the simulated user's answers, and the call plan. `expected` carries the post-seam trajectory.
 
-Keyless-first still holds: with no `candidate`, every seam runs scripted, and the same rows score the real model when a key is present. [`examples/braintrust-evals/seams.ts`](https://github.com/statelyai/agent/tree/main/examples/braintrust-evals) is the working version of all of this: datasets, scorers and `Eval()` wiring, with `runSeam` doing the rest.
+With no `candidate`, every seam runs scripted and keyless, and the same rows score the real model when a key is present. [`examples/braintrust-evals/seams.ts`](https://github.com/statelyai/agent/tree/main/examples/braintrust-evals) is a working version of all of this, with datasets, scorers, and `Eval()` wiring.
 
 ## Datasets from event logs
 
-Seam datasets do not have to be hand-written. A recorded run already contains every seam input: `result.events` is the log, and replaying a **prefix** of it reconstructs the exact request the next model call would receive.
+Seam datasets do not have to be hand-written. A recorded run already contains every seam input. `result.events` is the log, and replaying a prefix of it reconstructs the exact request the next model call would receive.
 
 ```ts
-import { verifyReplay } from "@statelyai/agent";
+import { replay } from "@statelyai/agent";
 import type { AgentLogEntry, AgentTextRequest } from "@statelyai/agent";
 
 /** One seam per model call in a recorded run: the prefix that produced it, and the request it owed. */
@@ -217,32 +235,39 @@ export function seamCasesFrom(machine: typeof emailDrafter, events: AgentLogEntr
     const prefix = events.slice(0, at);
     // Strict replay: every entry's recorded state/effect hashes must check out,
     // so a fixture cannot drift away from the machine that produced it.
-    const { effects } = verifyReplay(machine, prefix);
+    const { effects } = replay(machine, prefix, { verify: "strict" });
     const owed = effects.find((effect) => effect.kind === "text");
     if (!owed) continue;
 
     // The completion the run actually recorded for that call, if it got one.
-    const completion = events[at]?.event as { output?: unknown } | undefined;
-    cases.push({ prefix, request: owed.request, recorded: completion?.output });
+    // Match it by the request's own done event rather than by position: other
+    // entries can be journaled between the call and its completion.
+    const done = owed.toDoneEvent(undefined) as { type: string; actorId?: string };
+    const completion = events.slice(at).find((entry) => {
+      const event = entry.event as { type: string; actorId?: string };
+      return event.type === done.type && event.actorId === done.actorId;
+    });
+    const output = (completion?.event as { output?: unknown } | undefined)?.output;
+    cases.push({ prefix, request: owed.request, recorded: output });
   }
 
   return cases;
 }
 ```
 
-- Record once, regress every seam forever. A production run becomes a dataset row per model call.
-- `verifyReplay` is what makes the fixture trustworthy: it replays with `verify: 'strict'`, so an entry whose recorded state or owed-effect hashes no longer match the machine throws `AgentReplayDivergenceError` instead of silently scoring a stale path. Change the machine, and the fixtures tell you.
-- `owed.request` is the full `AgentTextRequest` (system, prompt, messages, schema). Feed it to a candidate model directly for a single-call eval, or use `prefix` as the starting log for a routed-executor run that scores the trajectory after the seam.
+- A production run becomes one dataset row per model call, so recording a run once produces a regression case for every seam.
+- `verify: 'strict'` makes the fixture trustworthy, because an entry whose recorded state or owed-effect hashes no longer match the machine throws `AgentReplayDivergenceError` instead of scoring a stale path.
+- `owed.request` is the full `AgentTextRequest`, with system, prompt, messages, and schema. Pass it to a candidate model for a single-call eval, or use `prefix` as the starting log for a routed-executor run that scores the trajectory after the seam.
 - `recorded` is the previous model's answer for that seam, so the dataset ships with a baseline to score against.
 
 ## Pairing with observability
 
-Evals score runs offline; tracing watches them in production. They share the machine's trace stream, so a vendor with an OTLP endpoint (Braintrust, LangSmith, Langfuse, Honeycomb) receives spans from `@statelyai/agent/otel` while the same runs are scored here. Neither side needs the other, and neither requires a vendor-specific adapter in your machine.
+Evals score runs offline, and tracing observes runs in production. Both read the machine's trace stream. A vendor with an OTLP endpoint, such as Braintrust, LangSmith, Langfuse, or Honeycomb, receives spans from `@statelyai/agent/otel` while the same runs are scored here. Neither side depends on the other, and neither requires a vendor-specific adapter in your machine.
 
 ## Related
 
 - [Testing and verification](verify.md): `simulateAgent`, `explorePaths`, and static linting.
 - [Observability](observability.md): the trace stream and OTel export.
-- [The event log](event-log.md): the log envelope, replay, and `verifyReplay`.
+- [The event log](event-log.md): the log envelope, replay, and strict verification.
 - [Hosts and executors](hosts.md#scripted-executors): scripted executor semantics.
 - [Usage and budgets](usage-and-budgets.md): what `result.usage` counts.

--- a/docs/event-log.md
+++ b/docs/event-log.md
@@ -5,31 +5,25 @@ description: The event log is the source of truth. Append external inputs, repla
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-## Durability map
-
-This page is the hub for the durability story. The neighbours:
-
-- [Human in the loop](human-in-the-loop.md): pausing at idle and resuming from a persisted snapshot.
-- [The step path](steps.md): per-model-call hosts that append before continuing.
-- [Observability](observability.md): replaying a traced run.
-- [SQLite stores](#sqlite-stores) (below): the shipped `AgentEventLogStore` and `AgentSnapshotStore` implementations.
-- [Hosts](hosts.md): where a thread id and a store live in a real deployment.
+This page describes the event log: what it records, how replay uses it, and how to store, fork, and verify it.
 
 ## The model
 
-A machine's durable state is not a snapshot. It is the ordered array of **external inputs** it has received: effect completions (done/error, outputs inline), user-sent events, timer firings. Because transitions are pure, folding that array through the machine reconstructs the exact snapshot, including which effects were started and which are still owed. The log is the source of truth; everything else is derived.
+A machine's durable state is the ordered array of **external inputs** it has received, not a snapshot. External inputs are effect completions (done or error, with outputs inline), user-sent events, and timer firings. Transitions are pure, so folding that array through the machine reconstructs the exact snapshot, including which effects were started and which are still owed. Everything else is derived from the log.
 
-The rule: **external inputs only.** Never log raised/internal events; replay re-derives them, and logging them would double-apply. Concurrency is captured, not re-run: the recorded completion order is the serialization, so replay is deterministic even when the live run raced.
+Log external inputs only. Replay re-derives raised and internal events, so logging them applies them twice. The log captures concurrency rather than re-running it: the recorded completion order is the serialization, so replay is deterministic even when the live run raced.
 
-This puts one obligation on machine authors: transitions and effect inputs (prompt builders, spawn inputs) must be pure functions of state and event. No `Date.now()`, no `Math.random()` inside transition code; inject time and randomness as events or input.
+This places one obligation on machine authors. Transitions and effect inputs such as prompt builders and spawn inputs must be pure functions of state and event. Do not call `Date.now()` or `Math.random()` inside transition code. Inject time and randomness as events or as input.
+
+<!-- viz: data flow: external inputs (effect done/error, user events, timer firings) appended to log -> fold through pure transitions -> snapshot + owed effects; raised/internal events shown as re-derived, not logged -->
 
 ## Rules of the event log
 
 <!-- verified against src/run-agent.ts (append filter), src/effects.ts (createReplayEntry, verifyEntry), src/event-log-store.ts (append) -->
 
-Four rules keep a log replayable. Each is enforced somewhere in the library, or detected the moment it is broken.
+Four rules keep a log replayable. The library enforces each rule, or detects it the moment it is broken.
 
-**Journal external inputs only.** Raised and internal events are re-derived by `replay`; recording them applies them twice. `runAgent` already filters them out, so the rule matters when you build entries yourself.
+**Journal external inputs only.** `replay` re-derives raised and internal events, so recording them applies them twice. `runAgent` filters them out already. The rule matters when you build entries yourself.
 
 ```ts no-check
 // Wrong: a self-sent event, already re-derived on replay.
@@ -39,7 +33,7 @@ entries.push(createReplayEntry(machine, entries, { type: "RETRY" })); // raised 
 entries.push(createReplayEntry(machine, entries, { type: "APPROVE" })); // sent by a human
 ```
 
-**Keep transitions and effect inputs pure.** Nothing statically detects `Date.now()` or `Math.random()` in machine code, but the per-entry `verification` hashes catch it on the next replay as an `AgentReplayDivergenceError`. Inject time and randomness instead.
+**Keep transitions and effect inputs pure.** No static check detects `Date.now()` or `Math.random()` in machine code. The per-entry `verification` hashes catch it on the next replay and throw `AgentReplayDivergenceError`. Inject time and randomness instead.
 
 ```ts no-check
 // Wrong: the prompt differs on every replay, so effectsHash diverges.
@@ -49,7 +43,7 @@ input: () => ({ prompt: `Today is ${new Date().toDateString()}` }),
 input: ({ context }) => ({ prompt: `Today is ${context.today}` }),
 ```
 
-**Never mutate a journaled entry.** `AgentEventLogStore` has exactly four methods (`append`, `read`, `length`, `fork`): no update, no delete. The in-memory store clones on write and on read, so an edit through a caller's reference does not stick, and a rewritten entry would invalidate every hash after it.
+**Never mutate a journaled entry.** `AgentEventLogStore` has exactly four methods: `append`, `read`, `length`, and `fork`. There is no update and no delete. The in-memory store clones on write and on read, so an edit through a caller's reference does not stick. A rewritten entry would also invalidate every hash after it.
 
 ```ts no-check
 // Wrong: the entry is already the source of truth for everything downstream.
@@ -60,13 +54,15 @@ await store.fork({ threadId: "session-1", newThreadId: "what-if", upToIndex: 3 }
 await store.append({ threadId: "what-if", expectedIndex: 3, entries: [correctedEntry] });
 ```
 
-**Append at the length you read.** `expectedIndex` is optimistic concurrency: a stale writer loses with `AgentEventLogConflictError` rather than interleaving. Entries must also be contiguous from that index, and event ids unique within the thread.
+`upToIndex` is exclusive. `upToIndex: 3` copies entries 0, 1, and 2, so the new thread has length 3 and the next append expects index 3.
+
+**Append at the length you read.** `expectedIndex` provides optimistic concurrency. A stale writer fails with `AgentEventLogConflictError` instead of interleaving. Entries must be contiguous from that index, and event ids must be unique within the thread.
 
 ```ts no-check
-// Wrong: guesses the position, so a concurrent writer's entries get clobbered or rejected at random.
+// Wrong: guesses the position.
 await store.append({ threadId, expectedIndex: 0, entries: newEntries });
 
-// Right: read the frontier, and treat a conflict as "someone else advanced the thread".
+// Right: read the current length first. A conflict means another writer advanced the thread.
 await store.append({ threadId, expectedIndex: await store.length(threadId), entries: newEntries });
 ```
 
@@ -74,7 +70,7 @@ await store.append({ threadId, expectedIndex: await store.length(threadId), entr
 
 <!-- RunAgentResult.events and RunAgentOptions events/onEvent from src/run-agent.ts; replay from src/effects.ts -->
 
-Every `runAgent` result carries the external inputs it observed as a versioned `AgentLogEntry[]`. Pass it directly to `replay`:
+Every `runAgent` result carries the external inputs it observed as a versioned `AgentLogEntry[]`. Pass it directly to `replay`.
 
 ```ts
 import { replay, runAgent } from "@statelyai/agent";
@@ -83,7 +79,7 @@ const first = await runAgent(machine, { input, executors });
 const { snapshot, effects } = replay(machine, first.events);
 ```
 
-A fresh run starts with an envelope around `@agent.init`. The remaining entries wrap effect completions/failures, externally sent events, and timer firings. Raised events and internal transitions are absent because `replay` re-derives them.
+A fresh run starts with an envelope around `@agent.init`. The remaining entries wrap effect completions and failures, externally sent events, and timer firings. Raised events and internal transitions are absent, because `replay` re-derives them.
 
 ```ts
 interface AgentLogEntry {
@@ -101,13 +97,13 @@ interface AgentLogEntry {
 }
 ```
 
-- `recordedAt` is acceptance metadata, never semantic machine time. If a transition needs time, put it in the machine event itself.
-- `machineVersion` is the explicit run option, else the machine's own `version` (`createMachine({ version })`), else its structural hash.
-- `verification` pins the logical state and still-owed effects after each entry.
+- `recordedAt` is acceptance metadata, not semantic machine time. If a transition needs time, put the time in the machine event itself.
+- `machineVersion` is the machine's own `version` from `createMachine({ version })`. Without a declared version, it is the machine's structural hash.
+- `verification` pins the logical state and the still-owed effects after each entry.
 
-XState v6 uses stable category event types with identity in payload fields. Preserve the whole object: an invoke completion is `{ type: "xstate.done.actor", actorId, sessionId, output }`; a timer firing is `{ type: "xstate.timer", id }`. `replay` rebinds logged actor sessions to the new actor system, so globally unique runtime IDs do not make the log machine-specific.
+XState v6 uses stable category event types and carries identity in payload fields. Preserve the whole event object. An invoke completion is `{ type: "xstate.done.actor", actorId, sessionId, output }`. A timer firing is `{ type: "xstate.timer", id }`. `replay` rebinds logged actor sessions to the new actor system, so globally unique runtime ids do not make the log machine-specific.
 
-When resuming by snapshot, pass the preceding events back to keep one complete history:
+When resuming by snapshot, pass the preceding events back to keep one complete history.
 
 ```ts
 const second = await runAgent(machine, {
@@ -120,9 +116,9 @@ const second = await runAgent(machine, {
 replay(machine, second.events);
 ```
 
-The `events` option only carries history forward; `snapshot` remains the live resume source. If omitted on a snapshot resume, the returned array contains only events observed during that invocation and is not a complete replay from initialization.
+The `events` option only carries history forward. `snapshot` remains the live resume source. If you omit `events` on a snapshot resume, the returned array contains only the events observed during that invocation, and it is not a complete replay from initialization.
 
-To capture the same replayable events while the run is in flight, use `onEvent`:
+To capture the same replayable events while the run is in flight, use `onEvent`.
 
 ```ts
 const events = [...previousEvents];
@@ -139,17 +135,17 @@ const result = await runAgent(machine, {
 });
 ```
 
-- Fires once per newly observed envelope, including the `@agent.init` entry on a fresh run.
-- Does not re-emit history supplied through `events`.
-- Excludes raised and internal events, unlike `onTransition`, so its output goes straight to `replay`.
+- `onEvent` fires once per newly observed envelope, including the `@agent.init` entry on a fresh run.
+- It does not re-emit history supplied through `events`.
+- It excludes raised and internal events, unlike `onTransition`, so its output can be passed straight to `replay`.
 
-`runAgent` owns a live XState actor. Its `onEvent` callback observes an event after XState accepted it and cannot await an asynchronous store before the transition. It is useful for export/write-through recording, but is not an append-before-transition crash-safety guarantee. For that guarantee use [the step path](steps.md#durable-append-before-continue).
+`runAgent` owns a live XState actor. Its `onEvent` callback observes an event after XState accepted it, and it cannot await an asynchronous store before the transition. Use it for export and write-through recording. It is not an append-before-transition crash-safety guarantee. For that guarantee, use [the step path](steps.md#durable-append-before-continue).
 
 ## Log-only resume (crash recovery)
 
 <!-- events-only resume from src/run-agent.ts (options.events + replay + getPersistedSnapshot); tests in src/run-agent.test.ts "restore semantics" -->
 
-With no `snapshot` and a self-contained log (a reserved `@agent.init` first entry, which every fresh `runAgent` log has), `runAgent` derives the resume snapshot from the log itself:
+A log is self-contained when its first entry is the reserved `@agent.init` entry. Every fresh `runAgent` log is self-contained. Given such a log and no `snapshot`, `runAgent` derives the resume snapshot from the log itself.
 
 ```ts
 const recovered = await runAgent(machine, {
@@ -158,27 +154,42 @@ const recovered = await runAgent(machine, {
 });
 ```
 
-- Recorded results are replayed, never re-executed: a model call whose completion is in the log runs zero times during recovery.
-- A request that was **in flight** when the log ended (its completion was never recorded) round-trips as a pending child and re-executes idempotently on restore: XState v6 restarts restored pending invokes.
+- Recorded results are replayed, never re-executed. A model call whose completion is in the log runs zero times during recovery.
+- A request that was in flight when the log ended has no recorded completion. It round-trips as a pending child and re-executes on restore, because XState v6 restarts restored pending invokes.
 - The recovered result's `events` extends the same log, so the whole history stays replayable.
 
-This is the crash-recovery path for hosts that persist entries as they happen (`onEvent` or an event-log store): after a process death mid-run, resume from the log alone. Because restart is at-least-once for the in-flight request, executors with non-idempotent side effects should dedupe by their own idempotency key. See [`examples/crash-recovery`](../examples/crash-recovery/index.ts).
+> **Warning:** Resume fan-out from the log, not from a mid-flight live snapshot. `replay` re-derives spawned branches that are still owed. Restoring a live `runAgent` snapshot that was persisted mid-flight drops frozen children instead. See [Roadmap](roadmap.md#near-term-non-gating).
+
+This is the crash-recovery path for hosts that persist entries as they happen, through `onEvent` or an event-log store. After a process dies mid-run, resume from the log alone. Restart is at-least-once for the in-flight request, so executors with non-idempotent side effects should deduplicate by their own idempotency key. See [`examples/crash-recovery`](../examples/crash-recovery/index.ts).
+
+<!-- viz: crash recovery sequence: host appends entries -> process dies mid-request -> restart with events only -> replay recorded completions -> in-flight request re-executed -> run continues -->
+
 
 ## The JSON wire contract
 
-`createReplayEntry`, `initEntry`, every built-in store append, and `replay` validate the complete envelope. Values that JSON would drop or coerce are rejected with `NonSerializableAgentEventError` carrying the exact `path`: `undefined`, functions, symbols, bigint, non-finite numbers, negative zero, sparse arrays, hidden properties, cycles, `Date`, `Map`, `Set`, and class instances. Framework error events normalize `Error` values to plain `{ name, message, cause? }` records before storage.
+`createReplayEntry`, `initEntry`, `replay`, and every built-in store append validate the complete envelope. Values that JSON would drop or coerce are rejected with `NonSerializableAgentEventError`, which carries the exact `path`. The rejected values are `undefined`, functions, symbols, bigint, non-finite numbers, negative zero, sparse arrays, hidden properties, cycles, `Date`, `Map`, `Set`, and class instances. Framework error events normalize `Error` values to plain `{ name, message, cause? }` records before storage.
 
-Use `assertJsonSerializable(value)` and `assertAgentLogEntry(entry)` at custom transport boundaries. This strict subset makes an exported log mean the same thing in another process or language.
+Use `assertJsonSerializable(value)` and `assertAgentLogEntry(entry)` at custom transport boundaries. This strict subset makes an exported log mean the same thing in another process or another language.
 
 ## Strict replay verification
 
-Normal `replay` checks verification hashes when present. `verifyReplay` requires them on every entry and fails at the first mismatch:
+`createReplayEntry` and `initEntry` write the `verification` hashes, and they do so by default. Hashes are absent in one case: `runAgent` resuming from a snapshot whose log does not start at the `@agent.init` entry, because that replay history is incomplete.
+
+`replay` has three verification modes.
+
+| `verify` | Behavior |
+| --- | --- |
+| default | Checks every entry that carries hashes. Entries without hashes pass. |
+| `'strict'` | Requires hashes on every entry. An entry without them throws `AgentReplayDivergenceError` with `kind: 'missing-verification'`. |
+| `false` | Runs no checks. |
+
+Pass `{ verify: 'strict' }` to require hashes on every entry and fail at the first mismatch.
 
 ```ts
-import { AgentReplayDivergenceError, verifyReplay } from "@statelyai/agent";
+import { AgentReplayDivergenceError, replay } from "@statelyai/agent";
 
 try {
-  verifyReplay(machine, entries);
+  replay(machine, entries, { verify: "strict" });
 } catch (error) {
   if (error instanceof AgentReplayDivergenceError) {
     console.error(error.eventId, error.index, error.kind);
@@ -186,18 +197,18 @@ try {
 }
 ```
 
-- `kind: "state"`: the current machine derived different logical state.
-- `kind: "effects"`: it owed different work, from a changed prompt, model, tool set, task input, or timer.
-- `kind: "missing-verification"`: an entry carried no hashes at all.
-- `AgentReplayMachineMismatchError` rejects an envelope stamped for another machine id/version before folding it.
+- `kind: "state"` means the current machine derived a different logical state.
+- `kind: "effects"` means the machine owed different work, caused by a changed prompt, model, tool set, task input, or timer.
+- `kind: "missing-verification"` means an entry carried no hashes.
+- `AgentReplayMachineMismatchError` rejects an envelope stamped for another machine id or version before folding it.
 
-Every framework error extends `AgentError` and carries a stable `.code` (`"replay-divergence"`, `"event-log-conflict"`, `"non-serializable-event"`, …), so a host can branch on the code instead of on `instanceof`. The other durability-adjacent errors: `AgentIllegalResumeEventError`, `AgentSnapshotVersionMismatchError`, `AgentDecisionExhaustedError`.
+Every framework error extends `AgentError` and carries a stable `.code` string, such as `"replay-divergence"`, `"event-log-conflict"`, or `"non-serializable-event"`. A host can branch on the code instead of on `instanceof`. The other durability-adjacent errors are `AgentIllegalResumeEventError`, `AgentSnapshotVersionMismatchError`, and `AgentDecisionExhaustedError`.
 
-Structural hashing cannot see custom function bodies or schema-validator implementations. Set an explicit `machineVersion` whenever those semantics change; the per-entry hashes then verify their observable state/effect consequences.
+Structural hashing cannot see custom function bodies or schema-validator implementations. Bump the machine's own `createMachine({ version })` whenever those semantics change, or pass an explicit `machineVersion` to `replay`. The per-entry hashes then verify the observable state and effect consequences.
 
 ## The store contract
 
-`AgentEventLogStore` is an append-only protocol with optimistic concurrency on the log length:
+`AgentEventLogStore` is an append-only protocol with optimistic concurrency on the log length.
 
 ```ts
 import { createInMemoryEventLogStore, initEntry } from "@statelyai/agent";
@@ -214,9 +225,9 @@ const recent = await store.read("session-1", { from: 3 });
 const next = await store.length("session-1"); // the next expectedIndex
 ```
 
-- `append` is atomic and rejects stale writers with `AgentEventLogConflictError` (`threadId`, `expectedIndex`, `actualLength`), so two hosts resuming one thread resolve to exactly one winner. Event ids must also be unique within a thread.
-- `read`/`length` are the whole history API: the log _is_ the history.
-- `fork({ threadId, newThreadId, upToIndex })` copies an exclusive index prefix; `atEventId` is the inclusive event-id form. Forked entries retain their ids. Rewind and diverge by appending different envelopes to the new thread.
+- `append` is atomic. It rejects stale writers with `AgentEventLogConflictError`, carrying `threadId`, `expectedIndex`, and `actualIndex`, the next index the store would accept, so two hosts resuming one thread resolve to exactly one winner. Event ids must be unique within a thread.
+- `read` and `length` are the only read methods. Everything a host needs to know about a thread is derived from its entries.
+- `fork({ threadId, newThreadId, upToIndex })` copies the prefix `[0, upToIndex)`. Omit `upToIndex` to copy the whole thread. Forked entries keep their ids. To diverge, append different envelopes to the new thread.
 
 Every entry carries optional host-owned `metadata`, stored verbatim.
 
@@ -224,12 +235,12 @@ Every entry carries optional host-owned `metadata`, stored verbatim.
 
 <!-- from src/sqlite/index.ts -->
 
-`@statelyai/agent/sqlite` ships both durability stores on Node's built-in `node:sqlite`: no dependencies, but Node-only and requires Node >= 22.18.
+`@statelyai/agent/sqlite` ships both durability stores on Node's built-in `node:sqlite`. It has no dependencies. It is Node-only and requires Node 22.18 or later.
 
 - `createSqliteEventLogStore(options)` returns an `AgentEventLogStore` plus `close()`.
 - `createSqliteSnapshotStore(options)` returns an `AgentSnapshotStore` plus `close()`.
-- `options.database` is a file path (or `':memory:'`) to open, or an existing `node:sqlite` `DatabaseSync` handle. Both stores can share one handle.
-- `close()` only closes a database the store opened itself; a passed-in handle stays the caller's to close.
+- `options.database` is a file path to open, `':memory:'`, or an existing `node:sqlite` `DatabaseSync` handle. Both stores can share one handle.
+- `close()` only closes a database the store opened itself. A handle you pass in stays yours to close.
 - `options.tableName` defaults to `agent_event_log` and `agent_snapshots`. Tables are created on demand.
 
 ```ts no-check
@@ -244,7 +255,7 @@ await events.append({ threadId: "session-1", expectedIndex: 0, entries });
 await snapshots.save("session-1", snapshot);
 ```
 
-`append` runs its length check and its inserts inside one `BEGIN IMMEDIATE` transaction. `node:sqlite` is synchronous, so nothing interleaves between the check and the write: racing appends resolve to exactly one winner, and the loser gets `AgentEventLogConflictError`.
+`append` runs its length check and its inserts inside one `BEGIN IMMEDIATE` transaction. `node:sqlite` is synchronous, so nothing interleaves between the check and the write. Racing appends resolve to exactly one winner, and the loser gets `AgentEventLogConflictError`.
 
 ## Fork and diff
 
@@ -254,17 +265,20 @@ import { diffEventLogs } from "@statelyai/agent";
 await store.fork({
   threadId: "session-1",
   newThreadId: "candidate",
-  atEventId: "evt_00000007",
+  upToIndex: 8,
 });
 
 const diff = diffEventLogs(machine, await store.read("session-1"), await store.read("candidate"));
 ```
 
-`diffEventLogs` returns the exact common prefix, parent-only and fork-only tails, both replay results, JSON Patch-style logical-state changes, and added/removed/changed frontier effects. It is structural only; semantic quality belongs to an evaluator.
+`diffEventLogs` returns the common prefix, the parent-only and fork-only tails, both replay results, JSON Patch-style logical-state changes, and added, removed, and changed frontier effects. The diff is structural only. To judge semantic quality, use an evaluator. See [Evals](evals.md).
+
+<!-- viz: fork and diff: one thread's log forked at an index into a second thread, showing shared prefix and two divergent tails feeding diffEventLogs -->
+
 
 ## Store conformance
 
-`createInMemoryEventLogStore()` is the reference implementation and the conformance baseline. An append-only log with a unique `(threadId, index)` constraint is a natural fit for any database; prove yours matches the reference on races, isolation, ordering, and fork semantics:
+`createInMemoryEventLogStore()` is the reference implementation and the conformance baseline. An append-only log with a unique `(threadId, index)` constraint maps onto any database. Check that your store matches the reference on races, isolation, ordering, and fork semantics.
 
 ```ts
 import { assertEventLogStoreConformance } from "@statelyai/agent";
@@ -272,14 +286,15 @@ import { assertEventLogStoreConformance } from "@statelyai/agent";
 await assertEventLogStoreConformance(() => createMyStore());
 ```
 
-Each assertion throws a descriptive `Error` on the first violation, so any runner (or a plain script) can drive it. The SQLite store passes the same suite.
+Each assertion throws a descriptive `Error` on the first violation, so any test runner or a plain script can drive it. The SQLite store passes the same suite.
 
 ## Snapshots as compaction
 
-[`AgentSnapshotStore`](human-in-the-loop.md) remains useful as an **idle-point cache**: at a quiescent point (an idle state with no in-flight effects), persist the snapshot and resume from it plus the events appended since, instead of replaying from index 0. Compact only at quiescent points; a snapshot taken mid-flight cannot carry in-flight effect state, but the log can.
+[`AgentSnapshotStore`](human-in-the-loop.md) serves as an idle-point cache. At a quiescent point, meaning an idle state with no in-flight effects, persist the snapshot. A later run resumes from that snapshot plus the events appended since, instead of replaying from index 0. Compact only at quiescent points. A snapshot taken mid-flight cannot carry in-flight effect state, but the log can.
 
 ## Related
 
-- [The step path](steps.md): driving a machine one external input at a time.
-- [Human in the loop](human-in-the-loop.md): idle states, the natural compaction points.
+- [The step path](steps.md): driving a machine one external input at a time, appending before continuing.
+- [Human in the loop](human-in-the-loop.md): idle states, which are the compaction points.
 - [Observability](observability.md): traces alongside the log, and `serializeTraceEvent` for JSONL output.
+- [Hosts and executors](hosts.md): where a thread id and a store live in a real deployment.

--- a/docs/from-a-loop.md
+++ b/docs/from-a-loop.md
@@ -1,30 +1,31 @@
 ---
 title: Migrating from a hand-rolled loop
-description: Convert a realistic while-loop tool-calling agent into an agent machine one step at a time, and see what you get for free.
+description: Convert a while-loop tool-calling agent into an agent machine one step at a time.
 ---
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
-> This page refactors a working `while`-loop agent into an agent machine **without rewriting your model calls**: your SDK calls, tools, and retry logic become the [executors](hosts.md); the machine replaces only the control flow.
 
-The call site stays one line. Where you had:
+This page refactors a working `while`-loop agent into an agent machine without rewriting your model calls. Your SDK calls, tools, and retry logic become the [executors](hosts.md). The machine replaces only the control flow.
+
+The call site stays one line. Where you had this:
 
 ```ts no-check
 const result = await generateText({ model, prompt, tools });
 ```
 
-you end with:
+you end with this:
 
 ```ts
 const result = await generateResult(machine, { input, executors });
 ```
 
-Your `generateText` call did not go away; it moved into the executors. The loop you wrote around it became the machine. And like `generateText`, the result carries metadata alongside the value: `result.output`, plus `result.snapshot`, the replayable `result.events`, and the aggregated `result.usage`.
+The `generateText` call still exists. It moves into the executors, and the loop you wrote around it becomes the machine. Like `generateText`, the result carries metadata alongside the value: `result.output`, `result.snapshot`, the replayable `result.events`, and the aggregated `result.usage`. `generateResult` throws `AgentIdleError` when the run settles idle instead of done, so use `runAgent` when a pause is an expected outcome.
 
-For the design move underneath this refactor (how to spot the states hiding in a loop before you write any of them down), read [Thinking in state machines](thinking-in-state-machines.md).
+For the design work behind this refactor, read [Thinking in state machines](thinking-in-state-machines.md). It covers how to find the states in a loop before you write any of them down.
 
-## Start: a hand-rolled loop
+## Starting point: a hand-rolled loop
 
-A realistic refund agent as a `while` loop with any SDK. It works: the model calls tools until it stops, a `$100` limit is enforced inline, and anything bigger pauses for a human.
+The starting point is a refund agent written as a `while` loop against an SDK. The model calls tools until it stops, a $100 limit is enforced inline, and a larger refund pauses for a human.
 
 ```ts
 import { generateText, tool } from "ai";
@@ -50,7 +51,7 @@ async function runRefundAgent(request: string) {
 
     for (const call of toolCalls) {
       if (call.toolName === "issueRefund") {
-        if ((call.input as { amount: number }).amount > 100) return { pending: true }; // ...now what?
+        if ((call.input as { amount: number }).amount > 100) return { pending: true }; // loop state is lost here
         refunded = true;
       }
       // push tool result onto messages, continue the loop
@@ -59,11 +60,15 @@ async function runRefundAgent(request: string) {
 }
 ```
 
-Three things are quietly wrong: the `$100` rule is an `if` the model could be prompted around, nothing stops `issueRefund` before `lookupOrder`, and the human pause returns `{ pending: true }`, **throwing away all the loop's state** with no way to resume.
+This loop has three problems:
+
+- The $100 rule is an `if` statement that the model can be prompted around.
+- Nothing stops `issueRefund` from running before `lookupOrder`.
+- The human pause returns `{ pending: true }` and discards the loop's state, so the run cannot resume.
 
 ## Step 1: implicit phases as explicit states
 
-The loop already has phases: deciding, doing, then finishing or waiting on a human. Name them as states. Declare schemas and setup with the flat `setupAgent` form.
+The loop has phases: deciding, doing, then finishing or waiting on a human. Name each phase as a state. Declare the schemas and the setup with `setupAgent`.
 
 ```ts
 import { z } from "zod";
@@ -73,45 +78,67 @@ import { openai } from "@ai-sdk/openai";
 
 const models = defineModels({ quick: openai("gpt-5.4-mini") });
 
+// The loop's lookupOrder tool becomes an actor the machine invokes.
+const lookupOrder = fromPromise(async ({ input }: { input: { orderId: string } }) => {
+  return { total: 5000 };
+});
+
 const agentSetup = setupAgent({
   models,
-  context: z.object({ request: z.string(), amount: z.number(), refunded: z.boolean() }),
-  input: z.object({ request: z.string(), amount: z.number() }),
+  actors: { lookupOrder },
+  context: z.object({
+    request: z.string(),
+    orderId: z.string(),
+    order: z.object({ total: z.number() }).nullable(),
+    refunded: z.boolean(),
+  }),
+  input: z.object({ request: z.string(), orderId: z.string() }),
   output: z.object({ refunded: z.boolean() }),
   events: {
-    REFUND: {}, // {} is shorthand for a payload-less event
+    REFUND: z.object({ amount: z.number() }),
     ESCALATE: z.object({ reason: z.string() }),
-    APPROVE: {},
+    APPROVE: {}, // {} is shorthand for a payload-less event
     DENY: {},
   },
 });
 ```
 
-The phases become `deciding`, `awaitingHuman`, `refunded`, `denied`.
+The phases become the states `lookingUp`, `deciding`, `awaitingHuman`, `refunded`, and `denied`.
+
+<!-- viz: refund machine: lookingUp (invokes lookupOrder) -> deciding -> refunded (REFUND, guarded by amount <= 100) / awaitingHuman (ESCALATE) -> refunded (APPROVE) or denied (DENY) -->
 
 ## Step 2: tool choice as a guarded decision
 
-"Which tool" was a model output you validated after the fact. Make it a **decision**: the model chooses exactly one currently-legal event, and a **guard** owns the `$100` limit so no prompt can talk past it.
+In the loop, the tool choice was a model output you validated afterward. Make it a **decision** instead. The model chooses exactly one event that is legal in the current state, and it chooses the refund amount as the event's payload. A guard holds the $100 limit, so a prompt cannot bypass it.
+
+The order lookup is a separate state that runs first. The model cannot reach the decision before the lookup finishes, because `deciding` is only entered from the lookup's `onDone`.
 
 ```ts no-check
 const machine = agentSetup.createMachine({
-  context: ({ input }) => ({ ...input, refunded: false }),
-  initial: "deciding",
+  context: ({ input }) => ({ ...input, order: null, refunded: false }),
+  initial: "lookingUp",
   states: {
+    lookingUp: {
+      invoke: {
+        src: "lookupOrder",
+        input: ({ context }) => ({ orderId: context.orderId }),
+        onDone: ({ output }) => ({ target: "deciding", context: { order: output } }),
+      },
+    },
     deciding: {
       invoke: {
         src: "agent.decide",
         input: ({ context }) => ({
           model: "quick",
           system: "Decide whether this refund can be issued directly.",
-          prompt: `${context.request} (amount: $${context.amount})`,
-          allowedEvents: ["REFUND", "ESCALATE"], // typo = compile error
+          prompt: `${context.request} (order total: $${context.order?.total})`,
+          allowedEvents: ["REFUND", "ESCALATE"], // an unknown name is a compile error
         }),
       },
       on: {
-        // The $100 rule, as a guard.
-        REFUND: ({ context }) =>
-          context.amount <= 100 ? { target: "refunded", context: { refunded: true } } : undefined,
+        // The $100 rule as a guard.
+        REFUND: ({ event }) =>
+          event.amount <= 100 ? { target: "refunded", context: { refunded: true } } : undefined,
         ESCALATE: { target: "awaitingHuman" },
       },
     },
@@ -120,11 +147,13 @@ const machine = agentSetup.createMachine({
 });
 ```
 
-A chosen `REFUND` for `$5000` can no longer slip through: the transition returns `undefined`, so the choice is rejected and the decision retries with typed feedback (see [transitions](machines.md#transitions)). The `system` and `prompt` are yours; how the model is coerced into picking one event is the host executor's job and swappable (see [Decisions](decisions.md) and [Coercion](decisions.md#coercion)).
+The model picks the amount, and the guard checks it. A `REFUND` chosen for $5000 no longer takes effect. The transition returns `undefined`, the choice is rejected, and the decision retries with typed feedback. See [transitions](machines.md#transitions).
+
+You write the `system` and `prompt` values. The host executor decides how the model is coerced into picking one event, and you can replace that executor. See [Decisions](decisions.md) and [Coercion](decisions.md#coercion).
 
 ## Step 3: the pause as an idle state
 
-The loop's `return { pending: true }` becomes a real waiting **state** with no invoke. `runAgent` settles `idle` there instead of losing everything; the snapshot is plain JSON you persist anywhere.
+The loop's `return { pending: true }` becomes a waiting state with no invoke. `runAgent` settles as `idle` in that state instead of discarding the run. The snapshot is plain JSON, so you can persist it anywhere.
 
 ```ts no-check
     // ...
@@ -142,18 +171,18 @@ The loop's `return { pending: true }` becomes a real waiting **state** with no i
 
 ## Step 4: the run with `runAgent`
 
-With `runAgent` owning the loop, the `while (true)` is gone; you supply executors built from the same `models` map.
+`runAgent` owns the loop, so the `while (true)` is gone. You supply executors built from the same `models` map.
 
 ```ts
 const executors = createAiSdkExecutors({ models });
 
 const result = await runAgent(machine, {
-  input: { request: "Refund my duplicate charge", amount: 5000 },
+  input: { request: "Refund my duplicate charge", orderId: "A-42" },
   executors,
 });
 
 if (result.status === "idle") {
-  // Persist result.snapshot anywhere (plain JSON), then resume in any process:
+  // result.snapshot is plain JSON. Persist it, then resume in any process.
   const resumed = await runAgent(machine, {
     snapshot: result.snapshot,
     event: { type: "APPROVE" },
@@ -163,14 +192,13 @@ if (result.status === "idle") {
 }
 ```
 
-The idle snapshot is genuinely plain JSON, so a real `stringify` → store → `parse` round-trip resumes identically:
+The idle snapshot is plain JSON, so a `stringify`, store, and `parse` round-trip resumes the same run.
+
+<!-- viz: resume flow: runAgent settles idle -> persisted snapshot -> JSON in a store -> new process parses -> runAgent(snapshot, event) -> done -->
 
 ```ts
-import { persistSnapshot } from "@statelyai/agent";
-
-// persistSnapshot deep-clones via JSON.stringify/parse; do it by hand to prove it:
-const wire = JSON.stringify(persistSnapshot(result.snapshot)); // what your DB/queue stores
-const restored = JSON.parse(wire); // a fresh process, no live objects
+const wire = JSON.stringify(result.persistedSnapshot ?? result.snapshot); // stored by your DB or queue
+const restored = JSON.parse(wire); // read in a fresh process, with no live objects
 
 const resumed = await runAgent(machine, {
   snapshot: restored,
@@ -180,17 +208,17 @@ const resumed = await runAgent(machine, {
 // resumed.status === 'done', resumed.output === { refunded: true }
 ```
 
-Those executors are your existing model code:
+The executors hold your existing model code:
 
 - The `createAiSdkExecutors` adapter wraps the AI SDK.
-- The `generateText`/`streamText` slots also accept the raw AI SDK functions directly, and any other SDK or a raw `fetch` backs them just as well.
-- The tools, retry logic, and provider calls you already wrote move in unchanged.
+- The `generateText` and `streamText` slots also accept the raw AI SDK functions. Another SDK or a raw `fetch` works the same way.
+- The tools, retry logic, and provider calls you already wrote move across unchanged.
 
-Only the `while` loop is gone. See [Hosts](hosts.md).
+Only the `while` loop is removed. See [Hosts](hosts.md).
 
 ## Existing server integration
 
-The machine is host-agnostic, so it runs wherever your loop ran. For a straight-through request handler that owns its own actor, bind executors with `provideExecutors` and run a plain XState actor, no `runAgent`:
+The machine is host-agnostic, so it runs wherever your loop ran. For a request handler that runs straight through and owns its own actor, bind the executors with `provideExecutors` and run a plain XState actor instead of `runAgent`.
 
 ```ts no-check
 import { createActor } from "xstate";
@@ -207,76 +235,87 @@ app.post("/refund", async (req, res) => {
 });
 ```
 
-For the idle human pause (the `$100` escalation above) over HTTP, persist the snapshot with `runAgent` and resume on a later request. [Use in any stack](any-stack.md) drops one machine into local, Express, and Cloudflare hosts with zero machine changes.
+To handle the human pause over HTTP, persist the snapshot with `runAgent` and resume it on a later request. [Use in any stack](any-stack.md) runs one machine in local, Express, and Cloudflare hosts without machine changes.
 
-## Behavior-preservation proof
+## Behavior preservation
 
-Before shipping, pin the new machine's behavior with a deterministic, model-free playthrough. `simulateAgent` scripts the decisions and runs the same step path `runAgent` uses, no API key, no network:
+Before you ship, pin the new machine's behavior with a deterministic playthrough that uses no model. `simulateAgent` scripts the decisions and runs the same step path that `runAgent` uses, with no API key and no network access.
 
 ```ts
 import { simulateAgent } from "@statelyai/agent";
 
 // A $5000 refund must escalate, not auto-refund.
 const result = await simulateAgent(machine, {
-  input: { request: "Refund my duplicate charge", amount: 5000 },
-  script: { decisions: { "agent.decide": [{ type: "REFUND" }] } },
+  input: { request: "Refund my duplicate charge", orderId: "A-42" },
+  script: {
+    invokes: { lookupOrder: [{ total: 5000 }] },
+    decisions: {
+      "agent.decide": [
+        { type: "REFUND", amount: 5000 },
+        { type: "ESCALATE", reason: "Above the automatic refund limit." },
+      ],
+    },
+  },
 });
-// The REFUND guard rejects amount > 100, so the run never reaches refunded: it
-// settles idle at deciding. The old loop's `if` is now enforced by construction.
+// The guard rejects the $5000 REFUND, which consumes its script entry. The
+// decision is requested again and consumes the next entry, so the run reaches
+// awaitingHuman and settles idle there.
 expect(result.status).toBe("idle");
 ```
 
-`canReach` and `explorePaths` go further: enumerate every branch and prove which outcomes are reachable. See [Testing and verification](verify.md).
+Script one entry per decision attempt, including attempts a guard rejects. A rejected decision consumes its entry, and the retry consumes the next one. If a queue runs dry while a request is pending, `simulateAgent` throws an error naming the request's kind, src, and id. The `invokes` channel cans the output of any non-model actor, which is how `lookupOrder` returns a total without calling your order service.
+
+`explorePaths` enumerates every branch, and `canReach` returns `{ reachable, witness }` for one target state. See [Testing and verification](verify.md).
 
 ## Retrofit with `getRequests`
 
-Everything above assumes you write the model calls into the machine as invokes. If you already have a plain XState machine, `getRequests` is the seam that skips that rewrite: it is a `RunAgentOptions` hook, and whenever the machine would otherwise settle idle, it reads the snapshot and returns the model request(s) to run instead. Return nothing and the run settles idle, which is how human-wait states stay human-wait states.
+The steps above assume you write the model calls into the machine as invokes. If you already have a plain XState machine, use `getRequests` instead. It is a `RunAgentOptions` hook. Whenever the machine would settle idle, `getRequests` reads the snapshot and returns the model requests to run. If it returns nothing, the run settles idle, which is how human-wait states stay human-wait states.
 
-The machine does not change at all. Where the prompts live is your call: state `description`s, `meta`, tags, or a lookup table keyed by state value. Nothing is blessed by the library.
+The machine does not change. You choose where the prompts live: state `description` fields, `meta`, tags, or a lookup table keyed by state value. The library does not require any of these.
 
-The prompts-in-descriptions recipe, copy-paste and adapt:
+The following example reads prompts from state descriptions.
 
 ```ts no-check
+import { getSnapshotRequests, runAgent } from "@statelyai/agent";
+
 const result = await runAgent(existingMachine, {
   executors,
-  getRequests: (snapshot) =>
-    snapshot._nodes
-      .filter((node) => node.description && !node.tags.includes("waiting"))
-      .map((node) => ({
-        model: "writer",
-        prompt: node.description!,
-        kind: node.tags.includes("decision") ? "decision" : "text",
-        // single-outcome states advance deterministically; else `decide`
-        onDone: node.ownEvents.length === 1 ? { type: node.ownEvents[0] } : undefined,
-        allowedEvents: node.ownEvents,
-      })),
+  getRequests: (snapshot) => getSnapshotRequests(snapshot, { model: "writer" }),
 });
 ```
 
-Semantics:
+`getSnapshotRequests(snapshot, { model, filter?, map? })` is the prompts-in-descriptions recipe as a function. By default every active node with a `description` that is not tagged `waiting` produces one request. The request's `prompt` is the node's `description`, its `kind` is `decision` when the node is tagged `decision`, its `system` comes from `meta.role`, and its `allowedEvents` are the node's own events. A node with exactly one own event gets an explicit `onDone`, so a single-outcome state advances without a model decision. Pass `filter` to choose which nodes produce requests, and `map` to reshape or drop each request.
 
-- Each request runs per its `kind`, appends to the run's message log (`RunAgentOptions.messages`, read back with `getAgentMessages(snapshot)`), and advances the machine per `onDone`: an explicit event, or a `decide` call when omitted. Always gated by `snapshot.can`.
-- Multiple returned requests run concurrently. For parallel regions, scope each one with `allowedEvents` (the node's `ownEvents` is a good default).
+To build requests some other way, read the active state nodes with `getSnapshotNodes(snapshot)`. It returns `{ id, key, description?, tags, meta?, ownEvents, leaf }` per node.
+
+```ts no-check
+import { getSnapshotNodes } from "@statelyai/agent";
+
+getRequests: (snapshot) =>
+  getSnapshotNodes(snapshot)
+    .filter((node) => node.leaf && node.meta)
+    .map((node) => buildRequest(node));
+```
+
+This hook behaves as follows:
+
+- Each request runs according to its `kind` and appends to the run's message log. The log is `RunAgentOptions.messages`, and you read it back with `getAgentMessages(snapshot)`.
+- Each request advances the machine according to `onDone`. `onDone` is either an explicit event, or a `decide` call when you omit it. Both are gated by `snapshot.can`.
+- Multiple returned requests run concurrently. For parallel regions, scope each request with `allowedEvents`. The node's `ownEvents` is a reasonable default.
 - A pass that sends no event settles idle.
 - Every model call counts against `maxModelCalls`.
 
-Runnable version: [described-workflow](../examples/described-workflow/index.ts), a plain `createMachine` with no invokes and no `setupAgent`, driven end to end by `getRequests`.
-
-## What the machine adds
-
-Same behavior as the loop, plus three things the loop only gets with hand-built machinery:
-
-- **Legality by construction**, and snapshot resume at every idle state.
-- **Durability**: the [step path](steps.md) and the [event log](event-log.md).
-- **One ordered ledger**: the transcript bookkeeping you hand-maintained becomes [`onTrace`](observability.md), for evals, JSONL, and telemetry.
+For a runnable version, see [described-workflow](../examples/described-workflow/index.ts). It is a plain `createMachine` with no invokes and no `setupAgent`, driven by `getRequests`.
 
 ## Related
 
-A worked end-to-end version of this page's conversion (a genuinely tangled loop, refactored one shippable step at a time with the behavior pinned by tests) lives in [retrofit](../examples/retrofit/index.ts): `before.ts`, then `step1/2/3.ts`, then `index.ts`.
+For what the machine gives you over the loop, see the [overview](index.md).
+
+For a worked version of this conversion, see [retrofit](../examples/retrofit/index.ts). It refactors a tangled loop one step at a time with the behavior pinned by tests, in the order `before.ts`, `step1.ts`, `step2.ts`, `step3.ts`, and `index.ts`.
 
 The same conversion works from shapes other than a `while` loop:
 
-- [plain-xstate](../examples/plain-xstate/index.ts): a bog-standard XState machine driven with no agent-specific setup.
-- [described-workflow](../examples/described-workflow/index.ts): prompts written as state `description`s, run via `runAgent`'s `getRequests` option.
+- [plain-xstate](../examples/plain-xstate/index.ts): a standard XState machine driven with no agent-specific setup.
+- [described-workflow](../examples/described-workflow/index.ts): prompts written as state `description` fields and run through the `getRequests` option of `runAgent`.
 - [todo-nl](../examples/todo-nl/index.ts): natural-language commands mapped onto machine events.
-- [Thinking in state machines](thinking-in-state-machines.md): the design tutorial behind this refactor, worked end to end on one triage agent.
+- [Thinking in state machines](thinking-in-state-machines.md): the design tutorial behind this refactor, worked through on one triage agent.

--- a/docs/generate-machines.md
+++ b/docs/generate-machines.md
@@ -5,51 +5,88 @@ description: Have a model author the agent workflow itself, then validate, lint,
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-An agent machine is [data](machines-as-data.md), so a model can write one. The payoff is not that generation is easy: it is that a generated machine can be **checked before it runs**.
+This page covers having a model author an agent machine config, then validating, linting, and simulating that config before it runs.
 
-- **Bounded.** The config's shape is fixed by a shipped JSON Schema. Expressions are dot paths, not code, so a generated config cannot do anything a hand-authored machine could not.
-- **Lintable.** `lintAgentMachine` catches dead decisions, unreachable states, and output-contract gaps statically. Every check applies to config-built machines.
-- **Simulatable.** `simulateAgent` plays the machine through with canned responses, keylessly, before it touches a model.
+An agent machine is [data](machines-as-data.md), so a model can write one. A generated machine can be checked before it runs, for three reasons.
 
-That turns "the model wrote a workflow" into a pipeline with gates, not a leap of faith.
+- The config's shape is fixed by a JSON Schema that ships with the package. Expressions are dot paths, not code, so a generated config cannot do anything a hand-authored machine could not do.
+- `validateAgentConfig` checks the config against that schema and returns diagnostics. It is exported from `@statelyai/agent/validate`, which uses `ajv` as an optional peer dependency, so install `ajv` to use it.
+- `lintAgentMachine` statically catches dead decisions, unreachable states, and output-contract gaps. Every check applies to machines built from a config.
+- `simulateAgent` plays the machine through with canned responses and no API key, before it calls a model.
 
 ## The loop
 
 ```
-generate → validate (Ajv) → lower (fromConfig) → lint → simulate → run
+generate → validate (validateAgentConfig) → lower (fromConfig) → lint → simulate → run
 ```
+
+<!-- viz: generation pipeline: generate -> validate (validateAgentConfig) -> lower (fromConfig) -> lint -> simulate -> run, with each failing gate feeding back into generate as a repair prompt, capped at 3 attempts -->
+
 
 | Step     | API                                       | Fails on                                                          |
 | -------- | ----------------------------------------- | ----------------------------------------------------------------- |
-| Generate | your model call                           | nothing (raw text)                                                |
-| Validate | Ajv 2020 + `agent-workflow.json`          | malformed config shape                                            |
+| Generate | your model call                           | nothing; the model returns unvalidated text                       |
+| Validate | `validateAgentConfig`                     | malformed config shape                                            |
 | Lower    | `setupAgent.fromConfig`                   | unresolved named guards/actions, `onDone` on a decision           |
-| Lint     | `lintAgentMachine` / `assertAgentMachine` | undeliverable decisions, unreachable states, missing final output |
-| Simulate | `simulateAgent`                           | no path settles; a loop                                           |
+| Lint     | `lintAgentMachine(machine, { throw: true })` | undeliverable decisions, unreachable states, missing final output |
+| Simulate | `simulateAgent`                           | the scripted path never settles, such as a machine that loops     |
 | Run      | `runAgent`                                | runtime only                                                      |
 
-How the gates behave:
+Each gate runs on the config the model returned, in order:
 
-- Every gate but the last runs with no API key.
-- Each throws a message naming the offending field, state, or path, so a failed gate feeds straight back to the model as a repair prompt instead of surfacing to a user.
-- Cap the repair loop at ~3 attempts. A config that fails three schema-shaped repairs is usually asking for something the data form cannot express, so [author it in TypeScript](machines.md) instead.
+```ts no-check
+import { lintAgentMachine, setupAgent, simulateAgent } from "@statelyai/agent";
+import { validateAgentConfig } from "@statelyai/agent/validate";
+
+// 1. Validate the config shape against the JSON Schema.
+const { valid, errors } = validateAgentConfig(config);
+if (!valid) {
+  // Feed these back to the model as a repair prompt.
+  throw new Error(errors.map((e) => `${e.path}: ${e.message}`).join("\n"));
+}
+
+// 2. Lower the config into a machine. Throws on unresolved names and bad targets.
+const { machine } = setupAgent.fromConfig(config, { compileSchema });
+
+// 3. Lint the machine. `throw: true` raises on the first error-severity finding.
+lintAgentMachine(machine, { throw: true });
+
+// 4. Simulate a playthrough with no API key.
+const { status } = await simulateAgent(machine, {
+  input: { question: "refund?" },
+  script: { decisions: { "agent.decide": [{ type: "RESOLVE" }] } },
+});
+if (status !== "done") {
+  throw new Error(`Generated machine settled as '${status}'`);
+}
+```
+
+`compileSchema` is the JSON Schema compiler `fromConfig` uses for the config's schemas. Build it from `ajv`. See [Machines as data](machines-as-data.md).
+
+The gates behave as follows.
+
+- `validateAgentConfig(config)` returns `{ valid, errors }`. Each error is `{ severity, path, message, keyword }`, where `path` is a JSON Pointer into the config. It uses Ajv's 2020 build, which the `agent-workflow.json` dialect requires.
+- Validation checks shape only. `fromConfig` is what checks that named guards, actions, and actors are implemented.
+- Every gate except `run` works with no API key.
+- Each gate throws a message naming the offending field, state, or path. A failed gate can therefore be fed back to the model as a repair prompt instead of surfacing to a user.
+- Cap the repair loop at about 3 attempts. A config that fails three schema-shaped repairs usually asks for something the data form cannot express. In that case, [author it in TypeScript](machines.md) instead.
 
 ## The skill
 
-The full authoring procedure (schema location, the rules a config must follow, a few-shot config, the Ajv adapter, the lint and simulate calls, and the repair loop) ships as an agent skill:
+The full authoring procedure ships as an agent skill. It covers the schema location, the rules a config must follow, a few-shot config, the Ajv adapter, the lint and simulate calls, and the repair loop.
 
 **[`skills/generate-machine/SKILL.md`](https://github.com/statelyai/agent/blob/main/skills/generate-machine/SKILL.md)**
 
-Copy that directory into your coding agent's skills dir (`.claude/skills/` for Claude Code, or wherever your harness loads skills from). The agent then loads it on requests like "author an agent machine for X" and runs the gates itself.
+Copy that directory into your coding agent's skills directory. For Claude Code this is `.claude/skills/`. Other harnesses use their own location. The agent then loads the skill on requests such as "author an agent machine for X" and runs the gates itself.
 
 ## Limits
 
-Honest constraints on generated machines:
+Generated machines have these constraints.
 
-- **Named guards and actions are host-resolved.** A config cannot carry functions. A model can emit `guard: "isReady"`, but the implementation lives in the `guards` passed to `fromConfig(...)`, and an unresolved name is a build-time throw. Either list the names your host implements in the prompt, or forbid them.
-- **Ajv validity is not semantic validity.** The schema constrains shape, not meaning: a config can validate and still reference a request that does not exist, or route to a state that solves nothing. That is what the lint and simulate gates are for.
-- **A dry run covers one path.** The simulation follows the script you gave it. Use `explorePaths` when the generated branch structure matters.
-- **Model refs and tool names are unchecked strings.** They resolve at run time, in the host. Generated machines carry string refs (`"openai/gpt-5.4-mini"` here is illustrative; substitute your provider's current models), so pass `createAiSdkExecutors({ resolveModel })`; see [Models and providers](models-and-providers.md).
+- Named guards and actions are resolved by the host. A config cannot carry functions. A model can emit `guard: "isReady"`, but the implementation lives in the `guards` option passed to `fromConfig(...)`, and an unresolved name throws at build time. List the names your host implements in the prompt, or forbid named references entirely.
+- Schema validity is not semantic validity. The schema constrains shape, not meaning. A config can validate and still reference a request that does not exist, or route to a state that does not make progress. The lint and simulate gates cover those cases.
+- A dry run covers one path. The simulation follows the script you gave it. Use `explorePaths` when the generated branch structure matters.
+- Model refs and tool names are unchecked strings. They resolve at run time, in the host. Generated machines carry string refs, so pass `createAiSdkExecutors({ resolveModel })`. See [Models and providers](models-and-providers.md). The ref `"openai/gpt-5.4-mini"` used on this page is illustrative. Substitute your provider's current models.
 
 ## Related
 

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -5,29 +5,42 @@ description: Give an agent machine the executor functions that call a model, and
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
+This page describes the executor contract, the AI SDK adapter that ships with the package, and how to write your own executors.
+
 ## The executor contract
 
 <!-- AgentRequestExecutors contract and bind-time checks from src/run-agent.ts -->
 
-A **host** runs an agent machine and supplies the functions that call a model. The machine decides what to ask; the host executes it. The machine never talks to a model directly.
+A **host** runs an agent machine and supplies the functions that call a model. The machine determines which request to make. The host performs the call. The machine never calls a model directly.
 
-Those functions are the **executors** (`AgentRequestExecutors`). Each is a plain async function over a plain request object, so any SDK or a raw `fetch` can back it:
+Those functions are the **executors**, typed as `AgentRequestExecutors`. Each executor is an async function that takes a plain request object, so you can implement one with any SDK or with `fetch`.
 
-| Executor                      | Returns                                                                                                     | Required when                            |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `generateText(request, info)` | `{ output }` (text string or structured object; optional passthrough fields like `usage` allowed alongside) | machine has a generate-mode text request |
-| `streamText(request, info)`   | `{ output }` (accumulated text; chunks stream through `info.onChunk`)                                       | machine has a streaming request          |
-| `decide(request)`             | `{ event }` (the one event the model chose)                                                                 | machine has a decision                   |
+<!-- viz: executor boundary: machine (states, requests, decisions) -> request object -> host executors (generateText / streamText / decide) -> model provider, with the result folded back as an event -->
 
-At bind time, before any actor runs, `runAgent` checks the required executors, so a machine that needs `decide` without one fails immediately rather than mid-run. A machine with only plain actors needs no executors.
 
-> **Note:** Mind the arity. `decide` takes one argument (the request); `generateText` and `streamText` take two (`request, info`, where `info` carries `onChunk` and the abort `signal`).
+| Executor                      | Returns       | Required when                            |
+| ----------------------------- | ------------- | ---------------------------------------- |
+| `generateText(request, info)` | `{ output }`  | machine has a generate-mode text request |
+| `streamText(request, info)`   | `{ output }`  | machine has a streaming request          |
+| `decide(request, info)`       | `{ event }`   | machine has a decision                   |
+
+What each return value holds:
+
+- `generateText` returns `output` as a text string, or as a structured object when the request declares an output schema.
+- `streamText` returns `output` as the accumulated text. Individual chunks are delivered through `info.onChunk` while the call runs.
+- `decide` returns `event`, the one event the model chose from the candidate set.
+
+An executor may return extra passthrough fields alongside `output` or `event`. `usage` is the common one. See [Usage and budgets](usage-and-budgets.md).
+
+`runAgent` checks the required executors at bind time, before any actor runs. A machine that needs `decide` but has no `decide` executor fails immediately instead of failing mid-run. A machine with only plain actors needs no executors.
+
+All three executors take the same two arguments, `request` and `info`. The `info` argument carries `onChunk`, the abort `signal`, and the request id.
 
 ## The shipped AI SDK adapter
 
 <!-- createAiSdkExecutors surface from src/ai-sdk/index.ts -->
 
-`createAiSdkExecutors` from `@statelyai/agent/ai-sdk` is the only adapter this package ships. It builds the `{ generateText, streamText, decide }` set from the Vercel AI SDK (decisions map onto a tool-forced `generateText` call). The subpath exports adapters only (`defineModels`, `createAiSdkExecutors`); `runAgent` always comes from the root and always takes explicit executors.
+`createAiSdkExecutors` from `@statelyai/agent/ai-sdk` is the only adapter that ships with this package. It builds the `{ generateText, streamText, decide }` set from the Vercel AI SDK. Decisions map onto a tool-forced `generateText` call. The `/ai-sdk` subpath exports only adapters, `defineModels` and `createAiSdkExecutors`. `runAgent` is always imported from the root and always takes explicit executors.
 
 ```ts
 import { runAgent } from "@statelyai/agent";
@@ -42,7 +55,7 @@ const result = await runAgent(machine, {
 });
 ```
 
-Executor sets are plain objects, so mixing is fine: keep the adapter's `decide` and swap in your own `streamText`.
+Executor sets are plain objects, so you can mix them. The following example keeps the adapter's `decide` and replaces its `streamText`.
 
 ```ts
 const executors = {
@@ -53,18 +66,18 @@ const executors = {
 
 <!-- peer dependencies and entry points from package.json#peerDependencies and package.json#exports -->
 
-Dependencies stay minimal:
+The package has these dependencies:
 
-- `ai` is an optional peer dependency, imported only by the `/ai-sdk` subpath.
-- `xstate` is core's only runtime peer.
-- `@opentelemetry/api` is an optional peer for the OTel bridge.
+- `ai` is an optional peer dependency. Only the `/ai-sdk` subpath imports it.
+- `xstate` is the only runtime peer dependency of core.
+- `@opentelemetry/api` is an optional peer dependency for the OpenTelemetry bridge.
 - No provider package is a dependency, because you supply the model resolver.
 
-The package ships `@statelyai/agent`, `@statelyai/agent/ai-sdk`, `@statelyai/agent/machines`, `@statelyai/agent/otel`, `@statelyai/agent/sqlite`, and the JSON Schema at `@statelyai/agent/agent-workflow.json`. Every host helper (`getJsonSchema`, `buildEnvelopeSchema`, `parseStructuredEnvelope`, `parseOutput`, `getAgentOutputMode`, `renderDecisionAttempts`, `resolveDecision`, `executeAgentRequest`, ...) is a root export.
+The package exports `@statelyai/agent`, `@statelyai/agent/ai-sdk`, `@statelyai/agent/machines`, `@statelyai/agent/otel`, `@statelyai/agent/sqlite`, and the JSON Schema at `@statelyai/agent/agent-workflow.json`. Host helpers such as `getJsonSchema`, `buildEnvelopeSchema`, `parseStructuredEnvelope`, `parseOutput`, `getAgentOutputMode`, `renderDecisionAttempts`, `resolveDecision`, and `executeAgentRequest` are root exports.
 
 ### Typed model aliases
 
-Pass one `models` map to both `setupAgent` and the adapter, and request `model:` values are typed against its keys:
+Pass the same `models` map to `setupAgent` and to the adapter. Request `model:` values are then typed against the map's keys.
 
 ```ts
 const models = defineModels({
@@ -89,28 +102,28 @@ const agentSetup = setupAgent({
 await runAgent(machine, { input, executors: createAiSdkExecutors({ models }) });
 ```
 
-For a fully dynamic host (one whose machine must not name concrete models), use `resolveModel` instead:
+Use `resolveModel` for a dynamic host, where the machine must not name concrete models.
 
-- It takes the raw ref string and returns a model, so refs like `"openai/gpt-5.4-mini"` resolve without a static map.
-- Pass both `models` and `resolveModel` and `resolveModel` wins.
-- With `models` alone, an unknown ref throws.
-- `parseModelRef(ref)` splits a `"provider/model-id"` ref, so a resolver is one line: `(ref) => openai(parseModelRef(ref).modelId)`.
+- `resolveModel` takes the raw ref string and returns a model, so a ref such as `"openai/gpt-5.4-mini"` resolves without a static map.
+- If you pass both `models` and `resolveModel`, `resolveModel` takes precedence.
+- If you pass only `models`, an unknown ref throws.
+- `parseModelRef(ref)` splits a `"provider/model-id"` ref into its parts, so a resolver can be a single expression: `(ref) => openai(parseModelRef(ref).modelId)`.
 
-Model refs are opaque strings, so any string is a legal `model:` value; the `models` map only adds key autocomplete and a resolution point.
+Model refs are opaque strings, so any string is a legal `model:` value. The `models` map adds key autocomplete and a resolution point.
 
 ### Multi-step tool loops
 
-A text request runs a single model call by default. Set `metadata.maxSteps` on the request to allow a bounded tool-call loop; the adapter forwards it as `stopWhen: stepCountIs(maxSteps)`. This is adapter behavior, not core.
+A text request runs a single model call by default. Set the typed `maxSteps` field on the request to allow a bounded tool-call loop. The adapter forwards it as `stopWhen: stepCountIs(maxSteps)`. This is adapter behavior, not core behavior.
 
-Request `metadata` is the host-owned per-call channel: core leaves it uninterpreted except for adapter conventions like `maxSteps`. A host that doesn't understand a key ignores it, so requests stay portable. It differs from XState `meta` (state-node/transition metadata for tooling); request `metadata` is runtime input passed to the executor. See [Text requests](text-requests.md#tools-and-multi-step-loops).
+Request `metadata` is the host-owned channel for per-call values. Core does not interpret it. A host ignores keys it does not understand, so requests remain portable across hosts. Request `metadata` is not the same as XState `meta`. XState `meta` is state-node and transition metadata used by tooling. Request `metadata` is runtime input passed to the executor. See [Text requests](text-requests.md#tools-and-multi-step-loops).
 
 ## Threading host context into actors and requests
 
-Host-owned values (a session handle, db client, auth or billing ids) often need to reach the code that makes a model call. There is no `hostContext` option today (under consideration, **not shipped**). Pick the pattern by whether the value is serializable and whether it is needed per call:
+Host-owned values such as a session handle, a database client, or auth and billing ids often need to reach the code that calls the model. There is no `hostContext` option today. It is under consideration and is not shipped. Choose a pattern based on whether the value is serializable and whether it is needed per call.
 
-- **Serializable ids the machine carries:** pass as machine `input`, land in `context`, map into each actor's `input`.
-- **Non-serializable handles (a live session, db client, socket):** close over them where you define the actor via `.provide({ actors })` or `.withExecutor(...)`. The handle stays in the closure, never in `context` (it won't survive [snapshot serialization](human-in-the-loop.md#persist-and-resume-across-processes)).
-- **Per-call reference ids** (auth token, billing id, trace id): put them in the request's input schema, so they're typed and validated at the call site rather than smuggled through `metadata`.
+- Serializable ids that the machine carries: pass them as machine `input`. They land in `context`, and you map them into each actor's `input`.
+- Non-serializable handles such as a live session, a database client, or a socket: close over them where you define the actor, using `.provide({ actors })` or `.withExecutor(...)`. The handle stays in the closure and never enters `context`, because it does not survive [snapshot serialization](human-in-the-loop.md#persist-and-resume-across-processes).
+- Per-call reference ids such as an auth token, a billing id, or a trace id: put them in the request's input schema. They are then typed and validated at the call site instead of being passed through `metadata`.
 
 ```ts no-check
 function buildMachine(session: Session, db: DbClient) {
@@ -129,7 +142,7 @@ function buildMachine(session: Session, db: DbClient) {
 
 <!-- createScriptedExecutors surface from src/scripted-executors.ts -->
 
-`createScriptedExecutors` is the keyless executor set: a full `{ generateText, streamText, decide }` that plays back scripted answers from FIFO queues instead of calling a model. No API key, no network. It is a root export (no dependencies), so a machine runs end to end with nothing installed but core.
+`createScriptedExecutors` returns a full `{ generateText, streamText, decide }` set that plays back scripted answers from FIFO queues instead of calling a model. It needs no API key and makes no network calls. It is a root export with no dependencies, so a machine runs end to end with only core installed.
 
 ```ts
 import { createScriptedExecutors, runAgent } from "@statelyai/agent";
@@ -143,17 +156,18 @@ const result = await runAgent(moderationMachine, {
 });
 ```
 
-- `decisions` answers `decide`; `text` answers every text request, `generateText` and `streamText` sharing the one queue.
-- Entries are values or functions of the request: route on `request.name`, on the decision's candidate `events`, or on prior `attempts`.
-- An entry may be the raw envelope (`{ output, usage }` / `{ event, usage }`), so scripted runs can exercise usage aggregation.
+- `decisions` answers `decide`. `text` answers every text request, and `generateText` and `streamText` share that one queue. `userInput` answers `agent.userInput` invokes.
+- The returned object also carries a `userInput` handler. Pass it to `runAgent`'s `userInput` option, because `agent.userInput` is an actor source rather than an executor slot.
+- An entry is a value or a function of the request. A function can route on `request.name`, on the decision's candidate `events`, or on prior `attempts`.
+- An entry may be a raw envelope, `{ output, usage }` or `{ event, usage }`, so a scripted run can exercise usage aggregation.
 - A guard-rejected decision consumes an entry and retries with the next one.
-- A dry queue throws with `code: 'scripted-executors-exhausted'`, naming the pending request. Queues are copied, so one script object seeds many runs.
+- An empty queue throws an error with `code: 'scripted-executors-exhausted'` that names the pending request. Queues are copied, so one script object can seed many runs.
 
-For a playthrough with no run loop at all, `simulateAgent` scripts the pure step path by invoke `src`. See [Testing and verification](verify.md).
+To script a run with no run loop, use `simulateAgent`, which scripts the step path by invoke `src`. See [Testing and verification](verify.md).
 
 ## Writing your own executors
 
-The contract is three plain functions, so a raw `fetch` is enough:
+The contract is three async functions, so `fetch` is enough to implement one.
 
 ```ts
 import type { AgentRequestExecutors } from "@statelyai/agent";
@@ -171,20 +185,23 @@ const executors: AgentRequestExecutors = {
 await runAgent(machine, { input, executors });
 ```
 
-A hand-written host reads the fields it needs off the plain request and builds its own payload. The one public mapping helper is `getJsonSchema(schema)`: it reads a Standard Schema's JSON Schema for a `response_format` or a tool's `parameters`. Wrap the declared output schema with `buildEnvelopeSchema` first (below).
+A hand-written host reads the fields it needs from the request and builds its own payload. The one public mapping helper is `getJsonSchema(schema)`. It reads a Standard Schema's JSON Schema for use as a `response_format` or as a tool's `parameters`. Wrap the declared output schema with `buildEnvelopeSchema` first. See [The structured-output envelope](#the-structured-output-envelope).
 
-Two more root exports for hand-rolled hosts:
+Two other root exports are useful for hand-written hosts:
 
-- **`isStandardSchema(value)`** narrows an unknown schema before extraction. A tool's `inputSchema` may be an SDK-specific wrapper core can't read: check first and fall back to unconstrained parameters instead of crashing (what the shipped adapter does internally).
-- **`renderDecisionAttempts(request)`** renders a decision request's prior failed `attempts` as feedback messages to append to the next call, so retries converge instead of repeating the same illegal choice. See [Decisions](decisions.md#validation-and-retries).
+- `isStandardSchema(value)` narrows an unknown schema before extraction. A tool's `inputSchema` may be an SDK-specific wrapper that core cannot read. Check the value first and fall back to unconstrained parameters. The shipped adapter does this internally.
+- `renderDecisionAttempts(request)` renders a decision request's prior failed `attempts` as feedback messages to append to the next call, so a retry does not repeat the same illegal choice. See [Decisions](decisions.md#validation-and-retries).
 
-For runnable reference implementations against real provider SDKs (raw `openai`, raw `@anthropic-ai/sdk`, Cloudflare Workers AI, Durable Objects), see [Models and providers](models-and-providers.md).
+For runnable reference implementations against provider SDKs, including raw `openai`, raw `@anthropic-ai/sdk`, Cloudflare Workers AI, and Durable Objects, see [Models and providers](models-and-providers.md).
 
 ## The structured-output envelope
 
 <!-- buildEnvelopeSchema and the wire contract from src/text-logic.ts; adapter in src/ai-sdk -->
 
-When a request has a structured output schema (`getAgentOutputMode(request.outputSchema) === 'structured'`), a host sends the schema wrapped as a root object (the **envelope**) and unwraps it before returning. This is THE wire contract for structured output: a root object is universally accepted as a provider response schema, unlike a bare union or array root that many providers reject.
+When a request has a structured output schema, meaning `getAgentOutputMode(request.outputSchema)` returns `'structured'`, the host sends the schema wrapped in a root object called the **envelope**, then unwraps the response before returning it. This is the wire contract for structured output. Providers accept a root object as a response schema, but many reject a bare union or array at the root.
+
+<!-- viz: structured output round trip: declared schema -> buildEnvelopeSchema -> getJsonSchema -> provider -> parseStructuredEnvelope -> unwrapped .result returned as output -->
+
 
 ```json
 { "result": <the declared schema>, "reasoning": "<optional string>" }
@@ -206,20 +223,20 @@ if (getAgentOutputMode(request.outputSchema) === "structured") {
 }
 ```
 
-Return the **unwrapped** `.result` as `output`:
+Return the unwrapped `.result` as `output`.
 
-- The machine only ever validates and sees the schema it declared.
-- `reasoning` is surfaced on the raw executor result only, never in machine context/output (see [reasoning opt-in](text-requests.md#reasoning)).
-- Requests with no declared output schema are text requests and skip the envelope entirely.
-- Prompt-serialized hosts that never send a response schema (the Workers AI host, for one) parse best-effort JSON and skip it too.
+- The machine validates and sees only the schema it declared.
+- `reasoning` appears on the raw executor result only. It never appears in machine context or output. See [reasoning opt-in](text-requests.md#reasoning).
+- A request with no declared output schema is a text request and skips the envelope.
+- A prompt-serialized host that never sends a response schema, such as the Workers AI host, parses the JSON best-effort and also skips the envelope.
 
 ## Retries and budgets
 
-Transport-level retries and executor-level budgets belong to the host. See [Usage and budgets](usage-and-budgets.md#retries-and-executor-budgets).
+The host owns transport-level retries and executor-level budgets. See [Usage and budgets](usage-and-budgets.md#retries-and-executor-budgets).
 
 ## Machines with no requests
 
-`RunAgentOptions.getRequests` is the retrofit seam: when a machine would otherwise settle idle, this hook reads the snapshot and returns the model request(s) to run instead, so a plain invoke-less XState machine runs as an agent with no machine changes. Prompts can come from state `description`s, `meta`, tags, or a lookup keyed by state value. Full recipe in [Migrating from a loop](from-a-loop.md#retrofit-with-getrequests).
+`RunAgentOptions.getRequests` lets you run an existing XState machine as an agent without changing the machine. When the machine would otherwise settle idle, the hook reads the snapshot and returns the model requests to run instead. Prompts can come from state `description` fields, `meta`, tags, or a lookup keyed by state value. See [Migrating from a loop](from-a-loop.md#retrofit-with-getrequests).
 
 ## Related
 

--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -5,30 +5,36 @@ description: Pause an agent for human input by settling idle, persist the snapsh
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
+This page describes how an agent pauses for human input, how to persist the pause, and how to resume it in another process.
+
 ## The idle-first model
 
 <!-- idle settle and snapshot resume behavior from src/run-agent.ts -->
 
-A state waiting on a human is just a state with no invoke and an `on:` handler for the human's event. No `interrupt()` to learn.
+A state that waits on a human is a state with no invoke and an `on:` handler for the human's event. There is no separate interrupt API.
 
-- When nothing is in flight, `runAgent` settles **`{ status: 'idle', snapshot }`** instead of hanging.
-- Persist the snapshot, present the human their choices, resume by handing the snapshot back with the chosen event.
-- The machine decides which events are legal; the host delivers them.
+- When nothing is in flight, `runAgent` settles with `{ status: 'idle', snapshot }` instead of hanging.
+- Persist the snapshot, present the human their choices, then resume by passing the snapshot back with the chosen event.
+- The machine decides which events are legal. The host delivers them.
 
-The machine itself is unchanged between the run that settled and the run that resumes.
+The machine is unchanged between the run that settled and the run that resumes.
 
-> **Note:** Idle is a whole-machine condition. If one region of a parallel machine waits for a human while a sibling still has work running, the run finishes that work first. Waits modeled with `agent.userInput` are exempt (pending placeholders that never block the settle). See [Parallel machines and pending user input](#parallel-machines-and-pending-user-input).
+<!-- viz: idle lifecycle: runAgent -> idle settle with snapshot -> persist -> human chooses event -> runAgent(snapshot, event) -> done or idle again -->
+
+> **Note:** Idle is a whole-machine condition. If one region of a parallel machine waits for a human while a sibling still has work running, the run finishes that work first. Waits modeled with `agent.userInput` are exempt, because they are pending placeholders that never block the settle. See [Parallel machines and pending user input](#parallel-machines-and-pending-user-input).
 
 ### Custom wait signals
 
-<!-- setupAgent({ isSuspended }) and RunAgentOptions.isSuspended from src/run-agent.ts, src/setup-agent.ts -->
+<!-- setupAgent({ isIdle }) and RunAgentOptions.isIdle from src/run-agent.ts, src/setup-agent.ts -->
 
-By default `runAgent` detects a resting state with a timing heuristic. To settle intentional waits deterministically, tell the machine which states are idle states. (The predicate is named `isSuspended`; the docs call the states themselves idle states.) There is no built-in tag; you choose the signal (a tag, a `snapshot.matches(...)`, or a `meta` field). Declare it once with `setupAgent({ isSuspended })` and the predicate travels with the machine, including through `machine.provide(...)`:
+By default, `runAgent` detects a resting state with a timing heuristic. To settle intentional waits deterministically, tell the machine which states are idle states. The predicate is named `isIdle`.
+
+There is no built-in tag. You choose the signal: a tag, a `snapshot.matches(...)` check, or a `meta` field. Declare it once with `setupAgent({ isIdle })`. The predicate travels with the machine, including through `machine.provide(...)`.
 
 ```ts no-check
 const agentSetup = setupAgent({
   // ...schemas...
-  isSuspended: (snapshot) => snapshot.hasTag('awaiting-review'),
+  isIdle: (snapshot) => snapshot.hasTag('awaiting-review'),
 });
 
 // ...then mark the idle states with the tag you chose:
@@ -38,13 +44,14 @@ reviewing: {
 },
 ```
 
-A host can override per run by passing `isSuspended` to `runAgent` directly. Resolution order: `runAgent` option → machine-carried predicate → timing heuristic.
-
-> The `isSuspended` option name is provisional and may change before 2.0.
+A host can override the predicate for one run by passing `isIdle` to `runAgent`. The resolution order is the `runAgent` option, then the machine-carried predicate, then the timing heuristic.
 
 ## An idle state
 
-The `reviewing` state has no invoke. Once reached, nothing happens until a human sends `APPROVE` or `REJECT`:
+In this machine, the `reviewing` state has no invoke. Once the machine reaches it, nothing happens until a human sends `APPROVE` or `REJECT`.
+
+<!-- viz: state machine: drafting (invoke writeDraft) -> reviewing -> APPROVE -> published (final); reviewing -> REJECT -> drafting -->
+
 
 ```ts
 import { z } from "zod";
@@ -97,36 +104,36 @@ const machine = agentSetup.createMachine({
 
 ## Idle settle and resume
 
-The first `runAgent` runs the draft, reaches `reviewing`, settles `idle`. Persist the snapshot, wait for the human, resume with `{ snapshot, event }`:
+The first `runAgent` call runs the draft, reaches `reviewing`, and settles `idle`. Persist the snapshot, wait for the human, then resume with `{ snapshot, event }`.
 
 ```ts
-import { persistSnapshot } from "@statelyai/agent";
-
 const first = await runAgent(machine, {
   input: { topic: "release notes" },
   executors,
 });
-// first.status === 'idle'
-const persisted = persistSnapshot(first.snapshot);
 
-// ...later, possibly a different process, the human approved...
-const second = await runAgent(machine, {
-  snapshot: persisted,
-  event: { type: "APPROVE" },
-  executors,
-});
-// second.status === 'done'
+if (first.status === "idle") {
+  const persisted = JSON.parse(JSON.stringify(first.persistedSnapshot));
+
+  // ...later, possibly a different process, the human approved...
+  const second = await runAgent(machine, {
+    snapshot: persisted,
+    event: { type: "APPROVE" },
+    executors,
+  });
+  // second.status === 'done'
+}
 ```
 
-`persistSnapshot(snapshot)` handles the round-trip: it deep-clones to plain JSON via `JSON.stringify`/`JSON.parse`, returning the exact shape you store and feed back to `runAgent({ snapshot })`. It drops or throws on non-JSON values exactly as `JSON.stringify` would, so the persisted value matches what a real persistence layer sees.
+A settled result already carries persistable snapshots, so there is no library helper for the round-trip. Store the value with whatever your persistence layer uses, and pass what you read back as `runAgent({ snapshot })`. Outside a `runAgent` result, take the snapshot from `actor.getPersistedSnapshot()` on a live actor, or `machine.getPersistedSnapshot(snapshot)` for a snapshot you hold. Serializing through `JSON.stringify` and `JSON.parse` in a sample shows exactly what a real store sees, including any non-JSON value it would drop.
 
-> **`persistedSnapshot` vs `snapshot`.** An idle result always carries `snapshot`, the live settled snapshot. It also carries `persistedSnapshot` when the settle left pending `agent.userInput` invokes, because the live `snapshot` cannot round-trip active children: persisting it in that case silently drops those invokes, and the loss only surfaces on resume. Persist `result.persistedSnapshot ?? result.snapshot` and both cases are covered.
+> **Persist `persistedSnapshot` on an idle result.** An idle result carries two snapshots: `snapshot`, the live settled snapshot, and `persistedSnapshot`, the JSON-serializable one. The live `snapshot` cannot round-trip active children, so persisting it drops any pending `agent.userInput` invoke silently, and the loss only surfaces on resume. Narrow on `status === 'idle'` and persist `persistedSnapshot`. Where a value can also come from a non-idle result, `result.persistedSnapshot ?? result.snapshot` is correct. The rest of this page assumes that rule.
 
 ## Rules of resume
 
-<!-- verified against src/run-agent.ts (resume checks, onIllegalResumeEvent, onVersionMismatch, migrateSnapshot) and src/event-log-store.ts (fork, append) -->
+<!-- verified against src/run-agent.ts (resume checks, onVersionMismatch, migrateSnapshot) and src/event-log-store.ts (fork, append) -->
 
-**Resume with an event the restored state accepts.** `runAgent` checks legality before starting the actor and throws `AgentIllegalResumeEventError` (`eventType`, `acceptedTypes`) rather than silently dropping the event.
+**Resume with an event the restored state accepts.** `runAgent` checks legality before starting the actor. It throws `AgentIllegalResumeEventError`, carrying `eventType` and `acceptedTypes`, instead of dropping the event silently.
 
 ```ts no-check
 // Wrong: the event the UI showed five minutes ago may no longer be legal.
@@ -137,18 +144,18 @@ const choices = getAcceptedEvents(snapshot); // { type, toolName, schema? }[]
 await runAgent(machine, { snapshot, event: parseAgentEvent(snapshot, payload), executors });
 ```
 
-**Persist before you surface anything to the human.** `runAgent` owns no store and stops its actor on every settle path, so an unpersisted snapshot is gone the moment the process is. Persist `persistedSnapshot ?? snapshot`, because the live snapshot cannot round-trip pending `agent.userInput` invokes.
+**Persist before you surface anything to the human.** `runAgent` owns no store and stops its actor on every settle path, so an unpersisted snapshot is lost when the process ends. Persist `persistedSnapshot ?? snapshot`, as described in [Idle settle and resume](#idle-settle-and-resume).
 
 ```ts no-check
 // Wrong: the notification can outlive the process that holds the only copy.
 notifyReviewer(result.snapshot);
 
 // Right: durable first, then tell the human.
-await store.save(threadId, persistSnapshot(result.persistedSnapshot ?? result.snapshot));
+await store.save(threadId, result.persistedSnapshot ?? result.snapshot);
 notifyReviewer(threadId);
 ```
 
-**Give a divergent resume its own thread.** Nothing in `runAgent` tracks thread identity, so resuming one persisted snapshot twice just runs it twice. The log layer is where branching is enforced: `fork` demands a `newThreadId` and refuses a thread that already has entries, and `append` rejects duplicate event ids within a thread.
+**Give a divergent resume its own thread.** `runAgent` does not track thread identity, so resuming one persisted snapshot twice runs it twice. The log layer enforces branching. `fork` requires a `newThreadId` and refuses a thread that already has entries. `append` rejects duplicate event ids within a thread.
 
 ```ts no-check
 // Wrong: two resumes of the same snapshot, both appending to one thread.
@@ -160,29 +167,28 @@ await store.fork({ threadId: "session-1", newThreadId: "session-1-alt", upToInde
 await store.append({ threadId: "session-1-alt", expectedIndex: 7, entries: branchB });
 ```
 
-**Match the machine version, or migrate deliberately.** A snapshot stamped by an older machine shape resumes into transitions that may no longer exist, so `runAgent` throws `AgentSnapshotVersionMismatchError` (`from`, `to`, `machineId`) by default.
+**Match the machine version, or migrate deliberately.** A snapshot stamped by an older machine shape can resume into transitions that no longer exist. By default, `runAgent` throws `AgentSnapshotVersionMismatchError`, carrying `from`, `to`, and `machineId`.
 
 ```ts no-check
 // Wrong: silencing the check leaves the snapshot pointing at a state that moved.
 await runAgent(machine, { snapshot, event, executors, onVersionMismatch: "ignore" });
 
-// Right: adapt the old shape, or pin an explicit version you control.
+// Right: adapt the old shape with a host-owned migration.
 await runAgent(machine, {
   snapshot,
   event,
   executors,
-  machineVersion: "2025-11-04",
   migrateSnapshot: (old, { from, to }) => upgradeSnapshot(old, from, to),
 });
 ```
 
-Details on the last two: [Illegal resume events](#illegal-resume-events) and [Machine-version resume](#machine-version-resume).
+Read more about [Illegal resume events](#illegal-resume-events) and [Machine-version resume](#machine-version-resume).
 
 ## The human's choices
 
 <!-- getAcceptedEvents from src/events.ts -->
 
-The `getAcceptedEvents(snapshot)` helper returns one descriptor per **currently-legal** event: its `type`, a synthetic `toolName`, and its payload schema when registered. Drive the loop off it:
+The `getAcceptedEvents(snapshot)` helper returns one descriptor per currently legal event. Each descriptor has the event `type`, a synthetic `toolName`, and the payload schema when one is registered. Drive the loop from these descriptors.
 
 ```ts
 import { getAcceptedEvents, runAgent } from "@statelyai/agent";
@@ -200,7 +206,7 @@ while (result.status === "idle") {
 }
 ```
 
-A generic host that builds the event dynamically (form input, a webhook payload, an interaction protocol) can't type it against a specific machine. `parseAgentEvent(snapshot, event)` validates the `{ type, ...payload }` at runtime against accepted event types and registered payload schemas, returning it typed as the machine's event union or throwing a descriptive error. It replaces `event as never` casts in meta-driven hosts:
+A generic host builds the event dynamically from form input, a webhook payload, or an interaction protocol, so it cannot type the event against a specific machine. `parseAgentEvent(snapshot, event)` validates the `{ type, ...payload }` object at runtime against the accepted event types and registered payload schemas. It returns the event typed as the machine's event union, or throws a descriptive error. Use it instead of an `event as never` cast in meta-driven hosts.
 
 ```ts
 import { parseAgentEvent } from "@statelyai/agent";
@@ -209,20 +215,22 @@ const event = parseAgentEvent(result.snapshot, { type: chosenType, ...formPayloa
 result = await runAgent(machine, { snapshot: result.snapshot, event, executors });
 ```
 
-Legality comes from the machine, not a system prompt: `getAcceptedEvents` reports only events the snapshot can take, so a UI built from these choices cannot drive an illegal transition.
+The machine determines legality, not a system prompt. `getAcceptedEvents` reports only events the snapshot can take, so a UI built from these descriptors cannot drive an illegal transition.
 
 ## Persist and resume across processes
 
-Persist the snapshot anywhere: a database row, a queue message, `localStorage`, a file. `runAgent` stops its actor on every settle path (`done`, `idle`, `error`), so resume is **always by snapshot**, never by holding a live actor. A crash, a redeploy, or a days-long wait all resume identically. (To persist after every model call, not only at settle, see [Steps](steps.md).)
+Persist the snapshot anywhere: a database row, a queue message, `localStorage`, or a file. `runAgent` stops its actor on every settle path (`done`, `idle`, `error`), so resume is always by snapshot, never by holding a live actor. A crash, a redeploy, and a days-long wait all resume the same way. To persist after every model call instead of only at settle, see [Steps](steps.md).
 
-The recurring shape: **run to idle → serialize the snapshot to a handle → store it → later, load and resume with an event**. The handle is just the JSON-serialized snapshot; nothing else travels with it, because the snapshot is the whole process state.
+The sequence is: run to idle, serialize the snapshot to a handle, store the handle, then load it later and resume with an event. The handle is the JSON-serialized snapshot. Nothing else travels with it, because the snapshot holds the whole process state.
 
-- [file-snapshot-store](../examples/file-snapshot-store/index.ts): a `node:fs` store keyed by session id, resumed across several fresh `runAgent` calls (SQLite variant sketched inline).
-- [machine-as-tool](../examples/machine-as-tool/index.ts): the same handle passed through a host harness's tool call. `startTool` runs to idle and returns the handle; `resumeTool` revives it and delivers the event.
+<!-- viz: cross-process resume sequence: process A runAgent -> idle -> persisted snapshot -> store; process B load -> runAgent(snapshot, event) -> done -->
 
-The `AgentSnapshotStore` type (`load(id): Promise<Snapshot | undefined>`, `save(id, snapshot): Promise<void>`) is exported so stores interoperate. **Type-only**: the library ships no implementation; a store (file, SQLite, KV row) is userland.
+- [file-snapshot-store](../examples/file-snapshot-store/index.ts): a `node:fs` store keyed by session id, resumed across several fresh `runAgent` calls. A SQLite variant is sketched inline.
+- [machine-as-tool](../examples/machine-as-tool/index.ts): the same handle passed through a host harness's tool call. `startTool` runs to idle and returns the handle. `resumeTool` restores it and delivers the event.
 
-To _render_ the choices from a stored handle, rehydrate it and read them:
+The `AgentSnapshotStore` type is exported so stores interoperate. It declares `load(id): Promise<Snapshot | undefined>` and `save(id, snapshot): Promise<void>`. The type is exported without an implementation. Write your own store against a file, SQLite, or a key-value row.
+
+To render the choices from a stored handle, restore the snapshot and read them.
 
 ```ts
 import { createActor } from "xstate";
@@ -232,15 +240,15 @@ const snapshot = createActor(machine, { snapshot: JSON.parse(handle) }).getSnaps
 const choices = getAcceptedEvents(snapshot); // one descriptor per legal event
 ```
 
-**Resume cannot re-run earlier work.** A resumed snapshot starts _at_ the idle state, so earlier states never re-enter: side effects and model calls that ran before the pause run exactly once, however many times you resume. Nothing to isolate. (Contrast inline-interrupt designs, where code before the interrupt call re-executes on resume unless manually isolated in its own node.) Re-running work is always an explicit, authored transition, such as a `REJECT` targeting the drafting state again. Pinned by a test in `src/run-agent.test.ts` ("pre-idle side effects and model calls run exactly once").
+Resume cannot re-run earlier work. A resumed snapshot starts at the idle state, so earlier states are never re-entered. Side effects and model calls that ran before the pause run exactly once, however many times you resume. Re-running work is always an authored transition, such as a `REJECT` that targets the drafting state again. A test in `src/run-agent.test.ts` named "pre-idle side effects and model calls run exactly once" pins this behavior.
 
-> **Context must be JSON-serializable.** Persisted snapshots round-trip through `JSON.stringify`/`JSON.parse`, so anything in `context` that is not plain JSON silently corrupts on resume: `Date` becomes a string, `Map`/`Set` become `{}`, class instances lose their prototype. Keep non-serializable handles (sessions, db clients, sockets) in closures and store only their serializable ids in `context`; see [threading host context](hosts.md#threading-host-context-into-actors-and-requests).
+> **Context must be JSON-serializable.** Persisted snapshots round-trip through `JSON.stringify` and `JSON.parse`, so anything in `context` that is not plain JSON corrupts silently on resume. A `Date` becomes a string, a `Map` or `Set` becomes `{}`, and class instances lose their prototype. Keep non-serializable handles such as sessions, database clients, and sockets in closures, and store only their serializable ids in `context`. See [threading host context](hosts.md#threading-host-context-into-actors-and-requests).
 
 ### Illegal resume events
 
-<!-- AgentIllegalResumeEventError and onIllegalResumeEvent from src/run-agent.ts -->
+<!-- AgentIllegalResumeEventError from src/run-agent.ts -->
 
-Resuming with an event the restored state cannot take is a programmer error, so `runAgent` throws `AgentIllegalResumeEventError` (carrying `eventType` and `acceptedTypes`) before delivering it: a thrown error, not an `error`-status settle. No need to pre-check legality:
+Resuming with an event the restored state cannot take is a programmer error. `runAgent` throws `AgentIllegalResumeEventError`, carrying `eventType` and `acceptedTypes`, before delivering the event. This is a thrown error, not an `error`-status settle, so you do not need to pre-check legality.
 
 ```ts
 import { AgentIllegalResumeEventError, runAgent } from "@statelyai/agent";
@@ -254,21 +262,23 @@ try {
 }
 ```
 
-A type-legal event a **guard** rejects is not an illegal resume event: no transition, and the run settles per normal semantics. To restore the older silent-drop behavior, pass `onIllegalResumeEvent: 'ignore'`.
+A type-legal event that a guard rejects is not an illegal resume event. No transition happens, and the run settles under normal semantics. There is no option to ignore an illegal resume event. It always rejects.
 
 ### Machine-version resume
 
 <!-- agentMeta stamping, onVersionMismatch, migrateSnapshot from src/run-agent.ts -->
 
-Every settled snapshot carries a plain `agentMeta: { machineId, version }` field that survives the JSON round-trip, so a snapshot persisted for days remembers which machine shape produced it. `version` defaults to `getMachineStructuralHash(machine)`: a dependency-free hash over the machine's structure (state ids/nesting, transition event types and targets, invoke srcs, `initial`), ignoring prompts, guards, and other functions.
+Every settled snapshot carries a plain `agentMeta: { machineId, version }` field that survives the JSON round-trip, so a snapshot persisted for days records which machine shape produced it. `version` is the machine's own `version` from XState's `createMachine({ version })`, which is the single source of truth. A machine that declares no version falls back to `getMachineStructuralHash(machine)`, a dependency-free hash over the machine's structure. The hash covers state ids and nesting, transition event types and targets, invoke srcs, and `initial`. It ignores prompts, guards, and other functions.
 
-On resume, `runAgent` compares the incoming stamp against the current machine's version. If they differ (a state or transition added, removed, or retargeted since the snapshot was saved):
+On resume, `runAgent` compares the incoming stamp against the current machine's version. The versions differ when a state or transition was added, removed, or retargeted since the snapshot was saved. In that case:
 
-- `onVersionMismatch: 'throw'` (default) throws `AgentSnapshotVersionMismatchError` with `from`/`to`.
-- `'warn'` logs once and proceeds; `'ignore'` proceeds silently.
-- `migrateSnapshot(snapshot, { from, to })` (when provided) runs instead; its return value is the snapshot resumed from, so you can adapt an old snapshot to the new shape.
+- `onVersionMismatch: 'throw'`, the default, throws `AgentSnapshotVersionMismatchError` with `from` and `to`.
+- `onVersionMismatch: 'warn'` logs once and proceeds. `'ignore'` proceeds silently.
+- `migrateSnapshot(snapshot, { from, to })`, when provided, runs instead of the above. Its return value is the snapshot resumed from, so you can adapt an old snapshot to the new shape.
 
-An unstamped snapshot (no `agentMeta`) is always accepted. Pass an explicit `machineVersion` (semver or build id) to control migration boundaries yourself rather than tracking the structural hash.
+A snapshot with no `agentMeta` stamp is always accepted. Declare `createMachine({ version })`, such as a semver string or a build id, to control migration boundaries yourself instead of tracking the structural hash.
+
+A machine that declares XState's own `createMachine({ version, migrate })` owns its mismatches. `runAgent` neither throws nor rewrites the snapshot's version in that case, so `migrate` sees the true `fromVersion`. A `migrateSnapshot` option still wins when you pass one, which is the seam for host-owned migrations of a machine you do not control.
 
 ```ts
 try {
@@ -280,11 +290,11 @@ try {
 }
 ```
 
-> **Branch on `error.code`.** Both errors extend `AgentError`, which carries a `.code` string (`'illegal-resume-event'`, `'snapshot-version-mismatch'`). Where `instanceof` is unreliable (errors crossing a bundle or process boundary), check the code instead.
+> **Branch on `error.code`.** Both errors extend `AgentError`, which carries a `.code` string: `'illegal-resume-event'` and `'snapshot-version-mismatch'`. Check the code where `instanceof` is unreliable, such as when errors cross a bundle or process boundary.
 
 ### Reading interaction meta
 
-Schema-typed state `meta` gives the host a typed interaction label or view hints. Legal choices still come from `getAcceptedEvents`. Meta is keyed by state id, so pull it off an idle snapshot with `getStateMeta`:
+Schema-typed state `meta` gives the host a typed interaction label or view hints. Legal choices still come from `getAcceptedEvents`. Meta is keyed by state id, so read it off an idle snapshot with `getStateMeta`.
 
 ```ts
 import { getStateMeta } from "@statelyai/agent";
@@ -292,13 +302,13 @@ import { getStateMeta } from "@statelyai/agent";
 const interaction = getStateMeta(snapshot).interaction ?? null;
 ```
 
-`getStateMeta` merges the active state(s)' meta into one object typed from the machine's meta schema (later/deeper wins for nested or parallel machines, `{}` when none declare meta). It replaces the older `Object.values(snapshot.getMeta())[0]` cast. See `readInteraction` in [machine-as-tool](../examples/machine-as-tool/index.ts).
+`getStateMeta` merges the meta of the active states into one object, typed from the machine's meta schema. A deeper state's meta wins over an ancestor's, and between parallel siblings at the same depth the later state id alphabetically wins, so the merge is deterministic. It returns `{}` when no active state declares meta. Use it instead of the older `Object.values(snapshot.getMeta())[0]` cast. See `readInteraction` in [machine-as-tool](../examples/machine-as-tool/index.ts).
 
 ## Inline input without settling
 
 <!-- agent.userInput builtin and RunAgentOptions.userInput from src/run-agent.ts -->
 
-To gather input mid-run without settling idle (a CLI prompt between two model calls), invoke the builtin `agent.userInput` actor and supply a `userInput` handler to `runAgent`:
+To gather input mid-run without settling idle, such as a CLI prompt between two model calls, invoke the builtin `agent.userInput` actor and supply a `userInput` handler to `runAgent`.
 
 ```ts no-check
 // in the machine:
@@ -318,16 +328,16 @@ await runAgent(machine, {
 });
 ```
 
-The handler resolves to a `string` (what the human typed), so `onDone`'s `output` needs no cast. For structured input, gather the string(s) and parse in a follow-up state (see [twenty-questions](../examples/twenty-questions/index.ts)), or register a custom actor source in place of `agent.userInput`.
+The handler resolves to a `string`, which is what the human typed, so the `output` in `onDone` needs no cast. For structured input, gather the strings and parse them in a follow-up state. See [twenty-questions](../examples/twenty-questions/index.ts). You can also register a custom actor source in place of `agent.userInput`.
 
-Without a handler, `agent.userInput` becomes a **pending placeholder** instead of an error (next section).
+Without a handler, `agent.userInput` becomes a pending placeholder instead of an error. See [Parallel machines and pending user input](#parallel-machines-and-pending-user-input).
 
 ### Implementing agent.userInput
 
-Two ways to implement the builtin:
+There are two ways to implement the builtin.
 
-- **`RunAgentOptions.userInput`**, the inline path shown above.
-- **A provided actor source**, for the [step path](steps.md) or when the inline path doesn't fit:
+- `RunAgentOptions.userInput` is the inline path shown above.
+- A provided actor source works for the [step path](steps.md), or when the inline path does not fit.
 
 ```ts
 import { createAsyncLogic } from "xstate";
@@ -341,9 +351,26 @@ const boundMachine = machine.provide({
 });
 ```
 
-If a machine invokes `agent.userInput` and neither is supplied, `runAgent` fails at bind time, before any model call, naming the actor and recommending the idle-state pattern instead.
+If a machine invokes `agent.userInput` and you supply neither implementation, `runAgent` fails at bind time, before any model call. The error names the actor and recommends the idle-state pattern.
 
-Static [machine config](machines-as-data.md) uses the same actor source:
+### Scripted user input in tests
+
+`createScriptedExecutors` takes a `userInput` script: one flat queue of answers consumed in order. The returned object carries a `userInput` handler alongside the executor slots, so pass it to `runAgent`'s `userInput` option. A queue that runs dry throws.
+
+```ts no-check
+const scripted = createScriptedExecutors({
+  text: ["a draft"],
+  userInput: ["sam@example.com", "yes"],
+});
+
+const result = await runAgent(machine, {
+  input,
+  executors: scripted,
+  userInput: scripted.userInput,
+});
+```
+
+Static [machine config](machines-as-data.md) uses the same actor source.
 
 ```yaml
 invoke:
@@ -364,12 +391,15 @@ invoke:
 
 <!-- pending agent.userInput placeholder and pendingUserInputs/persistedSnapshot from src/run-agent.ts -->
 
-Whole-machine idle is not enough for parallel machines: one region may wait for a human while a sibling still has work in flight. An unhandled `agent.userInput` invoke covers this. It waits indefinitely without blocking idle detection, so the run finishes the sibling work, then settles idle with two extra fields:
+Whole-machine idle is not enough for parallel machines, because one region may wait for a human while a sibling still has work in flight. An unhandled `agent.userInput` invoke covers this case. It waits indefinitely without blocking idle detection, so the run finishes the sibling work and then settles idle with two extra fields.
 
-- **`pendingUserInputs`**: one `{ id, input }` entry per pending `agent.userInput` invoke, carrying the invoke's resolved input (prompt, metadata) for the host to render.
-- **`persistedSnapshot`**: the JSON-serializable snapshot that includes those in-flight invokes. Persist this one, not `snapshot` (see the callout above).
+- `pendingUserInputs` holds one `{ id, input }` entry per pending `agent.userInput` invoke. The `input` is the invoke's resolved input, such as the prompt and metadata, for the host to render.
+- `persistedSnapshot` is the JSON-serializable snapshot that includes those in-flight invokes. This is the case the `persistedSnapshot ?? snapshot` rule in [Idle settle and resume](#idle-settle-and-resume) exists for.
 
-Resume with it plus a `userInput` handler; the restored invoke re-runs against the handler and the machine proceeds:
+Resume with `persistedSnapshot` and a `userInput` handler. The restored invoke re-runs against the handler and the machine proceeds.
+
+<!-- viz: parallel machine idle: region A pending agent.userInput placeholder alongside region B still running an effect; run settles idle only after B finishes, carrying pendingUserInputs + persistedSnapshot -->
+
 
 ```ts
 const first = await runAgent(machine, { input, executors });
@@ -385,12 +415,14 @@ if (first.status === "idle" && first.pendingUserInputs) {
 }
 ```
 
-Resuming without a handler settles idle again with the same pending inputs, so a host can safely re-enter the loop.
+Resuming without a handler settles idle again with the same pending inputs, so a host can re-enter the loop safely.
 
 ## Waiting styles
 
-- **Idle state** (`on:` handler, no invoke, flagged by your own `isSuspended` signal): the wait is an **event choice**; resume delivers the chosen event. Best for approve/reject flows where `getAcceptedEvents` drives a UI.
-- **`agent.userInput`**: the wait is a **value request** with a prompt and schema; resume supplies the value. Best for free-form input, and the only style that lets sibling parallel regions keep working while a human is pending.
+There are two ways to model a wait.
+
+- An idle state is a state with an `on:` handler, no invoke, and your own `isIdle` signal. The wait is an event choice, and resume delivers the chosen event. Use it for approve and reject flows where `getAcceptedEvents` drives a UI.
+- `agent.userInput` is a value request with a prompt and a schema, and resume supplies the value. Use it for free-form input. It is the only style that lets sibling parallel regions keep working while a human is pending.
 
 ## Related
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,13 +5,11 @@ description: Author AI agents as typed XState state machines, where the machine 
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-`@statelyai/agent` lets you author an AI agent as a typed XState state machine. The machine is a portable blueprint of what your agent can do; it never talks to a model directly.
+`@statelyai/agent` lets you author an AI agent as a typed XState state machine. The machine describes what your agent can do. It never calls a model directly.
 
-- The **machine** declares states, legal transitions and guards, the model calls each state makes, and the events the model may choose right now.
-- The **host** supplies executors: three plain functions (`generateText`, `streamText`, `decide`) taking plain request objects and returning plain results.
-- `runAgent` sits between them, calling an executor whenever the machine needs a model.
-
-**The machine decides, the host executes.**
+- The **machine** declares states, transitions, guards, the model calls each state makes, and the events the model may choose in the current state.
+- The **host** supplies executors. These are three functions named `generateText`, `streamText`, and `decide`. Each takes a request object and returns a result object.
+- `runAgent` connects the two. It calls an executor whenever the machine needs a model. It settles as `done`, `idle`, or `error`. `generateResult` is the variant for runs that must finish: it returns the done result and throws `AgentIdleError` when the run settles idle instead.
 
 ```mermaid
 flowchart LR
@@ -23,9 +21,9 @@ flowchart LR
   R -->|event or output| M
 ```
 
-Because the machine only knows the executor contract, the same machine runs unchanged against the Vercel AI SDK, Cloudflare Workers AI, a raw provider fetch, or scripted answers in a test.
+The machine knows only the executor contract. The same machine runs unchanged against the Vercel AI SDK, Cloudflare Workers AI, a raw provider fetch, or scripted answers in a test.
 
-A [decision](decisions.md) is where this matters most: the model chooses exactly one **currently-legal** machine event, not free text and not an arbitrary tool call. An illegal choice is rejected before it takes effect, so illegal behavior is impossible by construction rather than discouraged by a prompt.
+In a [decision](decisions.md), the model chooses exactly one machine event that is legal in the current state. It does not return free text and it does not call an arbitrary tool. The machine rejects an illegal choice before it takes effect.
 
 ## Install
 
@@ -35,18 +33,18 @@ A [decision](decisions.md) is where this matters most: the model chooses exactly
 pnpm add @statelyai/agent@alpha xstate@alpha zod ai@^6 @ai-sdk/openai@^3
 ```
 
-- Node 22.18 or newer, XState v6 alpha.25 or newer. `xstate` is the only required peer.
-- `ai` and `@ai-sdk/openai` back the shipped adapter, `createAiSdkExecutors`. Core has no runtime dependency besides `xstate`.
-- The `@alpha` tag floats: install once, then pin what it resolved to.
-- ESM-first (a CommonJS build ships too). The example below uses top-level `await`, so set `"type": "module"`.
+Requires Node 22.18 or newer. `xstate` is the only required peer dependency. `ai` and `@ai-sdk/openai` back the shipped adapter, `createAiSdkExecutors`. The example below uses top-level `await`, so set `"type": "module"` in `package.json`.
 
-Version and peer detail, plus the same agent built up step by step, are in the [Quickstart](quickstart.md).
+Read more about versions, peers, and pinning the alpha in the [Quickstart](quickstart.md#installation).
 
 ## Your first agent
 
 <!-- setup + invoke + run; full walkthrough lives in quickstart.md -->
 
-One request, one state, one run. Save as `agent.ts` and run it with `npx tsx agent.ts`.
+This agent has one request, one state, and one run. Save it as `agent.ts` and run it with `npx tsx agent.ts`.
+
+<!-- viz: two-state machine: answering (invoke answerQuestion) -> done (final, outputs answer) -->
+
 
 ```ts
 import { z } from "zod";
@@ -54,6 +52,7 @@ import { runAgent, setupAgent } from "@statelyai/agent";
 import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
 import { openai } from "@ai-sdk/openai";
 
+// `gpt-5.4-mini` is an illustrative model ID. Use one your provider supports.
 const models = defineModels({ quick: openai("gpt-5.4-mini") });
 const answerSchema = z.object({ answer: z.string() });
 
@@ -94,46 +93,49 @@ const result = await runAgent(machine, {
 if (result.status === "done") console.log(result.output.answer);
 ```
 
-That is the whole shape. Everything it does not show has an owning page:
+Each part of this example has an owning page:
 
 - `setupAgent` and `createMachine`: [Agent machines](machines.md).
 - Named `requests` and their schemas: [Text requests](text-requests.md).
-- Swapping `createAiSdkExecutors` for `createScriptedExecutors` to run with **no API key**, letting the model choose an event, and guards that overrule it: the [Quickstart](quickstart.md).
-- `runAgent` versus `provideExecutors` versus the step path: [Choosing a run mode](choosing-a-run-mode.md).
+- Replacing `createAiSdkExecutors` with `createScriptedExecutors` to run without an API key, letting the model choose an event, and writing guards that override that choice: the [Quickstart](quickstart.md).
+- Choosing between `runAgent`, `provideExecutors`, and the step path: [Choosing a run mode](choosing-a-run-mode.md).
 
 ## Compared to a plain loop
 
-Most agents start as a `while` loop around a model call. That works until:
+Most agents start as a `while` loop around a model call. A loop has the following limitations:
 
-- **State goes implicit.** Which step you are on lives in local variables and `if` chains; a machine's states, transitions, and requests are data you can read, diagram, and reason about before anything runs.
-- **Legality is prompt-enforced.** Nothing stops the model from calling a tool at the wrong time; a machine and its guards define every path, so the model cannot drive the agent into a state you did not author.
-- **Pausing means rearchitecting.** Waiting for a human, surviving a deploy, or resuming on another worker means serializing ad-hoc loop state by hand; every machine settle point produces a plain JSON snapshot you persist anywhere.
-- **Testing needs the model.** Every branch is buried behind live calls, so tests mock the SDK instead of asserting on structure.
-- **The SDK is baked in.** A loop is written against one provider's API; a machine depends on no model SDK, so you swap hosts, not agents.
+- The current step lives in local variables and `if` chains. A machine's states, transitions, and requests are data you can read, diagram, and reason about before the agent runs.
+- Nothing stops the model from calling a tool at the wrong time. A machine and its guards define every path, so the model cannot move the agent into a state you did not author.
+- Pausing requires serializing loop state by hand. This applies when you wait for a human, redeploy, or resume on another worker. A machine produces a JSON snapshot at every settle point, and you can persist that snapshot anywhere.
+- Testing requires the model, because every branch sits behind a live call. Tests then mock the SDK instead of asserting on structure.
+- A loop is written against one provider's API. A machine depends on no model SDK, so you replace the host instead of the agent.
 
-A state machine makes each of these a declared, checkable property instead of a convention. The loop is still there; the library owns it. See [Migrating from a hand-rolled loop](from-a-loop.md) for the mechanical translation.
+A state machine turns each of these into a declared property you can check before the agent runs. The library owns the loop. See [Migrating from a hand-rolled loop](from-a-loop.md) for the translation.
 
-## Three starting points
+## Starting points
 
-- **Author a new agent.** Describe states, decisions, and typed requests, run locally with `runAgent`, then test and inspect it with no API key. Start at the [Quickstart](quickstart.md).
-- **Retrofit an existing agent.** Your existing SDK calls, tools, and retry code become the executors; the machine replaces only the control flow. See [Migrating from a hand-rolled loop](from-a-loop.md).
-- **Copy a known pattern.** ReAct, reflection, plan-and-execute, RAG, supervisor, swarm handoff, each a single runnable file. Browse [Agent patterns](patterns.md).
+- To author a new agent, describe states, decisions, and typed requests, run them locally with `runAgent`, then test and inspect the agent without an API key. Start at the [Quickstart](quickstart.md).
+- To retrofit an existing agent, turn your existing SDK calls, tools, and retry code into executors. The machine replaces only the control flow. See [Migrating from a hand-rolled loop](from-a-loop.md).
+- To copy a known pattern, browse [Agent patterns](patterns.md). ReAct, reflection, plan-and-execute, RAG, supervisor, and swarm handoff are each a single runnable file.
 
-## Sidebar map
+## Package entry points
 
-- **Get started**: [Quickstart](quickstart.md), [Thinking in state machines](thinking-in-state-machines.md), [Migrating from a hand-rolled loop](from-a-loop.md), [Scope](scope.md).
-- **Core concepts**: [Agent machines](machines.md), [Decisions](decisions.md), [Text requests](text-requests.md), [Tools](tools.md), [Messages](messages.md), [Preset machines](machines-presets.md).
-- **Running agents**: [Choosing a run mode](choosing-a-run-mode.md), [Hosts and executors](hosts.md), [Use in any stack](any-stack.md), [The step path](steps.md).
-- **State and durability**: [Where state lives](persistence.md), [The event log](event-log.md), [Human in the loop](human-in-the-loop.md).
-- **Production**: [Models and providers](models-and-providers.md), [Observability](observability.md), [Usage and budgets](usage-and-budgets.md), [Debugging](debugging.md), [Multi-agent](multi-agent.md).
-- **Machines as data**: [Machines as data](machines-as-data.md), [Generating machines](generate-machines.md).
-- **Testing**: [Testing and verification](verify.md), [Evals](evals.md).
-- **Resources**: [Agent patterns](patterns.md), [Coming from LangGraph](langgraph-comparison.md), [Post-alpha roadmap](roadmap.md).
+<!-- entry points from package.json#exports -->
+
+| Import path | Contents |
+| ----------- | -------- |
+| `@statelyai/agent` | `setupAgent`, `runAgent`, `generateResult`, the step helpers, and the verification APIs. |
+| `@statelyai/agent/ai-sdk` | `createAiSdkExecutors`, `defineModels`, and the Vercel AI SDK mappers. |
+| `@statelyai/agent/machines` | The [preset machines](machines-presets.md), such as `createToolLoopMachine` and `createRouterMachine`. |
+| `@statelyai/agent/otel` | `createOtelTraceHandler`, which maps trace events to OpenTelemetry spans. |
+| `@statelyai/agent/sqlite` | `createSqliteEventLogStore` and `createSqliteSnapshotStore`. |
+| `@statelyai/agent/validate` | `validateAgentConfig`, which checks a JSON machine config against the schema. Requires `ajv`. |
+| `@statelyai/agent/agent-workflow.json` | The JSON Schema for machine configs. See [Machines as data](machines-as-data.md). |
 
 ## Alpha status
 
 The API changed completely in 2.0 and is still settling. Expect breaking changes before 2.0 stable.
 
-What is deliberately not shipped yet (storage adapters beyond SQLite, transport helpers, a fan-out helper, and more) is listed on the [Post-alpha roadmap](roadmap.md).
+Some features are deliberately not shipped yet, including storage adapters beyond SQLite, transport helpers, and a fan-out helper. See the [Post-alpha roadmap](roadmap.md) for the full list.
 
-If something here blocks you, or the API surface feels wrong, open an issue. This alpha exists to find that out before 2.0 stable.
+If something here blocks you, or the API surface seems wrong, open an issue.

--- a/docs/langgraph-comparison.md
+++ b/docs/langgraph-comparison.md
@@ -5,47 +5,50 @@ description: A term-by-term translation of LangGraph concepts, the same agent bu
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-[LangGraph](https://docs.langchain.com/oss/javascript/langgraph) and `@statelyai/agent` solve overlapping problems: both give an LLM workflow explicit structure, both pause for humans, both persist and resume. They disagree about where control flow lives.
+This page maps [LangGraph](https://docs.langchain.com/oss/javascript/langgraph) concepts to `@statelyai/agent`. It gives a term-by-term translation, builds one small agent in both libraries, compares them dimension by dimension, and lists the LangGraph tutorials that ship here as runnable examples.
 
-This page starts with a term-by-term translation, builds one small agent in both, compares them dimension by dimension, then lists the LangGraph tutorials ported as runnable examples.
+Both libraries give an LLM workflow explicit structure, pause for humans, and persist and resume. The main difference is where control flow lives.
 
-**You don't have to choose.** [examples/langchain-host](../examples/langchain-host/index.ts) keeps LangChain for model calls, callbacks, tracing through LangSmith (LangChain's hosted observability product), and the agent loop while the machine owns control flow: wrap any `BaseChatModel` as executors, or hand a `createAgent` loop the machine as tools.
+You can also use both. [examples/langchain-host](../examples/langchain-host/index.ts) keeps LangChain for model calls, callbacks, tracing through LangSmith, and the agent loop, while the machine owns control flow. Wrap any `BaseChatModel` as executors, or give a `createAgent` loop the machine as tools. LangSmith is LangChain's hosted observability product.
 
-Code blocks are illustrative and not typechecked in this repo. LangGraph snippets target `@langchain/langgraph` 1.x.
+Code blocks on this page are illustrative and are not typechecked in this repo. LangGraph snippets target `@langchain/langgraph` 1.x.
 
 ## Term mapping
 
 | LangGraph                              | Here                                               | How it maps                                                                                                                                                                                                                                                                                   |
 | -------------------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `StateGraph(State)`                    | `setupAgent({ ... }).createMachine({ ... })`       | `setupAgent` declares the schemas (context, input, output, events) once; `createMachine` builds the typed graph. See [Agent machines](machines.md).                                                                                                                                           |
+| `StateGraph(State)`                    | `setupAgent({ ... }).createMachine({ ... })`       | `setupAgent` declares the context, input, output, and event schemas once. `createMachine` builds the typed graph. See [Agent machines](machines.md).                                                                                                                                           |
 | Graph state / reducers                 | `context` + transition functions                   | Context is the typed state object. A transition returns the next `context`, so a reducer becomes an ordinary function of `{ context, event }`.                                                                                                                                                |
-| Node (`add_node`)                      | A state with an `invoke`                           | A node's work is the state's invoked actor: a text request, a decision, or a plain actor. Entering the state starts the work; `onDone` writes the result into context.                                                                                                                        |
+| Node (`add_node`)                      | A state with an `invoke`                           | A node's work is the state's invoked actor: a text request, a decision, or a plain actor. Entering the state starts the work. `onDone` writes the result into context.                                                                                                                        |
 | Edge (`add_edge`)                      | `onDone.target` or an `always` transition          | A fixed edge is the target of the state's completion.                                                                                                                                                                                                                                         |
-| `add_conditional_edges`                | Guarded transitions, or `type: 'choice'`           | A branch is a transition function returning a different target (or `undefined` to block). Deterministic branches use the `choice` pseudo-state; model-chosen branches use `agent.decide`.                                                                                                     |
+| `add_conditional_edges`                | Guarded transitions, or `type: 'choice'`           | A branch is a transition function returning a different target, or `undefined` to block the branch. Deterministic branches use the `choice` pseudo-state. Model-chosen branches use `agent.decide`.                                                                                                     |
 | Router node returning a literal        | `agent.decide` with `allowedEvents`                | The model chooses one machine event from the currently legal set; the event's transition is the branch. See [Decisions](decisions.md).                                                                                                                                                        |
 | `interrupt()`                          | An idle state with an `on:` handler                | A pause is a state that invokes nothing and waits for an event. `runAgent` settles `idle`, hands back a snapshot, and the run resumes when you send the event. See [Human in the loop](human-in-the-loop.md).                                                                                 |
 | `Command(resume=...)`                  | The resume event you send                          | Resuming is sending a typed event (`APPROVE`, `EDIT`, `REJECT`) into the restored snapshot. The payload is schema-validated.                                                                                                                                                                  |
 | `interrupt_before` on a tool           | An idle state before the tool state                | Model the approval point as its own state; the tool state is only reachable through it. See [`review-tool-calls`](../examples/review-tool-calls/index.ts).                                                                                                                                    |
-| Checkpointer (`MemorySaver`, Postgres) | `persistSnapshot` or the event log                 | Two options: persist the JSON snapshot yourself, or append the event log and replay it. Neither requires a configured backend to run. See [The event log](event-log.md).                                                                                                                      |
+| Checkpointer (`MemorySaver`, Postgres) | A persisted snapshot or the event log              | Two options: persist the JSON snapshot yourself, or append the event log and replay it. Neither requires a configured backend to run. See [The event log](event-log.md).                                                                                                                      |
 | `thread_id`                            | Your own key + a log or snapshot per key           | There is no built-in thread registry. Use whatever key your app already has (session id, row id) and store the snapshot or log entries under it.                                                                                                                                              |
-| Time travel / `get_state_history`      | Snapshot list, or `replay` plus the store's `fork` | Rewind by replaying a prefix of the log (or restoring an earlier snapshot); `fork` is a method on the event-log store, not a root export, and copies a prefix into a new thread you then append to. See [`time-travel`](../examples/time-travel/index.ts).                                    |
-| `Send(...)` for map-reduce             | Spawned child actors                               | A planner produces N items and the machine spawns one child branch per item; a reducer state composes the results. See [`fan-out`](../examples/fan-out/index.ts).                                                                                                                             |
+| Time travel / `get_state_history`      | Snapshot list, or `replay` plus the store's `fork` | Rewind by replaying a prefix of the log, or by restoring an earlier snapshot. `fork` is a method on the event-log store rather than a root export. It copies a prefix into a new thread that you then append to. See [`time-travel`](../examples/time-travel/index.ts).                                    |
+| `Send(...)` for map-reduce             | Spawned child actors                               | A planner produces N items and the machine spawns one child branch per item. A reducer state composes the results. See [`fan-out`](../examples/fan-out/index.ts).                                                                                                                             |
 | Subgraphs                              | Child machines invoked as actors                   | A machine is an actor, so a subgraph is an `invoke` of another agent machine with its own typed input/output. See [Multi-agent](multi-agent.md) and [`subflows`](../examples/subflows/index.ts).                                                                                              |
-| `create_agent` / `create_react_agent`  | One request with `tools`, or an explicit loop      | Default: one state, `tools` on the request, your SDK runs the loop (`metadata.maxSteps` bounds it); see [`tool-calling`](../examples/tool-calling/index.ts). When turns need gating or mid-loop persistence, unroll to visible states; see [`react-agent`](../examples/react-agent/index.ts). |
-| Tool binding (`bind_tools`)            | Request-level `tools`, or tool states              | Tools the model calls inside one request are declared on the request; tools that should be their own graph step are states. See [Text requests](text-requests.md#tools-and-multi-step-loops).                                                                                                 |
-| `stream_mode`                          | `onChunk`, `onTransition`, `onTrace`               | Text chunks stream through the request's `onChunk`; state changes through `onTransition`; a structured trace through `onTrace`. See [Observability](observability.md).                                                                                                                        |
-| Provider model object                  | `models` registry + host executors                 | The machine names a model ref; the [host](hosts.md) resolves it. The same machine runs against any provider by swapping executors.                                                                                                                                                            |
+| `create_agent` / `create_react_agent`  | One request with `tools`, or an explicit loop      | By default, use one state with `tools` on the request and let your SDK run the loop, bounded by the request's `maxSteps`. See [`tool-calling`](../examples/tool-calling/index.ts). When turns need gating or mid-loop persistence, unroll the loop into visible states. See [`react-agent`](../examples/react-agent/index.ts). |
+| Tool binding (`bind_tools`)            | Request-level `tools`, or tool states              | Tools the model calls inside one request are declared on the request. Tools that should be their own graph step are states. See [Text requests](text-requests.md#tools-and-multi-step-loops).                                                                                                 |
+| `stream_mode`                          | `onChunk`, `onTransition`, `onTrace`               | Text chunks stream through the request's `onChunk`. State changes stream through `onTransition`. A structured trace streams through `onTrace`. See [Observability](observability.md).                                                                                                                        |
+| Provider model object                  | `models` registry + host executors                 | The machine names a model ref, and the [host](hosts.md) resolves it. The same machine runs against any provider when you swap executors.                                                                                                                                                            |
 
 ## The agent
 
-An email assistant with a human gate:
+The comparison below uses an email assistant with a human gate.
 
 1. Draft an email from a request.
 2. Stop and show the draft to a human.
-3. Approve sends it; revise loops back to drafting with feedback.
-4. At most 3 revisions, then it must be approved or dropped.
+3. Approving sends the email. Revising loops back to drafting with feedback.
+4. Allow at most 3 revisions. After that, the draft must be approved or dropped.
 
-Same four moving parts in both: a model call, a pause, a loop, and a bound on the loop.
+Both implementations have the same four moving parts: a model call, a pause, a loop, and a bound on the loop.
+
+<!-- viz: email assistant machine: drafting -> reviewing on draft complete; reviewing -> sent on APPROVE; reviewing -> drafting on REVISE, guarded by revisions < 3; reviewing marked as the idle state -->
+
 
 ## In LangGraph
 
@@ -67,6 +70,9 @@ import { ChatOpenAI } from "@langchain/openai";
 // Model IDs here are illustrative; substitute your provider's current models.
 const model = new ChatOpenAI({ model: "gpt-4.1-mini" });
 
+// Your own email client.
+declare const mailer: { send(body: string): Promise<void> };
+
 const State = new StateSchema({
   request: z.string(),
   draft: z.string().default(""),
@@ -84,17 +90,20 @@ const draft: GraphNode<typeof State> = async (state) => {
         : state.request,
     },
   ]);
-  return { draft: res.text, revisions: state.revisions + 1 };
+  return { draft: res.text };
 };
 
-// The pause. Requires a checkpointer at compile time, and the whole node
-// re-runs from the top when the graph resumes.
+// The pause. Requires a checkpointer at compile time. The whole node re-runs
+// from the top when the graph resumes.
 const review: GraphNode<typeof State> = (state) => {
   const decision = interrupt({ draft: state.draft, action: "approve or revise" }) as
     | { type: "approve" }
     | { type: "revise"; feedback: string };
 
-  return { feedback: decision.type === "revise" ? decision.feedback : "" };
+  // Revisions are counted when the human asks for one.
+  return decision.type === "revise"
+    ? { feedback: decision.feedback, revisions: state.revisions + 1 }
+    : { feedback: "" };
 };
 
 const send: GraphNode<typeof State> = async (state) => {
@@ -104,7 +113,7 @@ const send: GraphNode<typeof State> = async (state) => {
 
 // The revision bound is an `if` inside a router function.
 const route: ConditionalEdgeRouter<typeof State, "draft" | "send"> = (state) =>
-  state.feedback && state.revisions < 3 ? "draft" : "send";
+  state.feedback && state.revisions <= 3 ? "draft" : "send";
 
 const graph = new StateGraph(State)
   .addNode("draft", draft)
@@ -117,7 +126,7 @@ const graph = new StateGraph(State)
   .compile({ checkpointer: new MemorySaver() });
 ```
 
-Running it, with `thread_id` as the durable pointer back to the saved checkpoint:
+To run it, use `thread_id` as the durable pointer back to the saved checkpoint.
 
 ```ts
 const config = { configurable: { thread_id: "email-42" } };
@@ -137,7 +146,7 @@ const done = await graph.invoke(new Command({ resume: { type: "approve" } }), co
 ```ts
 import { z } from "zod";
 import { openai } from "@ai-sdk/openai";
-import { getAcceptedEvents, persistSnapshot, runAgent, setupAgent } from "@statelyai/agent";
+import { getAcceptedEvents, runAgent, setupAgent } from "@statelyai/agent";
 import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
 
 const models = defineModels({ writer: openai("gpt-4.1-mini") });
@@ -191,8 +200,7 @@ const machine = agentSetup.createMachine({
     reviewing: {
       on: {
         APPROVE: { target: "sent" },
-        // The revision bound is a guard. Past 3 revisions, REVISE stops being
-        // an accepted event at all: no router can route around it.
+        // Past 3 revisions, REVISE is no longer an accepted event.
         REVISE: ({ context, event }) =>
           context.revisions < 3
             ? {
@@ -202,14 +210,28 @@ const machine = agentSetup.createMachine({
             : undefined,
       },
     },
-    sent: { type: "final" },
+    sent: {
+      type: "final",
+      // The email is sent on entry, which matches the LangGraph `send` node.
+      entry: ({ context }, enq) => {
+        enq(mailer.send, context.draft ?? "");
+      },
+    },
   },
 });
 ```
 
-Running it, with your own key and no configured backend:
+Both versions count a revision at the point the human asks for one, and both allow at most 3. The LangGraph bound lives in the router function, and the machine's bound is the `REVISE` transition returning `undefined`, which also removes `REVISE` from the events the machine accepts.
+
+To run it, supply your own key. No persistence backend is required.
 
 ```ts
+// Whatever key-value storage you already have.
+declare const store: {
+  save(key: string, value: string): Promise<void>;
+  load(key: string): Promise<string>;
+};
+
 const executors = createAiSdkExecutors({ models });
 
 const first = await runAgent(machine, {
@@ -218,8 +240,8 @@ const first = await runAgent(machine, {
 });
 
 if (first.status === "idle") {
-  getAcceptedEvents(first.snapshot); // ['APPROVE', 'REVISE'], the exact choices to render
-  await store.save("email-42", JSON.stringify(persistSnapshot(first.snapshot)));
+  getAcceptedEvents(first.snapshot); // ['APPROVE', 'REVISE']
+  await store.save("email-42", JSON.stringify(first.persistedSnapshot ?? first.snapshot));
 }
 
 // ...a later request, possibly another process...
@@ -232,7 +254,7 @@ const done = await runAgent(machine, {
 
 ## Conditional edges and guards
 
-The second pair, since routing is where the designs diverge hardest. In LangGraph a node produces a literal and a router function turns it into a node name; the rewrite bound is an `if` inside that router:
+Routing is where the two designs differ most, so here is a second pair of examples. In LangGraph, a node produces a literal and a router function turns it into a node name. The rewrite bound is an `if` inside that router.
 
 ```ts no-check
 import {
@@ -243,6 +265,7 @@ import {
   type ConditionalEdgeRouter,
   type GraphNode,
 } from "@langchain/langgraph";
+import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
 
 const State = new StateSchema({
@@ -251,6 +274,11 @@ const State = new StateSchema({
   grade: z.string().default(""),
   rewrites: z.number().default(0),
 });
+
+// Your chat model and the two nodes the router picks between.
+declare const model: ChatOpenAI;
+declare const generate: GraphNode<typeof State>;
+declare const rewrite: GraphNode<typeof State>;
 
 const grade: GraphNode<typeof State> = async (state) => {
   const res = await model.invoke([
@@ -277,7 +305,7 @@ const graph = new StateGraph(State)
   .compile();
 ```
 
-Here the router is a decision the model makes over named events. The branch is the event's transition, and a guard returning `undefined` makes that branch unavailable:
+In `@statelyai/agent`, the router is a decision the model makes over named events. The branch is the event's transition, and a guard returning `undefined` makes that branch unavailable.
 
 ```ts no-check
 grading: {
@@ -292,7 +320,7 @@ grading: {
   },
   on: {
     GENERATE: { target: "generating" },
-    // Bound the correction loop: past 2 rewrites, REWRITE is illegal.
+    // Past 2 rewrites, REWRITE is no longer an accepted event.
     REWRITE: ({ context }) =>
       context.rewrites < 2
         ? { target: "rewriting", context: { rewrites: context.rewrites + 1 } }
@@ -301,60 +329,67 @@ grading: {
 }
 ```
 
-There is no routing string to typo and no bound stated as prose. The model picks a named event; if the guard rejects it, the attempt is recorded as `rejected-by-guard` and the model is asked again with that feedback.
+The model picks a named event, so there is no routing string to mistype. If the guard rejects the event, the attempt is recorded as `rejected-by-guard` and the model is asked again with that feedback.
+
+<!-- viz: decision-with-guard loop: agent.decide proposes an event -> machine checks accepted events and guards -> accepted event transitions to the target state, rejected event is recorded as rejected-by-guard and fed back to the model -->
+
 
 ## Dimension by dimension
+
+The table below compares the two libraries on the dimensions that most often decide which one to use.
 
 | Dimension             | LangGraph                                                                                                                                                                                                                             | `@statelyai/agent`                                                                                                                                                                                                          |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Graph definition      | `new StateGraph(State)` with `addNode` / `addEdge` / `addConditionalEdges`, compiled to a Pregel runtime.                                                                                                                             | `setupAgent(...).createMachine(...)`: a statechart with nested and parallel states, entry/exit actions, and invoked actors.                                                                                                 |
-| Control-flow legality | A conditional router is a function returning a node name; `Command({ goto })` can also jump from inside a node. Bounds like "max 3 revisions" are `if`s the runtime does not enforce.                                                 | Transitions are declared per state. A guard returning `undefined` makes the transition illegal, and `snapshot.can(event)` is checked before anything is applied. Illegal paths are not authorable.                          |
+| Control-flow legality | A conditional router is a function returning a node name. `Command({ goto })` can also jump from inside a node. Bounds such as "max 3 revisions" are `if` statements that the runtime does not enforce.                                                 | Transitions are declared per state. A guard returning `undefined` makes the transition illegal, and `snapshot.can(event)` is checked before anything is applied. Illegal paths cannot be authored.                          |
 | Model-chosen branches | A node returns a literal that the router matches on. Parsing and validating the model's answer is your code.                                                                                                                          | `agent.decide` offers the model only the events the current state accepts, intersected with `allowedEvents`. An illegal or guard-rejected pick is recorded as a typed attempt and re-asked. See [Decisions](decisions.md).  |
-| State                 | Channels declared with `StateSchema`, merged by reducers (`ReducedValue`, `MessagesValue`). Nodes return partial updates.                                                                                                             | A single typed `context` object, updated by transition functions returning partial context. A reducer becomes an ordinary function of `{ context, event }`.                                                                 |
-| Human in the loop     | `interrupt(payload)` inside a node, resumed with `Command({ resume })`. Requires a checkpointer and a `thread_id`; the interrupting node re-executes from the top on resume.                                                          | A state with no invoke. `runAgent` settles `idle` and hands back a JSON snapshot. No runtime primitive, no checkpointer requirement, and nothing re-executes. See [Human in the loop](human-in-the-loop.md).                |
-| Rendering the choices | The `interrupt` payload is whatever you passed; the UI's option list is prose you keep in sync by hand.                                                                                                                               | `getAcceptedEvents(snapshot)` returns the events the machine will actually honor right now, with their payload schemas.                                                                                                     |
-| Persistence           | A configured checkpointer (`MemorySaver`, Postgres, Redis, SQLite) plus a thread registry, wired at `compile()`.                                                                                                                      | Two independent choices: persist the JSON snapshot yourself, or append the [event log](event-log.md). SQLite stores ship; neither is required to pause.                                                                     |
-| Replay / determinism  | `getStateHistory` plus replay and fork from a checkpoint. Replay re-executes nodes after the chosen checkpoint, including model calls.                                                                                                | The log of external inputs is the source of truth. `replay` folds it back through pure transitions with no model calls, and each entry carries `stateHash` / `effectsHash` so a divergent replay is detectable, not silent. |
-| Typing                | Good: state types derive from `StateSchema`, and `GraphNode` / `ConditionalEdgeRouter` are typed. The `interrupt()` return value is untyped and needs a cast.                                                                         | Context, input, output, event payloads, and each request's input/output are Standard Schemas. Event names in `allowedEvents` and transition targets are checked at compile time; resume events are schema-validated.        |
-| Visualization         | `graph.getGraphAsync()` renders Mermaid or PNG. LangGraph Studio gives a live debugger.                                                                                                                                               | The machine is plain data: `getJsonSchema`, structural hashing, and any XState tool, including the Stately editor and inspector. See [Machines as data](machines-as-data.md).                                               |
-| Model coupling        | Nodes call LangChain model objects directly; the graph and the provider are one artifact.                                                                                                                                             | The machine names a model ref and never calls a provider. [Executors](hosts.md) resolve it, so the same machine runs against the AI SDK, Workers AI, or raw `fetch`.                                                        |
-| Offline verification  | Testing a branch generally means running the graph, with the model stubbed by hand.                                                                                                                                                   | `lintAgentMachine`, `canReach`, `explorePaths`, and `simulateAgent` check reachability, dead states, and scripted playthroughs with no API key and no network. See [Testing and verification](verify.md).                   |
-| Ecosystem maturity    | **Clearly ahead.** Years of production use, LangSmith tracing and evals, LangGraph Platform deployment, prebuilt agents and middleware, hundreds of LangChain integrations, a large body of tutorials, and a Python twin with parity. | Alpha. One core dependency (XState v6 alpha), a small shipped executor set, SQLite stores, and a runnable examples directory. No hosted platform, no eval product.                                                          |
+| State                 | Channels declared with `StateSchema`, merged by reducers such as `ReducedValue` and `MessagesValue`. Nodes return partial updates.                                                                                                             | A single typed `context` object, updated by transition functions that return partial context. A reducer becomes an ordinary function of `{ context, event }`.                                                                 |
+| Human in the loop     | `interrupt(payload)` inside a node, resumed with `Command({ resume })`. Requires a checkpointer and a `thread_id`. The interrupting node re-executes from the top on resume.                                                          | A state with no invoke. `runAgent` settles `idle` and returns a JSON snapshot. There is no runtime primitive, no checkpointer requirement, and nothing re-executes. See [Human in the loop](human-in-the-loop.md).                |
+| Rendering the choices | The `interrupt` payload is whatever you passed. You keep the UI's option list in sync by hand.                                                                                                                               | `getAcceptedEvents(snapshot)` returns the events the machine honors right now, with their payload schemas.                                                                                                     |
+| Persistence           | A configured checkpointer such as `MemorySaver`, Postgres, Redis, or SQLite, plus a thread registry, wired at `compile()`.                                                                                                                      | Two independent choices: persist the JSON snapshot yourself, or append the [event log](event-log.md). SQLite stores ship with the package. Neither is required in order to pause.                                                                     |
+| Replay / determinism  | `getStateHistory` plus replay and fork from a checkpoint. Replay re-executes nodes after the chosen checkpoint, including model calls.                                                                                                | The log of external inputs is the source of truth. `replay` folds it back through pure transitions with no model calls. Each entry carries `stateHash` and `effectsHash`, so a divergent replay is detectable. |
+| Typing                | State types derive from `StateSchema`, and `GraphNode` and `ConditionalEdgeRouter` are typed. The `interrupt()` return value is untyped and needs a cast.                                                                         | Context, input, output, event payloads, and each request's input and output are Standard Schemas. Event names in `allowedEvents` and transition targets are checked at compile time. Resume events are schema-validated.        |
+| Visualization         | `graph.getGraphAsync()` renders Mermaid or PNG. LangGraph Studio provides a live debugger.                                                                                                                                               | The machine is plain data, so `getJsonSchema`, structural hashing, and any XState tool work on it, including the Stately editor and inspector. See [Machines as data](machines-as-data.md).                                               |
+| Model coupling        | Nodes call LangChain model objects directly, so the graph and the provider are one artifact.                                                                                                                                             | The machine names a model ref and never calls a provider. [Executors](hosts.md) resolve the ref, so the same machine runs against the AI SDK, Workers AI, or raw `fetch`.                                                        |
+| Offline verification  | Testing a branch generally means running the graph with the model stubbed by hand.                                                                                                                                                   | `lintAgentMachine`, `canReach`, `explorePaths`, and `simulateAgent` check reachability, dead states, and scripted playthroughs with no API key and no network. See [Testing and verification](verify.md).                   |
+| Ecosystem maturity    | Ahead of `@statelyai/agent`. Years of production use, LangSmith tracing and evals, LangGraph Platform deployment, prebuilt agents and middleware, hundreds of LangChain integrations, a large body of tutorials, and a Python twin with parity. | Alpha. One core dependency, XState v6 alpha, plus a small shipped executor set, SQLite stores, and a runnable examples directory. There is no hosted platform and no eval product.                                                          |
 
-## LangGraph strengths
+## Which to choose
 
-Pick LangGraph when these matter more than machine-enforced control flow:
+The table above covers the mechanics. These are the cases each library suits.
 
-- **You want the platform, not just the library.** LangSmith (LangChain's hosted tracing, dataset, and eval product) plus LangGraph Platform for deployment and thread management are real products you would otherwise build.
-- **You are already in LangChain.** Hundreds of integrations, retrievers, and tool wrappers work out of the box, and `createAgent` gets a competent tool-calling agent running in minutes.
-- **Python and JS need parity.** LangGraph ships both with matching concepts. This library is TypeScript only.
-- **Your team already knows it.** Node/edge/checkpoint is a shared vocabulary with a lot of published prior art.
-- **The workflow is mostly linear or mostly free-form.** If control flow is a short pipeline, or if you genuinely want the model to drive with few constraints, a statechart is overhead without much payoff.
-- **You need production maturity today.** `@statelyai/agent` 2.0 is alpha and its APIs can still change.
+Choose LangGraph when:
 
-## Agent machine strengths
+- You want a platform rather than only a library, with LangSmith and LangGraph Platform handling tracing, evals, deployment, and thread management.
+- You already use LangChain and want its integrations, retrievers, and tool wrappers.
+- You need Python and JavaScript parity. `@statelyai/agent` is TypeScript only.
+- Your team already works in node, edge, and checkpoint vocabulary.
+- The workflow is a short pipeline or mostly model-driven, so explicit states add overhead.
+- You need production maturity today. `@statelyai/agent` 2.0 is alpha and its APIs can still change.
 
-- **Constraints must hold regardless of the prompt.** Spend limits, approval gates, retry budgets, ordering rules.
-- **Pausing should not require infrastructure.** Idle plus a JSON snapshot works in a Lambda, a queue worker, or a test.
-- **You need to prove behavior before shipping.** Reachability, dead-state, and scripted playthrough checks run in CI without a model.
-- **Replay has to be trustworthy.** Folding an event log through pure transitions reproduces a run exactly, with hashes that catch divergence.
-- **The workflow is genuinely stateful.** Nested and parallel regions, states that mean something to the business, and a diagram non-engineers can read.
-- **You want provider independence.** The machine has no SDK dependency, so swapping hosts does not touch the agent.
+Choose `@statelyai/agent` when:
+
+- Constraints such as spend limits, approval gates, retry budgets, and ordering rules must hold regardless of the prompt.
+- Pausing has to work without infrastructure, such as in a Lambda function, a queue worker, or a test.
+- Behavior has to be verified in CI without a model.
+- Replay has to reproduce a run exactly and detect divergence.
+- The workflow is stateful, with nested or parallel regions and states that map to business concepts.
+- The agent has to stay independent of any provider SDK.
 
 ## Ported examples
 
-Several LangGraph tutorials and how-tos exist here as runnable examples, so you can read the same problem in both shapes. Full list in [examples/README.md](../examples/README.md).
+Several LangGraph tutorials and how-tos ship here as runnable examples, so you can read the same problem in both shapes. The full list is in [examples/README.md](../examples/README.md).
 
 - [`corrective-rag`](../examples/corrective-rag/index.ts): the CRAG tutorial as explicit states (retrieve, grade, rewrite query, web-search fallback, grounded generate).
 - [`adaptive-rag`](../examples/adaptive-rag/index.ts): route local vs web, grade retrieval and generation, bounded rewrite.
 - [`reflection-writer`](../examples/reflection-writer/index.ts): the reflection essay-writer, generate and critique with a typed revision bound.
 - [`code-assistant`](../examples/code-assistant/index.ts): self-correcting code generation with a sandboxed check step and a bounded attempt budget.
-- [`customer-support`](../examples/customer-support/index.ts): the flagship customer-support tutorial, with `interrupt_before` as a real gate state.
-- [`review-tool-calls`](../examples/review-tool-calls/index.ts): `interrupt` + `Command(resume=...)` as approve / edit / reject events over a proposed tool call.
+- [`customer-support`](../examples/customer-support/index.ts): the customer-support tutorial, with `interrupt_before` modeled as a gate state.
+- [`review-tool-calls`](../examples/review-tool-calls/index.ts): `interrupt` and `Command(resume=...)` as approve, edit, and reject events over a proposed tool call.
 - [`time-travel`](../examples/time-travel/index.ts): the time-travel how-to as checkpoint history, rewind, and a forked branch.
-- [`tool-calling`](../examples/tool-calling/index.ts): `create_agent`'s job in one state; the SDK runs the tool loop inside a single request.
-- [`react-agent`](../examples/react-agent/index.ts): the same loop unrolled into a visible, budgeted machine when turns need gating.
-- [`fan-out`](../examples/fan-out/index.ts): `Send`-style dynamic map-reduce via spawned child branches.
+- [`tool-calling`](../examples/tool-calling/index.ts): the job of `create_agent` in one state, where the SDK runs the tool loop inside a single request.
+- [`react-agent`](../examples/react-agent/index.ts): the same loop unrolled into a visible, budgeted machine, for when turns need gating.
+- [`fan-out`](../examples/fan-out/index.ts): `Send`-style dynamic map-reduce using spawned child branches.
 - [`supervisor`](../examples/supervisor/index.ts) and [`hierarchical-teams`](../examples/hierarchical-teams/index.ts): supervisor handoff and two-level teams.
 - [`deep-research`](../examples/deep-research/index.ts): plan queries, research in parallel, reflect, synthesize.
 - [`lats`](../examples/lats/index.ts): Language Agent Tree Search with a rollout budget.

--- a/docs/machines-as-data.md
+++ b/docs/machines-as-data.md
@@ -7,7 +7,9 @@ description: Author an agent machine as a JSON or YAML config and lower it into 
 
 <!-- setupAgent.fromConfig lowering from src/workflow-config.ts -->
 
-An agent machine can be pure data. Describe it as a JSON or YAML config and hand it to `setupAgent.fromConfig(...)` (same import as `setupAgent`). It produces the same runnable XState machine `setupAgent(...)` builds by hand: states, choice routing, guard-expression transitions, emitted progress events, text requests, decisions, and idle steps. Only the authoring format changes.
+This page covers authoring an agent machine as a JSON or YAML config instead of TypeScript.
+
+Describe the machine as a config and pass it to `setupAgent.fromConfig(...)`, imported from the same module as `setupAgent`. It produces the same runnable XState machine that `setupAgent(...)` builds by hand. Configs support states, choice routing, guard-expression transitions, emitted progress events, text requests, decisions, and idle steps. Only the authoring format changes.
 
 ```ts
 import { setupAgent } from "@statelyai/agent";
@@ -17,14 +19,14 @@ const { machine, schemas } = setupAgent.fromConfig(config, {
 });
 ```
 
-> **Bring your own `compileSchema`.** The library bundles no JSON Schema engine, so `fromConfig(...)` will not run without a `compileSchema` you supply (Ajv, `@cfworker/json-schema`, or anything returning Standard Schema). See [Schema compilation](#schema-compilation).
+> **Bring your own `compileSchema`.** The library bundles no JSON Schema engine. `fromConfig(...)` does not run without a `compileSchema` that you supply. Use Ajv, `@cfworker/json-schema`, or anything that returns a Standard Schema. See [Schema compilation](#schema-compilation).
 
-`fromConfig(...)` returns two things:
+`fromConfig(...)` returns two values:
 
 - `machine`: the runnable XState machine, ready for `runAgent(...)`.
-- `schemas`: the compiled `AgentSchemaPack` (`context`, `events`, `emitted`, `input`, `output`, `meta` as Standard Schema validators), for host-side validation and tooling.
+- `schemas`: the compiled `AgentSchemaPack`. It exposes `context`, `events`, `emitted`, `input`, `output`, and `meta` as Standard Schema validators, for host-side validation and tooling.
 
-A config is portable: generate it from a model, store it in a database row, or edit it in a visual builder, and it runs exactly like a hand-authored [machine](machines.md).
+A config is portable. You can generate it from a model, store it in a database row, or edit it in a visual builder. It runs the same way as a hand-authored [machine](machines.md).
 
 ## Config validation
 
@@ -36,11 +38,41 @@ The package ships a JSON Schema for validating and editing configs:
 import workflowSchema from "@statelyai/agent/agent-workflow.json";
 ```
 
-Point an editor, form generator, or validation step at it to catch a malformed config before `fromConfig(...)`. It describes the whole config surface: `schemas` (including `events` and `emitted`), `context`, `requests`, `actors`, `initial`, and `states`, down to choice states, transitions, invokes, and actions.
+Point an editor or form generator at this schema. It describes the whole config surface: `schemas` including `events` and `emitted`, plus `context`, `requests`, `actors`, `initial`, and `states`, down to choice states, transitions, invokes, and actions.
+
+To validate a config in code, call `validateAgentConfig(config)` from `@statelyai/agent/validate`. It checks the value against the same shipped schema and returns `{ valid, errors }`. This subpath uses `ajv` as an optional peer dependency, so install `ajv` to use it.
+
+```ts no-check
+import { validateAgentConfig } from "@statelyai/agent/validate";
+
+const { valid, errors } = validateAgentConfig(config);
+// errors: { severity: 'error', path: '/states/idle/invoke', message, keyword }[]
+```
+
+Validation covers shape only. It does not check that a named guard, action, or actor is implemented, which `fromConfig(...)` does when it lowers the config.
+
+### Division of labor
+
+Run `validateAgentConfig` first. `fromConfig(...)` does not validate the config against the JSON Schema, so a malformed config reaches lowering unchecked.
+
+`fromConfig(...)` throws plain `Error`s, and only for lowering problems: an unknown state target, a guard or action name with no implementation, an `onDone` on an `agent.decide` invoke, a reserved `'.'` in a key, a malformed `choice` branch, and an `idleTags` entry that no state declares.
+
+### Reserved key prefix
+
+The `agent.` prefix belongs to the library. `setupAgent` throws when a `requests` or `actors` key starts with `agent.`, including the builtin names `agent.generateText`, `agent.streamText`, `agent.decide`, and `agent.userInput`. Rename the key without the prefix. To override a builtin deliberately, do it on the created machine with `machine.provide({ actors })`.
+
+## Expressions
+
+The config is data, not code. Every value is either a JSON literal or a whole-string `"{{ }}"` expression. An expression is a dot path resolved against `input`, `context`, and `event`. For example, `"{{ context.ticket }}"` reads `context.ticket`. The resolver walks the path and returns the value. There is no code evaluation and no `eval`. An expression can only read values, so a config produced by a model, a database, or a visual editor cannot do anything a hand-authored machine could not do.
+
+Two fields are exempt from template evaluation. State, invoke, and transition `meta`, and a request's `toolChoice`, are passed through verbatim. A `{{ }}` string in those fields stays a literal string.
 
 ## Example: a support ticket config
 
-This config drives the examples below: the model triages a ticket (escalate or reply), drafts a reply, then waits for a human to approve or reject. The example ships the equivalent JSON at [examples/json-agent/workflow.json](../examples/json-agent/workflow.json), run by [examples/json-agent/index.ts](../examples/json-agent/index.ts). Model IDs below are illustrative; substitute your provider's current models. As YAML for readability:
+The config below drives the examples on the rest of this page. The model triages a ticket as escalate or reply, drafts a reply, then waits for a human to approve or reject. The equivalent JSON ships at [examples/json-agent/workflow.json](../examples/json-agent/workflow.json) and is run by [examples/json-agent/index.ts](../examples/json-agent/index.ts). Model IDs are illustrative. Substitute your provider's current models. The config is shown as YAML for readability.
+
+<!-- viz: support-ticket machine: triaging (agent.decide) -> resolved on ESCALATE, -> drafting on REPLY; drafting -> awaitingApproval on draft onDone; awaitingApproval -> resolved on APPROVE or REJECT; mark awaitingApproval as the idle state -->
+
 
 ```yaml
 id: support-ticket-json
@@ -135,11 +167,13 @@ states:
 
 <!-- compileSchema requirement and SchemaCompiler from src/workflow-config.ts -->
 
-The `fromConfig` call requires a `compileSchema` option:
+The `fromConfig` call requires a `compileSchema` option.
 
-- A config carries JSON Schemas (context, events, input, output, and each request's input/output) that need a runtime validator, and the library bundles no JSON Schema engine.
-- `compileSchema` takes a JSON Schema object plus a name and returns a Standard Schema validator. `fromConfig(...)` calls it once per schema.
-- Use Ajv, `@cfworker/json-schema`, or any compiler that returns Standard Schema.
+- A config carries JSON Schemas for context, events, input, output, and each request's input and output. Those schemas need a runtime validator, and the library bundles no JSON Schema engine.
+- `compileSchema` takes a JSON Schema object and a name, and returns a Standard Schema validator. `fromConfig(...)` calls it once per schema.
+- Use Ajv, `@cfworker/json-schema`, or any compiler that returns a Standard Schema.
+
+Expose the source JSON Schema on the validator you return, as `jsonSchema: { input: () => schema }`. `lintAgentMachine` reads it to run the checks that need the declared shape, `unserializable-context` and `final-without-output`. Those checks are skipped when it is absent.
 
 With Ajv:
 
@@ -163,8 +197,6 @@ const ajvCompileSchema: SchemaCompiler = (jsonSchema, name): StandardSchemaV1 =>
                 message: `${name}${e.instancePath} ${e.message}`,
               })),
             },
-      // Expose the source JSON Schema so lint's serializability checks
-      // (`unserializable-context`, `final-without-output`) can read the shape.
       jsonSchema: { input: () => jsonSchema },
     },
   };
@@ -177,11 +209,13 @@ const { machine } = setupAgent.fromConfig(config, { compileSchema: ajvCompileSch
 
 <!-- Request shape from schemas/agent-workflow.json $defs.Request -->
 
-A `requests` entry can also declare:
+A `requests` entry can also declare these fields.
 
-- `tools`: a map of tool name to `{ description?, inputSchema?, outputSchema? }` (JSON Schemas), passed to the model alongside the request.
-- `toolChoice`: `"auto"`, `"none"`, `"required"`, or `{ type: "tool", name }`.
-- `reasoning: true`: opts into the structured-output envelope's `reasoning` field.
+| Field | Value | Effect |
+| --- | --- | --- |
+| `tools` | Map of tool name to `{ description?, inputSchema?, outputSchema? }`, where the schemas are JSON Schemas | Passes the tools to the model alongside the request. |
+| `toolChoice` | `"auto"`, `"none"`, `"required"`, or `{ type: "tool", name }` | Controls whether the model must call a tool. |
+| `reasoning` | `true` | Opts into the `reasoning` field of the structured-output envelope. |
 
 ```yaml
 requests:
@@ -208,10 +242,10 @@ requests:
 
 <!-- FromConfigOptions.guards / .actions from src/workflow-config.ts -->
 
-A config cannot carry functions, so anything beyond a truthy dot-path guard goes through a named reference plus a host implementation.
+A config cannot carry functions. Anything beyond a truthy dot-path guard uses a named reference plus a host implementation.
 
-- A string `guard` **without** `{{ }}` is a named guard reference. Implement it in `fromConfig(config, { guards })`, called with `{ context, event }`, returning a boolean.
-- An action `{ type, params }` is a named action reference. Implement it in `fromConfig(config, { actions })`, called with the template-resolved `params` as its only argument. Pull context/event data in via `{{ }}` templates on `params`.
+- A string `guard` without `{{ }}` is a **named guard** reference. Implement it in `fromConfig(config, { guards })`. The implementation is called with `{ context, event }` and returns a boolean.
+- An action `{ type, params }` is a **named action** reference. Implement it in `fromConfig(config, { actions })`. The implementation is called with the template-resolved `params` as its only argument. To pass context or event data, use `{{ }}` templates on `params`.
 
 ```yaml
 awaitingApproval:
@@ -230,11 +264,41 @@ const { machine } = setupAgent.fromConfig(config, {
 });
 ```
 
-A named reference with no implementation is a build-time error, never a silently dropped guard or action.
+A named reference with no implementation is a build-time error. The guard or action is never silently dropped.
+
+## Host-provided actors
+
+<!-- config.actors and createActorPlaceholdersFromWorkflowConfig from src/workflow-config.ts -->
+
+The top-level `actors` key declares actor sources that the config does not implement, such as a database read or a queue round trip. Each entry takes an optional `input` and `output` JSON Schema and a `description`. States invoke the source by its key.
+
+```yaml
+actors:
+  fetchOrder:
+    description: Load the order referenced by the ticket.
+    input:
+      type: object
+      properties: { ticket: { type: string } }
+    output:
+      type: object
+      properties: { orderId: { type: string } }
+```
+
+`fromConfig(...)` lowers each entry to a placeholder that throws when invoked, naming the key. Supply the implementation on the returned machine.
+
+```ts no-check
+const { machine } = setupAgent.fromConfig(config, { compileSchema: ajvCompileSchema });
+
+const bound = machine.provide({
+  actors: { fetchOrder: createAsyncLogic({ run: ({ input }) => loadOrder(input.ticket) }) },
+});
+```
+
+Use `actors` for work the host executes directly. Use `requests` for model calls, which the executors bind automatically.
 
 ## Running configs
 
-A lowered machine runs through `runAgent(...)` like any other agent machine. Pass the machine input, the host `executors`, and `on` handlers for emitted events:
+A machine built by `fromConfig(...)` runs through `runAgent(...)` like any other agent machine. Pass the machine input, the host `executors`, and `on` handlers for emitted events.
 
 ```ts no-check
 const result = await runAgent(machine, {
@@ -244,28 +308,35 @@ const result = await runAgent(machine, {
 });
 ```
 
-Executor return shapes:
+Executors return these shapes.
 
-- `decide` returns `{ event: { type, ...payload } }`, the chosen machine event. A bare `{ type }` throws a descriptive error.
-- `generateText` / `streamText` return `{ output }`, the structured result matching the request's `output` schema.
+| Executor | Returns | Notes |
+| --- | --- | --- |
+| `decide` | `{ event: { type, ...payload } }` | The chosen machine event. A bare `{ type }` throws a descriptive error. |
+| `generateText`, `streamText` | `{ output }` | The structured result matching the request's `output` schema. |
 
-A run settles one of two ways:
+A run settles in one of two ways.
 
-- `{ status: 'done', output }`: reached a final state.
-- `{ status: 'idle', snapshot }`: paused at an idle state. Persist `snapshot`, then resume when the event arrives:
+- `{ status: 'done', output }`: the machine reached a final state.
+- `{ status: 'idle', snapshot }`: the machine paused at an idle state. Persist `snapshot`, then resume when the event arrives.
+
+<!-- viz: run lifecycle: runAgent -> running -> settles as { status: 'done', output } or { status: 'idle', snapshot }, with the idle branch looping back into runAgent({ snapshot, event }) -->
+
 
 ```ts no-check
 result = await runAgent(machine, { snapshot, event: { type: "APPROVE" }, executors });
 ```
 
-> **Note:** An idle state is any state with no `invoke`: nothing runs, so the machine waits for an external event via `on`. A state with an `invoke` is doing work (a decision, a text request, or an `agent.userInput` pause).
+> **Note:** An **idle state** is any state with no `invoke`. Nothing runs in it, so the machine waits for an external event declared under `on`. A state with an `invoke` is doing work: a decision, a text request, or an `agent.userInput` pause.
 
-### Suspension declaration
+> **Note:** Two `prompt`-shaped fields sit at different layers. A `requests` entry's `prompt` is the text sent to the model. An `invoke`'s `input` is the data passed to the invoked source. That is either a request's typed input, or an `agent.decide` inline input carrying its own `model`, `prompt`, and `allowedEvents`.
 
-Without a declared suspension predicate, `runAgent` settles idle via a best-effort timing heuristic (and warns). A config declares one with `suspendedTags` — the declarative form of `setupAgent({ isSuspended })`, since JSON cannot carry a function:
+## Idle declaration
+
+Without a declared idle predicate, `runAgent` settles idle using a best-effort timing heuristic and logs a warning. A config declares the predicate with `idleTags`. This is the declarative form of `setupAgent({ isIdle })`, because JSON cannot carry a function.
 
 ```yaml
-suspendedTags: [awaiting-approval]
+idleTags: [awaiting-approval]
 states:
   awaitingApproval:
     tags: [awaiting-approval]
@@ -273,20 +344,12 @@ states:
       APPROVE: { target: resolved }
 ```
 
-- `fromConfig(...)` lowers the list into a `snapshot.hasTag(...)` predicate; every listed tag must appear in some state's `tags` (an unused entry is a build-time error).
-- For predicates a tag list cannot express, pass a function instead: `setupAgent.fromConfig(config, { isSuspended })`. It takes precedence over `suspendedTags`; a `runAgent({ isSuspended })` host override beats both.
-
-> **Note:** Two `prompt`-shaped fields sit at different layers. A `requests` entry's `prompt` is the text sent to the model. An `invoke`'s `input` is the data passed to the invoked source: a request's typed input, or an `agent.decide` inline input carrying its own `model`/`prompt`/`allowedEvents`.
-
-## Expressions
-
-The config is data, not code. Any value is a JSON literal or a whole-string `"{{ }}"` expression: a dot path resolved against `input`, `context`, and `event`. For example, `"{{ context.ticket }}"` reads `context.ticket`. No code, no `eval`: the resolver walks the path and returns the value. Because an expression can only read, a config from a model, database, or visual editor cannot do anything a hand-authored machine could not.
-
-Two fields are exempt: state, invoke, and transition `meta` and a request's `toolChoice` are passed through verbatim, not template-evaluated. A `{{ }}` string there stays a literal string.
+- `fromConfig(...)` converts the list into a `snapshot.hasTag(...)` predicate. Every listed tag must appear in some state's `tags`. An unused entry is a build-time error.
+- For predicates that a tag list cannot express, pass a function instead: `setupAgent.fromConfig(config, { isIdle })`. The function takes precedence over `idleTags`. A `runAgent({ isIdle })` host override takes precedence over both.
 
 ## Decisions from JSON
 
-A [decision](decisions.md) works from a config: invoke `src: agent.decide` with `allowedEvents`.
+A [decision](decisions.md) works from a config. Invoke `src: agent.decide` with `allowedEvents`.
 
 ```yaml
 states:
@@ -304,11 +367,15 @@ states:
       REPLY: { target: drafting }
 ```
 
-Delivery of the chosen event is automatic: the decision actor sends it to the invoking actor when it resolves, in both TypeScript and JSON. Handle the chosen event with the state's `on` transitions. A decision has no output of its own, so an `onDone` on an `agent.decide` invoke can never fire: `fromConfig(...)` rejects it as a config error. Only `onError` (retries exhausted) applies.
+The chosen event is delivered automatically. When the decision actor resolves, it sends the event to the invoking actor, in both TypeScript and JSON. Handle the chosen event with the state's `on` transitions.
+
+A decision has no output of its own, so an `onDone` on an `agent.decide` invoke can never fire. `fromConfig(...)` rejects it as a config error. Only `onError` applies, and it fires when retries are exhausted.
+
+<!-- viz: agent.decide flow: state invokes agent.decide with allowedEvents -> model picks one event -> actor sends the event to the invoking actor -> the state's `on` transition runs; onError branch when retries are exhausted -->
 
 ## Choice states and emitted events
 
-Use `type: choice` plus `choice:` for pure routing states, matching TypeScript `type: 'choice'` authoring:
+Use `type: choice` with a `choice` array for routing states that do no work. This matches `type: 'choice'` authoring in TypeScript.
 
 ```yaml
 states:
@@ -326,26 +393,22 @@ states:
     type: final
 ```
 
-Declare emitted event payloads under `schemas.emitted`. Hosts receive them through `runAgent(..., { on: { SCORED: handler } })`, same as hand-authored machines using `enq.emit(...)`.
+Declare emitted event payloads under `schemas.emitted`. Hosts receive them through `runAgent(..., { on: { SCORED: handler } })`, the same as for hand-authored machines that use `enq.emit(...)`.
 
 ## Limits of the data form
 
-The data form is narrower than TypeScript authoring, by design:
+The data form is narrower than TypeScript authoring.
 
-- Expressions are simple dot paths (`{{ context.foo.bar }}`), not arbitrary JavaScript.
-- Guard expressions are **truthy-only**: no `!=`, no comparisons, no boolean operators. For anything else, use a named guard (above).
-- Function-valued fields (`allowedEvents`, `input` as functions) cannot appear in JSON.
+- Expressions are dot paths such as `{{ context.foo.bar }}`, not arbitrary JavaScript.
+- Guard expressions are truthy-only. They support no `!=`, no comparisons, and no boolean operators. For anything else, use a named guard. See [Named guards and actions](#named-guards-and-actions).
+- Function-valued fields cannot appear in JSON. This includes `allowedEvents` and `input` when written as functions.
 - `meta` and `toolChoice` are not template-evaluated.
 
-For comparisons or function-valued fields with no named-reference escape hatch, author in TypeScript with `setupAgent(...)` and Zod (or any Standard Schema).
-
-## Generated-machine verification
-
-A machine built from data can be checked before it runs: no API key, no model call. Lint it with `lintAgentMachine`, simulate a scripted playthrough, or enumerate its decision branches, all in a plain script that CI can run.
+For comparisons, or for function-valued fields that have no named-reference equivalent, author the machine in TypeScript with `setupAgent(...)` and Zod or any other Standard Schema library.
 
 ## Related
 
-- [Testing and verification](verify.md): lint, simulate, and explore a lowered machine.
+- [Testing and verification](verify.md): check a lowered machine before it runs, with no API key and no model call. Lint it with `lintAgentMachine`, simulate a scripted playthrough, or enumerate its decision branches, all from a script CI can run.
 - [Generating machines with an LLM](generate-machines.md): the generate → validate → lint → simulate pipeline.
 - [Agent machines](machines.md): the TypeScript authoring form a config lowers to.
 - [Decisions](decisions.md): `agent.decide` from a config.

--- a/docs/machines-presets.md
+++ b/docs/machines-presets.md
@@ -7,13 +7,16 @@ description: Factories for proven agent shapes (tool loop, sequential, router, p
 
 ## Overview
 
-`@statelyai/agent/machines` ships factories for the agent shapes that every framework converges on. Each one is a thin composition over `setupAgent(...).createMachine(...)`:
+`@statelyai/agent/machines` ships factories for common agent shapes. Each factory is a thin composition over `setupAgent(...).createMachine(...)`.
 
-- The result is an **ordinary machine**. Same states, same guards, same snapshots, same `lintAgentMachine`.
-- **Executors stay separate.** Presets name no SDK; the host still passes `executors` to `runAgent`/`generateResult`.
-- **Nothing is hidden.** Every preset is ~100 lines of visible states you can read, diagram, and eject from.
+- The result is an ordinary machine, with the same states, guards, snapshots, and `lintAgentMachine` support as a machine you write yourself.
+- Executors stay separate. Presets name no SDK, so the host still passes `executors` to `runAgent` or `generateResult`.
+- Each preset is around 100 lines of states that you can read, diagram, and copy into your own project.
 
 ```ts
+import { tool } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
 import { runAgent } from "@statelyai/agent";
 import { createToolLoopMachine } from "@statelyai/agent/machines";
 import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
@@ -31,23 +34,24 @@ const machine = createToolLoopMachine({
   model: "quick",
   instructions: "Answer using the tools.",
   tools: { calculate },
-  maxTurns: 5,
+  maxSteps: 5,
 });
 
 const result = await runAgent(machine, {
   input: { prompt: "What is 42 times 17?" },
   executors: createAiSdkExecutors({ models }),
 });
-// Snapshots and log entries carry machine.version ("1") automatically.
 ```
+
+Snapshots and log entries carry `machine.version` automatically. See [Versioning](#versioning).
 
 ## Preset taxonomy
 
 Three questions separate the seven presets:
 
-- **Who runs the work?** One request (`toolLoop`), a fixed chain (`sequential`), or named sub-units (the rest).
-- **Who picks the next unit?** The author (`sequential`, `parallel`, `loop`) or the model (`router`, `supervisor`, `handoff`).
-- **Does control come back?** Delegation returns (`supervisor`); routing ends the run (`router`); handoff transfers for good (`handoff`).
+- Who runs the work? One request in `toolLoop`, a fixed chain in `sequential`, or named sub-units in the rest.
+- Who picks the next unit? The author in `sequential`, `parallel`, and `loop`. The model in `router`, `supervisor`, and `handoff`.
+- Does control come back? Delegation returns in `supervisor`. Routing ends the run in `router`. Handoff transfers control permanently in `handoff`.
 
 | Preset                    | Shape                                   | Model chooses                    | Control returns        |
 | ------------------------- | --------------------------------------- | -------------------------------- | ---------------------- |
@@ -57,82 +61,99 @@ Three questions separate the seven presets:
 | `createParallelMachine`   | Static fan-out, joined                  | nothing                          | yes, at the join       |
 | `createLoopMachine`       | Bounded repeat                          | nothing                          | yes, each iteration    |
 | `createSupervisorMachine` | Delegate, accumulate, repeat            | the worker, or `FINISH`          | yes, every turn        |
-| `createHandoffMachine`    | Peer swarm, `activeAgent` holds the mic | n/a (host sends `transfer_to_*`) | no, transfer is final  |
+| `createHandoffMachine`    | Peer swarm, `activeAgent` names the agent that runs the turn | n/a (host sends `transfer_to_*`) | no, transfer is final  |
 
 ## Config names
 
 Every preset uses the same vocabulary:
 
-- `model`: model ref or `models` alias. Entry-level `model` overrides the factory default.
-- `instructions`: the system prompt.
-- `tools`: tools the host runs inside one request.
-- `outputSchema`: structured output. Omitted means plain text.
-- `maxTurns` / `maxIterations`: the bound. `maxTurns` lowers to `metadata.maxSteps` for a request; `maxIterations` is a machine guard.
-- `interruptOn`: tool names the host should gate (tool-loop only).
-- Worker/route/branch/agent entries are a record: the key is the `name`, and each entry carries a `description` the deciding model reads.
+| Option | Meaning |
+| ------ | ------- |
+| `model` | A model ref or a `models` alias. A `model` on an entry overrides the factory default. |
+| `instructions` | The system prompt. |
+| `tools` | Tools the host runs inside one request. |
+| `outputSchema` | Structured output. Omit it for plain text. |
+| `maxSteps` | The bound on a request's host-side tool loop. It lowers to the request's typed `maxSteps`. |
+| `maxTurns` | The bound on a machine loop or delegation count. It is enforced by a guard. |
 
-An entry is either an inline request (`{ description, instructions, model, outputSchema, tools }`) or a child machine (`{ description, machine, input? }`). Child machines are registered as actor sources, so `runAgent` binds their executors too.
+Worker, route, branch, and agent entries are a record. The key is the entry's `name`, and each entry carries a `description` that the deciding model reads.
+
+An entry is either an inline request, written as `{ description, instructions, model, outputSchema, tools }`, or a child machine, written as `{ description, machine, input? }`. Child machines are registered as actor sources, so `runAgent` binds their executors too.
 
 ## The presets
 
 ### `createToolLoopMachine`
 
-One text request carries the `tools`; the host runs the tool loop inside it. `maxTurns` bounds it via `metadata.maxSteps`. States: `answering` → `done`.
+One text request carries the `tools`, and the host runs the tool loop inside that request. `maxSteps` bounds the loop through the request's typed `maxSteps` field. The states are `answering` and `done`.
 
-This is the default for tool use. `interruptOn` is passed through as `metadata.interruptOn` for hosts that gate tool execution; it does not add machine states. For a real approval gate as states, eject (see below).
+This preset is the default for tool use. It does not add machine states, and it sets no request `metadata`. To model an approval gate as states, eject. See [Ejection](#ejection).
 
 ### `createSequentialMachine`
 
-A prompt chain: one state per step, each step's output feeding the next. A step's `prompt(ctx)` can read `{ prompt, results, previous }`; without one, the default prompt is the previous step's output.
+A prompt chain with one state per step. Each step's output feeds the next step. A step's `prompt(ctx)` can read `{ prompt, results, previous }`. Without a `prompt`, the step's default prompt is the previous step's output.
+
+<!-- viz: state diagram of createSequentialMachine: step1 -> step2 -> step3 -> done, each step invoking one request and writing into results -->
 
 ### `createRouterMachine`
 
-One `agent.decide` picks exactly one declared route (`ROUTE_<name>`; build the string with `routeEventType(name)` when sending or asserting these events), then the machine runs it. Undeclared routes have no event, no state, and no transition, so they cannot be taken. Add `fallback` to land somewhere when the decision fails; without it, a failed decision errors the run.
+One `agent.decide` picks exactly one declared route, then the machine runs it. Route events are named `ROUTE_<name>`. Build the string with `routeEventType(name)` when you send or assert these events. Undeclared routes have no event, no state, and no transition, so the model cannot take them. Add `fallback` to target a state when the decision fails. Without `fallback`, a failed decision errors the run.
+
+<!-- viz: state diagram of createRouterMachine: routing state invoking agent.decide, one ROUTE_<name> transition per declared route, plus the optional fallback target -->
 
 ### `createParallelMachine`
 
-Static fan-out: one region per branch, all concurrent, joined into a keyed `results` object. Branch count is fixed at author time. For an N decided at run time, see [examples/fan-out](../examples/fan-out/index.ts).
+Static fan-out with one region per branch. All branches run concurrently and join into a keyed `results` object. The branch count is fixed at author time. For a branch count decided at run time, see [examples/fan-out](../examples/fan-out/index.ts).
+
+<!-- viz: state diagram of createParallelMachine: parallel state with one region per branch, all joining into a single done state with keyed results -->
 
 ### `createLoopMachine`
 
-A bounded repeat: run `body`, check `until` over `{ prompt, iterations, results, last }`, go again or stop. `maxIterations` is a guard, so the loop cannot run away even if `until` never fires.
+A bounded repeat. The machine runs `body`, evaluates `until` over `{ prompt, iterations, results, last }`, then repeats or stops. `maxTurns` is a guard, so the loop terminates even if `until` never returns true.
 
 ### `createSupervisorMachine`
 
-Each turn, one `agent.decide` picks a worker (`DELEGATE_<name>`, via `delegateEventType(name)`) or `FINISH` (`FINISH_EVENT_TYPE`). Results accumulate in context and are rendered back into the next decision. A spent `maxTurns` budget removes every delegate from the candidate set and a guard rejects one anyway.
+Each turn, one `agent.decide` picks a worker or finishes. `maxTurns` bounds the delegations and defaults to 6. It is a machine budget, and it never lowers a request's `maxSteps`. Worker events are named `DELEGATE_<name>`, built with `delegateEventType(name)`. The finish event is `FINISH`, exported as `FINISH_EVENT_TYPE`. Results accumulate in context and are rendered into the next decision. When the `maxTurns` budget is spent, every delegate is removed from the candidate set, and a guard rejects a delegate event if one is chosen anyway.
+
+<!-- viz: state diagram of createSupervisorMachine: deciding -> DELEGATE_<name> -> worker state -> back to deciding, with FINISH -> done and the maxTurns guard -->
 
 ### `createHandoffMachine`
 
-Peer swarm: `context.activeAgent` holds the mic, runs one turn, and the machine settles idle in `waiting`. A `transfer_to_<name>` event (via `transferEventType(name)`) moves the mic and re-routes. There is no final state: the conversation ends when the host stops resuming it. Persist the idle snapshot between turns.
+A peer swarm. `context.activeAgent` names the agent that runs the current turn. After the turn, the machine settles idle in `waiting`. A `transfer_to_<name>` event, built with `transferEventType(name)`, changes `activeAgent` and re-routes. There is no final state. The conversation ends when the host stops resuming it. Persist the idle snapshot between turns.
+
+## Ejection
+
+A preset is a starting point. When you need one more state, a human gate, a different bound, or your own typed context:
+
+1. Open the preset's source at `src/machines/<preset>.ts`. It is one small file of states.
+2. Copy it into your project and edit the `setupAgent(...)` call directly.
+3. Run it as before. The copied machine runs, lints, and persists the same way.
+
+Examples to eject toward:
+
+- [react-agent](../examples/react-agent/index.ts): the tool loop expressed as states.
+- [review-tool-calls](../examples/review-tool-calls/index.ts): an approval gate.
+- [fan-out](../examples/fan-out/index.ts): a branch count decided at run time.
+- [reflection-writer](../examples/reflection-writer/index.ts): a critique loop.
+- [supervisor](../examples/supervisor/index.ts) and [swarm-handoff](../examples/swarm-handoff/index.ts): multi-agent topologies.
 
 ## Versioning
 
-Every preset machine carries `version: "1"`, XState's standard `createMachine({ version })` prop. This is the machine's own topology version and has nothing to do with the `@statelyai/agent` package version. `runAgent` reads it automatically (resolution: `options.machineVersion` → `machine.version` → structural hash), so snapshots, event-log entries, and trace events are stamped with `"1"` and stay resumable across releases:
+Every preset machine carries `version: "1"`, using XState's standard `createMachine({ version })` prop. This is the machine's own topology version. It is unrelated to the `@statelyai/agent` package version. `runAgent` reads `machine.version`, and falls back to a structural hash only for a machine that declares no version. Snapshots, event-log entries, and trace events are stamped with `"1"` and stay resumable across releases:
 
 ```ts
 const result = await runAgent(machine, { input, executors });
 // result.events[0].machineVersion === "1"
 ```
 
-The policy:
+The versioning policy:
 
-- The version identifies the machine's **topology**, not the release that built it. Internals may be refactored (prompt wording, an added `onError`, a renamed internal id) without a bump, so persisted snapshots and event logs stay valid.
-- A topology change that a persisted snapshot could not resume into bumps the machine version (`"2"`), a minor package release at most. Resume across the bump via `migrateSnapshot`/`onVersionMismatch`.
+- The version identifies the machine's topology, not the release that built it. Internals can be refactored without a version bump, including prompt wording, an added `onError`, or a renamed internal id. Persisted snapshots and event logs stay valid.
+- A topology change that a persisted snapshot could not resume into bumps the machine version to `"2"`, in a minor package release at most. Resume across the bump with `migrateSnapshot` or `onVersionMismatch`.
 
-The same prop works for your own machines: set `version` in `createMachine(...)` and `runAgent` stamps it instead of the structural hash (which changes on any edit).
-
-## Ejection
-
-A preset is a starting point, not a framework. When you need one more state, a human gate, a different bound, or typed context of your own:
-
-- Open the preset's source (`src/machines/<preset>.ts`): one small file of visible states.
-- Copy it into your project and edit the `setupAgent(...)` call directly.
-- Nothing else changes: the copied machine runs the same way, lints the same way, and persists the same way.
-
-Related examples to eject toward: [react-agent](../examples/react-agent/index.ts) (tool loop as states), [review-tool-calls](../examples/review-tool-calls/index.ts) (approval gate), [fan-out](../examples/fan-out/index.ts) (dynamic N), [reflection-writer](../examples/reflection-writer/index.ts) (critique loop), [supervisor](../examples/supervisor/index.ts), [swarm-handoff](../examples/swarm-handoff/index.ts).
+The same prop works for your own machines. Set `version` in `createMachine(...)` and `runAgent` stamps that value instead of the structural hash, which changes on any edit.
 
 ## Related
 
-- [Agent machines](machines.md): what the presets compose (`setupAgent`, states, invokes, guards).
-- [Agent patterns](patterns.md): the full runnable example catalog.
-- [The event log](event-log.md): where `machineVersion` is recorded and checked.
+- Read more about [Agent machines](machines.md), including `setupAgent`, states, invokes, and guards.
+- Read more about [Agent patterns](patterns.md), the full runnable example catalog.
+- Read more about [The event log](event-log.md), where `machineVersion` is recorded and checked.

--- a/docs/machines.md
+++ b/docs/machines.md
@@ -7,7 +7,9 @@ description: Author an agent machine as a typed XState state machine that decide
 
 ## Overview
 
-An **agent machine** is a typed XState state machine describing what your agent can do: which states exist, which transitions are legal, which model calls happen, and which events the model may choose right now. It is a blueprint; it never talks to a model directly.
+An **agent machine** is a typed XState state machine that describes what your agent can do. It declares the states, the legal transitions, the model calls, and the events the model may choose in each state. An agent machine never calls a model itself. The host executes model calls on its behalf.
+
+<!-- viz: data-flow figure of the machine/host boundary: machine invokes a request -> host executor calls the model SDK -> output validated against the output schema -> onDone transition applied to the machine -->
 
 Author a machine in three steps:
 
@@ -19,13 +21,9 @@ Author a machine in three steps:
 
 <!-- flat schema fields on setupAgent from src/setup-agent.ts -->
 
-Pass schema fields directly to `setupAgent` to type context, event payloads, input, output, and state meta:
+Pass schema fields directly to `setupAgent` to type your data. `context` is required. `input`, `output`, `events`, `emitted`, and `meta` are optional.
 
-- `context` (required), `input`, `output`: context, input, and output shapes.
-- `events`: per-event payload types.
-- `meta`: typed state/transition metadata.
-
-Every schema is a [Standard Schema](https://standardschema.dev) (Zod, Valibot, ArkType, or a hand-written validator), retained on the agent so context and events are typed without `{} as Type` casts.
+Every schema is a [Standard Schema](https://standardschema.dev). Zod, Valibot, ArkType, and hand-written validators all work. The agent retains the schemas, so context and events are typed without `{} as Type` casts.
 
 ```ts
 import { z } from "zod";
@@ -47,9 +45,11 @@ factory, event log, and trace; invalid input throws `AgentError` with code
 `invalid-machine-input`. Calling XState's `createActor` directly does not run
 this validation.
 
-To keep conversation history in context, add a `messages` field with the `z.custom<AgentMessage[]>` recipe (see [messages](messages.md#store-messages-in-context)).
+To keep conversation history in context, add a `messages` field with the `z.custom<AgentMessage[]>` recipe. See [Messages](messages.md#store-messages-in-context).
 
-**Event schemas** type event payloads. Declare one schema per event type under `events`:
+### Event schemas
+
+Event schemas type event payloads. Declare one schema per event type under `events`:
 
 ```ts no-check
 // setupAgent({ ... })
@@ -61,9 +61,11 @@ events: {
 // ...
 ```
 
-In a `HEAL` transition, `event.amount` is a `number`; reading a field the event does not carry is a compile error. Write `{}` for a payload-less event.
+In a `HEAL` transition, `event.amount` is a `number`. Reading a field the event does not carry is a compile error. Write `{}` for a payload-less event.
 
-**Emitted event schemas** type the progress events a machine emits with `enq.emit(...)`, received by hosts via [`runAgent`'s `on` handlers](observability.md#observation-callbacks). Declare them under `emitted`:
+### Emitted event schemas
+
+Emitted event schemas type the progress events a machine emits with `enq.emit(...)`. Hosts receive them through [`runAgent`'s `on` handlers](observability.md#observation-callbacks). Declare them under `emitted`:
 
 ```ts no-check
 // setupAgent({ ... })
@@ -73,21 +75,21 @@ emitted: {
 // ...
 ```
 
-Both `enq.emit({ type: 'EVALUATED', ... })` and the host-side `on: { EVALUATED: handler }` are then typed; an undeclared type or wrong payload is a compile error.
+Both `enq.emit({ type: 'EVALUATED', ... })` and the host-side `on: { EVALUATED: handler }` are then typed. An undeclared type or a wrong payload is a compile error.
 
-> **Sharing a schema pack.** To reuse one schema set across machines or the step helpers, declare it once with `createAgentSchemas({ context, input, output, events })` and pass it as `setupAgent({ schemas })`. Equivalent to the inline form. See [Authoring forms](#authoring-forms).
+> **Note:** To reuse one schema set across machines or the step helpers, declare it once with `createAgentSchemas({ context, input, output, events })` and pass it as `setupAgent({ schemas })`. This is equivalent to the inline form. See [Authoring forms](#authoring-forms).
 
 ## Agent setup
 
 <!-- setupAgent config surface (models, requests, actors, builtins) from src/setup-agent.ts -->
 
-Beyond schemas, `setupAgent` takes your models plus optional `requests` and `actors`, and returns a **setup** whose `createMachine` builds the machine. Like XState's `setup()`, the return value is the typed foundation, not a running agent, so name it accordingly (`agentSetup`, `gameSetup`).
+Beyond schemas, `setupAgent` takes your models plus optional `requests`, `actors`, `actions`, `guards`, `states`, and `delays`. `states` narrows context per state. See [Per-state context narrowing](#per-state-context-narrowing). `delays` names the durations that [delayed transitions](#delayed-transitions) reference. It returns a **setup** whose `createMachine` method builds the machine. Like XState's `setup()`, the return value is a typed foundation, not a running agent. Name it accordingly, for example `agentSetup` or `gameSetup`.
 
-The builtins `agent.generateText`, `agent.streamText`, `agent.decide`, and `agent.userInput` are registered automatically; invoke them by name.
+The builtins `agent.generateText`, `agent.streamText`, `agent.decide`, and `agent.userInput` are registered automatically. Invoke them by name.
 
 ### Models
 
-The `models` map pairs a short alias with a resolved model, so request and decision `model:` values autocomplete its keys. The same map goes to the host adapter; see [Typed model aliases](hosts.md#typed-model-aliases).
+The `models` map pairs a short alias with a resolved model. Request and decision `model:` values autocomplete against its keys. Pass the same map to the host adapter. See [Typed model aliases](hosts.md#typed-model-aliases).
 
 ```ts
 import { openai } from "@ai-sdk/openai";
@@ -113,11 +115,11 @@ const agentSetup = setupAgent({
 });
 ```
 
-Aliases are optional: a request can carry any `model:` string (like `'openai/gpt-5.4-mini'`) that the host resolves at run time. See [Authoring forms](#authoring-forms).
+Aliases are optional. A request can carry any `model:` string, such as `'openai/gpt-5.4-mini'`, that the host resolves at run time. See [Authoring forms](#authoring-forms).
 
 ### Requests
 
-The `requests` map declares named text requests inline. Each entry carries its own input/output schemas, a model, and a `prompt` (or `messages`) built from typed input, and becomes an actor you invoke by its key.
+The `requests` map declares named text requests inline. Each entry carries its own input and output schemas, a model, and a `prompt` or `messages` value built from typed input. Each entry becomes an actor you invoke by its key.
 
 ```ts no-check
 // setupAgent({ ... })
@@ -139,7 +141,9 @@ See [Text requests](text-requests.md) for the full request surface, including st
 
 ### Actors
 
-The `actors` map registers reusable actor logic: text logic from `createTextLogic`, or any XState actor. Register logic here when it is reusable, exported, or worth testing standalone. Decisions are state-local (`src: 'agent.decide'`), not actor sources; to reuse one, share its input builder.
+The `actors` map registers reusable actor logic. This can be text logic from `createTextLogic` or any XState actor. Register logic here when it is reusable, exported, or worth testing on its own.
+
+Decisions are state-local. They use `src: 'agent.decide'` and are not actor sources. To reuse a decision, share its input builder.
 
 ```ts
 import { createTextLogic } from "@statelyai/agent";
@@ -158,13 +162,13 @@ const agentSetup = setupAgent({
 });
 ```
 
-> **Warning:** Actor source keys must be unique across `actors` and `requests`. `setupAgent` throws at setup time on a collision rather than letting one silently shadow the other.
+> **Warning:** Actor source keys must be unique across `actors` and `requests`. `setupAgent` throws at setup time on a collision.
 
 ### Built-in actor sources
 
 <!-- builtin src reference, from src/setup-agent.ts -->
 
-`setupAgent` registers reserved `src` strings on every machine, for ad-hoc model work that doesn't warrant a named request. The invoke's `input` shapes each call:
+`setupAgent` registers reserved `src` strings on every machine. Use them for ad-hoc model work that does not warrant a named request. The invoke's `input` shapes each call:
 
 | `src`                | Invoke `input`                                                              | `onDone` output                                        | Reference                                 |
 | -------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------ | ----------------------------------------- |
@@ -173,11 +177,29 @@ const agentSetup = setupAgent({
 | `agent.decide`       | `model`, `prompt`, optional `system`, `allowedEvents`                       | the one chosen event, applied to the machine           | [Decisions](decisions.md)                 |
 | `agent.userInput`    | `prompt`, optional `schema`                                                 | the human's value                                      | [Human in the loop](human-in-the-loop.md) |
 
-Named `requests` stay the default (typed, reusable, testable); the builtins are the inline escape hatch. Both are executed by the host, so a machine using either still names no SDK.
+Named `requests` are the default form because they are typed, reusable, and testable. The builtins are the inline alternative. The host executes both, so neither form names a model SDK in the machine.
+
+## Authoring forms
+
+<!-- canonical form vs the supported escape hatches -->
+
+The canonical form covers most machines: a `models` registry, flat schema fields on `setupAgent`, `model: 'quick'` alias keys, and a host with `createAiSdkExecutors({ models })`. Use it whenever the models are known at author time.
+
+Each alternate form handles one specific need:
+
+| Form | Use it when |
+| ---- | ----------- |
+| `createAgentSchemas` pack, passed as `setupAgent({ schemas })` | You share one schema set across several machines or the [step helpers](steps.md). |
+| String model refs with `resolveModel` (`model: 'openai/gpt-5.4-mini'`, `createAiSdkExecutors({ resolveModel })`) | The machine must not name concrete models, for portability or for refs loaded from JSON [config](machines-as-data.md). |
+| `createTextLogic`, a standalone request value | A request is exported, reused across states or machines, or unit-tested on its own. See [Text requests](text-requests.md#reusable-request-logic-with-createtextlogic). |
+| `logic.withExecutor(...)` | You bind execution onto one logic instead of the whole host, so a plain `createActor` runs it without [`runAgent`](hosts.md#writing-your-own-executors)'s executor slots. Registered dynamic spawns inherit through `actors`. See [Multi-agent composition](multi-agent.md#dynamic-binding). |
 
 ## Machine creation
 
-`agentSetup.createMachine` is XState's `createMachine` with the agent's schemas and actors already bound. It registers the machine so the step helpers and [`runAgent`](hosts.md) resolve its schemas and actors without re-passing them.
+`agentSetup.createMachine` is XState's `createMachine` with the agent's schemas and actors already bound. It registers the machine, so the step helpers and [`runAgent`](hosts.md) resolve its schemas and actors without you passing them again.
+
+<!-- viz: state diagram for the answering machine below: initial state `answering` invoking the `answerQuestion` request, onDone -> final state `done` producing { answer } -->
+
 
 ```ts no-check
 const machine = agentSetup.createMachine({
@@ -205,7 +227,7 @@ const machine = agentSetup.createMachine({
 
 ## Per-state context narrowing
 
-A context field that starts `null` and is assigned mid-run forces a `?? fallback` at every later read. When a state is reachable **only** after that field is set, narrow it non-null under `setupAgent({ states })`. Declare just the fields that change; the narrowed type flows into that state's invoke `input`, transition functions, and `output`, so the coalesce disappears:
+A context field that starts `null` and is assigned mid-run forces a `?? fallback` at every later read. When a state is reachable only after that field is set, narrow it to non-null under `setupAgent({ states })`. Declare only the fields that change. The narrowed type flows into that state's invoke `input`, transition functions, and `output`, so the fallback is no longer needed:
 
 ```ts
 const context = z.object({ question: z.string(), plan: planSchema.nullable() });
@@ -220,30 +242,17 @@ const agentSetup = setupAgent({
 });
 ```
 
-The field-level form is sugar for XState's full form, `executing: { schemas: { context: context.extend({ plan: planSchema }) } }`, which also works.
+The field-level form is shorthand for XState's full form, `executing: { schemas: { context: context.extend({ plan: planSchema }) } }`. The full form also works.
 
-> **Note:** Narrow only where every path into the state has assigned the field. A state also reachable on an error or refusal route (field still `null`) must keep its nullable handling. This narrows the _type_ only; runtime behavior is unchanged.
+> **Note:** Narrow only where every path into the state has assigned the field. A state that is also reachable on an error or refusal route, where the field is still `null`, must keep its nullable handling. Narrowing changes the type only. Runtime behavior is unchanged.
 
 See [examples/sql-agent/index.ts](../examples/sql-agent/index.ts).
-
-## Authoring forms
-
-<!-- canonical form vs the supported escape hatches -->
-
-**Canonical form** covers most machines: a `models` registry, flat schema fields on `setupAgent`, `model: 'quick'` alias keys, and a host with `createAiSdkExecutors({ models })`. Use it whenever the models are known at author time.
-
-Each alternate handles one specific need:
-
-- **`createAgentSchemas` pack** (`setupAgent({ schemas })`): share one schema set across several machines or the [step helpers](steps.md).
-- **String refs + `resolveModel`** (`model: 'openai/gpt-5.4-mini'`, `createAiSdkExecutors({ resolveModel })`): the machine must not name concrete models, for portability or refs loaded from JSON [config](machines-as-data.md).
-- **`createTextLogic`** (a standalone request value): a request that is exported, reused across states or machines, or unit-tested on its own. See [Text requests](text-requests.md#reusable-request-logic-with-createtextlogic).
-- **`withExecutor`** (`logic.withExecutor(...)`): bind execution onto one logic instead of the whole host, so a plain `createActor` runs it without [`runAgent`](hosts.md#writing-your-own-executors)'s executor slots. Registered dynamic spawns inherit through `actors`; see [Multi-agent composition](multi-agent.md#dynamic-binding).
 
 ## Transitions
 
 <!-- transition-function authoring style from src/setup-agent.ts and examples/twenty-questions -->
 
-A **transition** is a function of `{ context, event }` returning the next `target` and a `context` update (a **partial** update: omitted fields keep their values). You return updates rather than assigning them with `assign()`. The `event` is typed from the event schema.
+A **transition** is a function of `{ context, event }` that returns the next `target` and a `context` update. The update is partial: omitted fields keep their values. You return updates instead of assigning them with `assign()`. The `event` is typed from the event schema.
 
 ```ts no-check
 // inside a state
@@ -255,7 +264,7 @@ on: {
 }
 ```
 
-> **Guards are a return value, not a `guard:` field.** Returning `undefined` from a transition function makes that transition **illegal** for the current snapshot. Because the condition and the resulting transition share one function they can never disagree, the check is visible at the transition it protects, and `snapshot.can(event)` (which powers [decision](decisions.md) legality) derives from the same code path. If you know XState's `guard:`, read "returns `undefined`" wherever you'd expect one.
+> **Note:** Guards are a return value, not a `guard:` field. Returning `undefined` from a transition function makes that transition illegal for the current snapshot. The condition and the transition live in the same function, so they cannot disagree. `snapshot.can(event)`, which determines [decision](decisions.md) legality, derives from the same code path. If you know XState's `guard:`, read "returns `undefined`" wherever you would expect one.
 
 ```ts no-check
 // inside a state
@@ -268,9 +277,9 @@ on: {
 }
 ```
 
-This matters for [decisions](decisions.md): a model choosing an event whose transition returns `undefined` is rejected before the transition is taken. Guards make illegal choices impossible, not just discouraged.
+This affects [decisions](decisions.md). If the model chooses an event whose transition returns `undefined`, the choice is rejected before the transition is taken.
 
-A transition can also be a plain object. Its `context` is a static patch or a mapper function receiving the same args (including `output` on `onDone`):
+A transition can also be a plain object. Its `context` is a static patch, or a mapper function that receives the same arguments. On `onDone`, those arguments include `output`:
 
 ```ts no-check
 // inside a state
@@ -286,11 +295,36 @@ onDone: {
 }
 ```
 
-Use the full function form when the `target` is conditional (guards) or you need `enq` to enqueue effects; use the object form otherwise.
+Use the function form when the `target` is conditional or when you need `enq` to enqueue effects. Use the object form otherwise.
+
+## Choice states
+
+<!-- choice state node type from xstate v6 (StateMachine formatChoiceTransitions) and src/machines/loop.ts -->
+
+A **choice state** routes to one of several targets without waiting for an event. Set `type: 'choice'` and give the state a `choice` function of `{ context, event }` that returns the transition to take. The machine enters the state, runs the function, and leaves immediately.
+
+```ts no-check
+// inside states: { ... }
+checking: {
+  type: 'choice',
+  choice: ({ context }) =>
+    context.iterations >= context.maxTurns || context.done
+      ? { target: 'done' }
+      : { target: 'running' },
+},
+```
+
+The returned object takes the same fields as a transition object, including `context` for a partial context update. The function must return a target. A choice state whose function returns no target throws at run time.
+
+A choice state has no other behavior. `on`, `always`, `after`, `entry`, `exit`, `invoke`, and `states` are not allowed on it. Put the work in the target states.
+
+Use a choice state when the branch is a pure routing decision the machine makes on its own, such as a loop bound or a score threshold. Use a [decision](decisions.md) when the model picks the branch.
+
+In a JSON [machine config](machines-as-data.md), `choice` is an array of branches instead of a function. Each branch carries an optional `guard` and a `target`, and the first branch whose guard passes wins. A branch with no guard is the fallback.
 
 ## Request and actor invokes
 
-A state invokes an actor by `src` (a request key, a registered actor, or a builtin like `agent.decide` or `agent.userInput`), passing typed `input` and handling `onDone`/`onError`.
+A state invokes an actor by `src`. The `src` is a request key, a registered actor, or a builtin such as `agent.decide` or `agent.userInput`. The state passes typed `input` and handles `onDone` and `onError`.
 
 ```ts no-check
 // inside states: { ... }
@@ -304,13 +338,13 @@ drafting: {
 }
 ```
 
-The `onDone` handler receives the actor's `output`, typed from its output schema. Both `onDone` and `onError` are transition functions too.
+The `onDone` handler receives the actor's `output`, typed from its output schema. Both `onDone` and `onError` are transition functions.
 
 ### Inline text requests
 
 <!-- inline agent.generateText + runAgent, from src/setup-agent.ts and src/index.ts -->
 
-For a one-off text call, `agent.generateText` is the quick inline path (move it to a named [request](text-requests.md) once it is reused or worth testing):
+For a one-off text call, invoke `agent.generateText` inline. Move it to a named [request](text-requests.md) once it is reused or worth testing:
 
 ```ts no-check
 import { parseOutput, runAgent } from "@statelyai/agent";
@@ -318,7 +352,7 @@ import { parseOutput, runAgent } from "@statelyai/agent";
 // ...
 generating: {
   invoke: {
-    id: "draft", // durable id: how a resumed or replayed run matches the invoke to its onDone
+    id: "draft",
     src: "agent.generateText",
     input: ({ context }) => ({
       model: "openai/gpt-5.4-mini",
@@ -333,14 +367,14 @@ generating: {
 },
 
 // ...
-await runAgent(machine, { input, executors: { generateText, streamText } }); // any SDK
+await runAgent(machine, { input, executors: { generateText, streamText } });
 ```
 
-Every agent invoke should carry a durable `id`: it is how a resumed or replayed run matches the invoke back to its `onDone`. See [The event log](event-log.md).
+Give every agent invoke a durable `id`. A resumed or replayed run uses the `id` to match the invoke back to its `onDone`. See [The event log](event-log.md).
 
 ## Final states and output
 
-A final state ends the machine (or a region). Its `output` is typed against the machine's output schema:
+A final state ends the machine or a region of it. Its `output` is typed against the machine's output schema:
 
 ```ts no-check
 done: {
@@ -349,15 +383,15 @@ done: {
 }
 ```
 
-When the root declares no `output` and exactly one final state does, `createMachine` promotes that output to the root, so `snapshot.output` is set without repeating it everywhere.
+When the root declares no `output` and exactly one final state does, `createMachine` promotes that final state's output to the root. `snapshot.output` is then set without you declaring the output twice.
 
-> **Note:** Read `context` in a final `output` function, never the entering `event`. A final `output` function is evaluated more than once with different events, so `event` is unreliable there. Capture what you need into `context` in the transition targeting the final state, then read it back. The `lintAgentMachine` check `final-output-reads-event` flags this.
+> **Note:** Read `context` in a final `output` function, never the entering `event`. A final `output` function is evaluated more than once with different events, so `event` is unreliable there. Capture what you need into `context` in the transition that targets the final state, then read it back. The `lintAgentMachine` check `final-output-reads-event` flags this.
 
 ## State and transition meta
 
 <!-- typed meta protocol from examples/email-drafter/agent-logic.ts -->
 
-The `meta` field attaches typed data to a state or transition. With a `meta` schema on `setupAgent`, hosts read a typed interaction protocol instead of `Record<string, unknown>`:
+The `meta` field attaches typed data to a state or transition. When you declare a `meta` schema on `setupAgent`, hosts read a typed interaction protocol instead of `Record<string, unknown>`:
 
 ```ts no-check
 // inside states: { ... }
@@ -380,7 +414,7 @@ A `meta` value that does not match the schema is a compile error. See [examples/
 
 ## Delayed transitions
 
-A delayed transition (`after`) fires after a delay with no external event, keyed by milliseconds or by a named delay from `setupAgent`'s `delays`:
+A delayed transition (`after`) fires after a delay, with no external event. Key it by milliseconds or by a named delay from `setupAgent`'s `delays`:
 
 ```ts no-check
 // inside states: { ... }
@@ -391,11 +425,11 @@ waiting: {
 
 How `after` runs depends on the host:
 
-- Under [`runAgent`](hosts.md), the timer runs **live**: a pending `after` is not idle, so `runAgent` waits for it and continues.
-- On the [step path](steps.md), it surfaces from `getAgentEffects` as an effect with `kind: "delay"`: the durable host owns the clock (a workflow sleep, a Temporal timer, a queue delay) and applies the event when it fires. See [Steps](steps.md).
+- Under [`runAgent`](hosts.md), the timer runs live. A pending `after` does not count as idle, so `runAgent` waits for it and continues.
+- On the [step path](steps.md), the delay surfaces from `getAgentEffects` as an effect with `kind: "delay"`. The durable host owns the clock, such as a workflow sleep, a Temporal timer, or a queue delay, and applies the event when it fires. See [Steps](steps.md).
 
 ## Related
 
-- [Decisions](decisions.md): let the model choose exactly one currently-legal event.
-- [Text requests](text-requests.md): the full request surface, streaming, and structured output.
-- [Human in the loop](human-in-the-loop.md): idle states, resuming from a snapshot, and inline user input.
+- Read more about [Decisions](decisions.md), where the model chooses one currently-legal event.
+- Read more about [Text requests](text-requests.md), including streaming and structured output.
+- Read more about [Human in the loop](human-in-the-loop.md), including idle states, resuming from a snapshot, and inline user input.

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -9,7 +9,9 @@ description: Build and store conversation history as a parts-based message model
 
 <!-- AgentMessage union and part types from src/types.ts -->
 
-An `AgentMessage` is a parts-based, discriminated union representing one conversation turn. It structurally mirrors the Vercel AI SDK's `ModelMessage`, but core has no dependency on `ai`. Build messages, store them in machine context, and pass them to a [text request](text-requests.md) or [decision](decisions.md) through the `messages` field.
+This page covers the message model, the builder helpers, and how to store and persist conversation history.
+
+An `AgentMessage` is a parts-based discriminated union that represents one conversation turn. It structurally mirrors the Vercel AI SDK's `ModelMessage`, but core does not depend on the `ai` package. Build messages, store them in machine context, and pass them to a [text request](text-requests.md) or [decision](decisions.md) through the `messages` field.
 
 ```ts
 type AgentMessage = SystemMessage | UserMessage | AssistantMessage | ToolMessage;
@@ -17,12 +19,14 @@ type AgentMessage = SystemMessage | UserMessage | AssistantMessage | ToolMessage
 
 The `content` field is a string or an array of typed parts, depending on `role`:
 
-- **`system`**: a string.
-- **`user`**: a string, or `TextPart` / `ImagePart` / `FilePart` parts.
-- **`assistant`**: a string, or `TextPart` / `FilePart` / `ToolCallPart` / `ToolResultPart` parts.
-- **`tool`**: an array of `ToolResultPart`.
+| `role` | `content` |
+| ------ | --------- |
+| `system` | A string. |
+| `user` | A string, or an array of `TextPart`, `ImagePart`, and `FilePart` parts. |
+| `assistant` | A string, or an array of `TextPart`, `FilePart`, `ToolCallPart`, and `ToolResultPart` parts. |
+| `tool` | An array of `ToolResultPart`. |
 
-> **Warning:** `ImagePart` and `FilePart` can hold binary data or a `URL` instance, which are not JSON-serializable. Use base64 strings and URL strings if the messages will be persisted. See [Persisting messages](#persisting-messages).
+`ImagePart` and `FilePart` can hold binary data or a `URL` instance, neither of which is JSON-serializable. See [Persisting messages](#persisting-messages).
 
 ## Message builders
 
@@ -49,7 +53,7 @@ userMessage([
 ]);
 ```
 
-The `toolMessage(parts)` helper builds a `role: "tool"` message from `ToolResultPart`s; each tool result follows the assistant message whose `ToolCallPart` invoked it. Use it to seed `runAgent({ messages })` with a prior conversation where tools ran, or to append tool results from a custom host:
+The `toolMessage(parts)` helper builds a `role: "tool"` message from `ToolResultPart` values. Each tool result follows the assistant message whose `ToolCallPart` invoked it. Use `toolMessage` to seed `runAgent({ messages })` with a prior conversation in which tools ran, or to append tool results from a custom host:
 
 ```ts
 const messages = [
@@ -70,7 +74,7 @@ const messages = [
 
 ## Store messages in context
 
-Messages are plain context state. Declare the `messages` field with `z.custom<AgentMessage[]>`, and grow it over transitions:
+Messages are plain context state. Declare the `messages` field with `z.custom<AgentMessage[]>` and append to it over transitions:
 
 ```ts
 import { setupAgent, type AgentMessage } from "@statelyai/agent";
@@ -84,9 +88,9 @@ const agentSetup = setupAgent({
 });
 ```
 
-`z.custom` keeps the exact `AgentMessage[]` type at author time with a shallow runtime check, which is enough when the array is built from the helpers above. Do not put `messagesSchema` inside a `z.object`: it is a Standard Schema value, not a Zod type, so Zod infers the field as `unknown`.
+`z.custom` keeps the exact `AgentMessage[]` type at author time and performs a shallow runtime check. That check is enough when the array is built from the helpers above. Use the root `messagesSchema` export for messages that arrive from outside your process.
 
-Append with `appendMessages`, which returns a transition result adding one or more messages. Pass a message, an array, or a function of `{ context, event }`:
+Append with `appendMessages`, which returns a transition result that adds one or more messages. Pass a message, an array, or a function of `{ context, event }`:
 
 ```ts no-check
 import { appendMessages, userMessage } from '@statelyai/agent';
@@ -97,11 +101,13 @@ on: {
 }
 ```
 
+`appendMessages` is a pure helper. It returns a `{ context, event } => { context }` function and mutates nothing, so it fits anywhere a transition function fits, and it needs only a `messages: AgentMessage[]` field on context.
+
 A request that needs history sends it through `messages` instead of a bare `prompt`. [examples/email-drafter/agent-logic.ts](../examples/email-drafter/agent-logic.ts) keeps a running `messages` array in context and feeds it to a `createTextLogic` request.
 
 ### Validating messages with messagesSchema
 
-`messagesSchema` (root export) is a `StandardSchemaV1<AgentMessage[]>` that checks every message has a known `role` and that `content` is a string or an array of known parts. Use it as a **standalone** validator, on messages arriving from outside your process (an HTTP body, a stored transcript, a client resume payload):
+`messagesSchema` is a root export typed as `StandardSchemaV1<AgentMessage[]>`. It checks that every message has a known `role` and that `content` is a string or an array of known parts. Use it as a standalone validator on messages that arrive from outside your process, such as an HTTP body, a stored transcript, or a client resume payload:
 
 ```ts
 import { messagesSchema, type AgentMessage } from "@statelyai/agent";
@@ -113,10 +119,12 @@ if (result.issues) {
 const messages: AgentMessage[] = result.value;
 ```
 
-It is also usable directly as a schema wherever a Standard Schema is accepted (a `createAgentSchemas` pack field, a `createTextLogic` input schema of its own). Just never nest it inside `z.object`.
+You can also use `messagesSchema` directly wherever a Standard Schema is accepted, such as a `createAgentSchemas` pack field or a `createTextLogic` input schema.
+
+Never nest `messagesSchema` inside a `z.object`. It is a Standard Schema value, not a Zod type, so Zod infers the field as `unknown`. Use the `z.custom<AgentMessage[]>` recipe above for a context field.
 
 ## Persisting messages
 
-> **Warning:** `ImagePart` and `FilePart` can carry binary data (`Uint8Array` or `ArrayBuffer`) or a `URL` instance, none of which are JSON-serializable. When persisting machine context with messages, store binary content as base64 strings and URLs as strings; the library does not convert this for you.
+> **Warning:** `ImagePart` and `FilePart` can carry binary data as a `Uint8Array` or `ArrayBuffer`, or a `URL` instance. None of these are JSON-serializable. When you persist machine context that contains messages, store binary content as base64 strings and URLs as strings. The library does not convert them for you.
 
-Everything else in a message is plain JSON, so a history built from strings, base64, and URL strings survives a snapshot round-trip cleanly. See [Human in the loop](human-in-the-loop.md) for the persistence flow this applies to.
+Everything else in a message is plain JSON. A history built from strings, base64, and URL strings survives a snapshot round-trip. See [Human in the loop](human-in-the-loop.md) for the persistence flow this applies to.

--- a/docs/models-and-providers.md
+++ b/docs/models-and-providers.md
@@ -5,9 +5,11 @@ description: Reuse models and executors from other AI frameworks via AI SDK Lang
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
+This page covers how to supply models to a machine's [executors](hosts.md), and which capabilities each integration path supports.
+
 ## Reusing models from other frameworks
 
-Where a host's [executors](hosts.md) come from is the only integration point. The shared type across frameworks is the AI SDK **`LanguageModel`** object: whatever framework hands you one, drop it into `createAiSdkExecutors({ models })` for a full `{ generateText, streamText, decide }` set:
+A host's [executors](hosts.md) are the only integration point. Most frameworks expose models as an AI SDK **`LanguageModel`** object. Pass that object to `createAiSdkExecutors({ models })` to get a full `{ generateText, streamText, decide }` set.
 
 ```ts
 import { createAiSdkExecutors } from "@statelyai/agent/ai-sdk";
@@ -19,35 +21,53 @@ const executors = createAiSdkExecutors({
 await runAgent(machine, { input, executors });
 ```
 
-Three ways in, from most to least capable:
+There are four integration paths. The first two both go through `createAiSdkExecutors`, so they appear as one row in the [support table](#support-by-path).
 
-- **AI SDK adapter.** Any `LanguageModel` (Mastra, Cloudflare Workers AI via `workers-ai-provider`, TanStack AI, OpenRouter's AI SDK provider, any `@ai-sdk/*` package). Full support, including `decide`.
-- **OpenAI-compatible endpoints.** Point `createOpenAI({ baseURL })` from `@ai-sdk/openai` at any OpenAI-shaped endpoint (Groq, Ollama, vLLM, Together, LM Studio) and feed the result to the same adapter. Full support, including `decide`.
-- **Raw `ai` functions.** Pass `ai`'s `generateText`/`streamText` as your `executors` set. Text only: `decide` needs an adapter, and structured output is best-effort.
+- **AI SDK adapter.** Accepts any `LanguageModel`, including models from Mastra, Cloudflare Workers AI through `workers-ai-provider`, TanStack AI, OpenRouter's AI SDK provider, and any `@ai-sdk/*` package. Supports all three executors, including `decide`.
+- **OpenAI-compatible endpoints.** Point `createOpenAI({ baseURL })` from `@ai-sdk/openai` at any OpenAI-shaped endpoint, such as Groq, Ollama, vLLM, Together, or LM Studio, then pass the result to the same adapter. Supports all three executors, including `decide`.
+- **Hand-written `fetch` executors.** Write the three executors yourself against a provider's HTTP API. Supports all three executors, but you map structured output and decision retries yourself. See [Hosts](hosts.md#writing-your-own-executors).
+- **Raw `ai` functions.** Pass the `ai` package's `generateText` and `streamText` as your `executors` set. This path supports text only. `decide` requires the adapter, and structured output is best-effort.
+
+<!-- viz: executor sourcing paths: LanguageModel object -> createAiSdkExecutors -> { generateText, streamText, decide }, with the raw-`ai` path bypassing the adapter and losing decide/structured output -->
 
 ## Mastra models
 
-Mastra is a TypeScript agent framework whose agents are configured with an AI SDK `LanguageModel`. Reuse that same model object as an executor, no re-config and no second provider setup:
+Mastra is a TypeScript agent framework that configures agents with an AI SDK `LanguageModel`. Pass the same models to `createAiSdkExecutors`, and expose the run through a Mastra tool.
 
 ```ts
-import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+import { Agent } from "@mastra/core/agent";
+import { createTool } from "@mastra/core/tools";
 import { createAiSdkExecutors } from "@statelyai/agent/ai-sdk";
+import { runAgent } from "@statelyai/agent";
 
-// The model you already pass to `new Agent({ model })` in Mastra.
-// Model IDs here are illustrative; substitute your provider's current models.
-const model = openai("gpt-5.4-mini");
+const executors = createAiSdkExecutors({ models });
 
-await runAgent(machine, {
-  input,
-  executors: createAiSdkExecutors({ models: { quick: model } }),
+const startWorkflow = createTool({
+  id: "start_workflow",
+  description: "Start the drafting workflow from the user's request.",
+  inputSchema: z.object({ prompt: z.string() }),
+  outputSchema: z.object({ status: z.string() }),
+  execute: async ({ prompt }) => {
+    const result = await runAgent(machine, { input: { prompt }, executors });
+    return { status: result.status };
+  },
+});
+
+export const hostAgent = new Agent({
+  id: "drafting-host",
+  name: "Drafting Host",
+  instructions: "Call start_workflow with the user's request, then report what came back.",
+  model: "openai/gpt-5.4-mini",
+  tools: { start_workflow: startWorkflow },
 });
 ```
 
-Anything exposing a `LanguageModel` works the same way, so machine and Mastra share one model definition.
+Any framework that exposes a `LanguageModel` works the same way. The machine and the Mastra agent share one model definition. See [`examples/mastra-host`](https://github.com/statelyai/agent/tree/main/examples/mastra-host) for the full bridge, including pause and resume across tool calls.
 
 ## Cloudflare Workers AI
 
-Workers AI runs models on Cloudflare's edge, reached through a binding on the Worker's `env`. The `workers-ai-provider` package turns that binding into an AI SDK provider, so its models are ordinary `LanguageModel` objects:
+Workers AI runs models on Cloudflare's edge and is reached through a binding on the Worker's `env`. The `workers-ai-provider` package turns that binding into an AI SDK provider, so its models are ordinary `LanguageModel` objects.
 
 ```ts no-check
 import { createWorkersAI } from "workers-ai-provider";
@@ -55,6 +75,7 @@ import { createAiSdkExecutors } from "@statelyai/agent/ai-sdk";
 
 export default {
   async fetch(request, env) {
+    // Model IDs here are illustrative; substitute your provider's current models.
     const workersai = createWorkersAI({ binding: env.AI });
     const result = await runAgent(machine, {
       input: await request.json(),
@@ -67,16 +88,17 @@ export default {
 };
 ```
 
-Pass Cloudflare-specific per-call options through request `metadata`: the host owns it, the machine just carries it.
+Pass Cloudflare-specific per-call options through request `metadata`. The host reads `metadata`; the machine only carries it.
 
 ## Ollama and OpenAI-compatible endpoints
 
-Ollama runs models locally and serves them over an OpenAI-compatible HTTP API, so the AI SDK's OpenAI provider pointed at the local endpoint is enough. `apiKey` is optional: omit it for keyless local servers.
+Ollama runs models locally and serves them over an OpenAI-compatible HTTP API. Point the AI SDK's OpenAI provider at the local endpoint. `apiKey` is optional; omit it for keyless local servers.
 
 ```ts
 import { createOpenAI } from "@ai-sdk/openai";
 import { createAiSdkExecutors } from "@statelyai/agent/ai-sdk";
 
+// Model IDs here are illustrative; substitute your provider's current models.
 const ollama = createOpenAI({ baseURL: "http://localhost:11434/v1" });
 
 await runAgent(machine, {
@@ -87,13 +109,13 @@ await runAgent(machine, {
 });
 ```
 
-Swap `baseURL` (and add `apiKey` where the endpoint requires one) for Groq, vLLM, Together, OpenRouter, or LM Studio; nothing else changes.
+To use Groq, vLLM, Together, OpenRouter, or LM Studio, change `baseURL` and add `apiKey` where the endpoint requires one. Nothing else changes.
 
-If you would rather not depend on `ai` at all, write the three executors over raw `fetch` against the same Chat Completions endpoint: build the request body from the plain `AgentTextRequest` fields, and use `buildEnvelopeSchema`, `getJsonSchema`, and `parseOutput` from `@statelyai/agent` for structured output, plus `renderDecisionAttempts` for decision retries. See [Hosts](hosts.md#writing-your-own-executors).
+To avoid depending on `ai`, write the three executors over raw `fetch` against the same Chat Completions endpoint. Build the request body from the plain `AgentTextRequest` fields. Use `buildEnvelopeSchema`, `getJsonSchema`, and `parseOutput` from `@statelyai/agent` for structured output, and `renderDecisionAttempts` for decision retries. See [Hosts](hosts.md#writing-your-own-executors).
 
 ## Raw AI SDK functions
 
-The `generateText`/`streamText` executors accept the raw Vercel AI SDK functions directly, no adapter needed:
+The `generateText` and `streamText` executors accept the raw Vercel AI SDK functions directly. No adapter is needed.
 
 ```ts
 import { generateText, streamText } from "ai";
@@ -101,10 +123,10 @@ import { generateText, streamText } from "ai";
 await runAgent(machine, { input, executors: { generateText, streamText } });
 ```
 
-An `AgentTextRequest` is spread-compatible with the AI SDK's call options, and result shapes unwrap natively (`{ text }`; `{ textStream }`, final text via `await result.text`). Two caveats:
+An `AgentTextRequest` is spread-compatible with the AI SDK's call options. Result shapes unwrap natively: `{ text }` for `generateText`, and `{ textStream }` for `streamText`, whose final text is available via `await result.text`. This path has two limits.
 
-- **Structured output is best-effort.** A request with an `outputSchema` has its raw text `JSON.parse`d and validated; a parse failure throws. For reliable structured output, use `createAiSdkExecutors`.
-- **`decide` needs an adapter.** The tool-per-event mapping lives in the adapter; there is no raw AI SDK function for it.
+- Structured output is best-effort. A request with an `outputSchema` has its raw text parsed with `JSON.parse` and then validated. A parse failure throws. Use `createAiSdkExecutors` for reliable structured output.
+- `decide` requires the adapter. The tool-per-event mapping lives in the adapter, and there is no raw AI SDK function for it.
 
 ## Support by path
 
@@ -114,11 +136,11 @@ An `AgentTextRequest` is spread-compatible with the AI SDK's call options, and r
 | Raw `fetch` executors  | yes            | yes          | yes      | yes (you map it)  |
 | Raw `ai` functions     | yes            | yes          | no       | best-effort       |
 
-The `decide` executor maps each machine event to a forced tool call, and that mapping lives in the adapter layer, so raw `ai` functions cannot back a decision. For reliable structured output, use `createAiSdkExecutors` or map the envelope yourself. See [Text requests](text-requests.md) and [Decisions](decisions.md).
+The `decide` executor maps each machine event to a forced tool call. That mapping lives in the adapter layer, so raw `ai` functions cannot back a decision. For reliable structured output, use `createAiSdkExecutors` or map the envelope yourself. See [Text requests](text-requests.md) and [Decisions](decisions.md).
 
 ## Reference hosts by provider
 
-Runnable hosts, one per provider stack:
+Each example is a runnable host for one provider stack.
 
 | Example                                                                       | Backing                                                                                                           |
 | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
@@ -127,7 +149,3 @@ Runnable hosts, one per provider stack:
 | [anthropic-sdk-host](../examples/anthropic-sdk-host/index.ts)                 | raw `@anthropic-ai/sdk` (Messages); structured via forced tool call, decisions via `tool_choice: { type: 'any' }` |
 | [cloudflare-agent-host](../examples/cloudflare-agent-host/index.ts)           | Durable Object                                                                                                    |
 | [cloudflare-workers-ai-host](../examples/cloudflare-workers-ai-host/index.ts) | Workers AI binding                                                                                                |
-
-<!-- package entry points from package.json#exports -->
-
-Package entry points are `@statelyai/agent` (root), `@statelyai/agent/ai-sdk`, `@statelyai/agent/machines`, `@statelyai/agent/otel`, `@statelyai/agent/sqlite`, and `@statelyai/agent/agent-workflow.json`. Everything a hand-written host needs (`buildEnvelopeSchema`, `getJsonSchema`, `parseOutput`, `parseStructuredEnvelope`, `getAgentOutputMode`, `resolveDecision`, `renderDecisionAttempts`) comes from the root.

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -5,147 +5,32 @@ description: Compose agent machines today by invoking them as child actors, expo
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-An agent machine is an XState actor, so you compose agents with XState's existing actor patterns. No separate orchestration layer:
+This page covers how to compose several agent machines. An agent machine is an XState actor, so you use XState's existing actor patterns. There is no separate orchestration layer.
 
-- invoke one machine from another as a **child actor**
-- expose sub-agents as **host-owned tools**
-- let sibling machines coordinate by **sending events**
+There are three patterns:
 
-The machine decides, the [host](hosts.md) executes. Composition changes which machine is deciding, not who talks to the model.
+- Invoke one machine from another as a **child actor**.
+- Expose sub-agents as **host-owned tools**.
+- Let sibling machines coordinate by **sending events**.
 
-## Agent machines as child actors
+Composition changes which machine makes decisions. The [host](hosts.md) still executes every model call. Executor inheritance applies to all three patterns, so it is covered first.
 
-<!-- child-actor composition from examples/subflows/index.ts -->
-
-Register a child machine under `actors:` on the parent's `setupAgent(...)`, then invoke it by name. The parent treats the child like any other invoked actor: typed `input`, final output in `onDone`.
-
-[examples/subflows/index.ts](../examples/subflows/index.ts) delegates a topic to a research child this way:
-
-```ts
-const parentSetup = setupAgent({
-  context: z.object({ topic: z.string(), research: z.string().nullable() }),
-  input: z.object({ topic: z.string() }),
-  output: z.object({ research: z.string() }),
-  actors: { child: childMachine },
-});
-
-const subflowsMachine = parentSetup.createMachine({
-  context: ({ input }) => ({ topic: input.topic, research: null }),
-  initial: "delegating",
-  states: {
-    delegating: {
-      invoke: {
-        id: "child",
-        src: "child",
-        input: ({ context }: { context: { topic: string } }) => ({ topic: context.topic }),
-        onDone: ({ output }) => ({ target: "done", context: { research: output.research } }),
-      },
-    },
-    done: { type: "final", output: ({ context }) => ({ research: context.research ?? "" }) },
-  },
-});
-```
-
-The child is its own `setupAgent(...)` agent (`{ topic } -> { research }`); its `researchTopic` request inherits the parent run's executors automatically, no per-child binding (see [executor inheritance](#executor-inheritance) below).
-
-### Observing child actors
-
-<!-- onTransition vs inspect/inspectTransitions from src/run-agent.ts -->
-
-`runAgent` offers two ways to observe:
-
-- **`onTransition`** fires for the **root** machine's transitions only. Use it for parent progress.
-- **`inspect`** is the raw, system-wide stream (root, every invoked child, and spawned actors), so it is the only way to see a child's states. Attribute each event via `event.actorRef.id` (the invoke id) or `.src`.
-
-The `inspectTransitions(handler)` helper wraps `inspect`: it filters to `@xstate.transition` events and hands the handler the typed snapshot and actorRef, replacing the manual `event.type === '@xstate.transition'` check and casts.
-
-```ts
-import { inspectTransitions, runAgent } from "@statelyai/agent";
-
-await runAgent(parentMachine, {
-  executors,
-  onTransition: (snapshot) => console.log("parent:", snapshot.value),
-  inspect: inspectTransitions((snapshot, actorRef) => {
-    console.log(`[${actorRef.id}]`, snapshot.value); // child transitions included
-  }),
-});
-```
-
-[examples/subflows/index.ts](../examples/subflows/index.ts) contrasts the two channels side by side.
-
-## Sub-agents as host-owned tools
-
-<!-- host-owned sub-agent tools from examples/ai-sdk-sub-agents/index.ts -->
-
-A sub-agent need not be a machine. Here the machine sees a single text request with tools; the host makes those tools delegate to worker agents built with another framework.
-
-[examples/ai-sdk-sub-agents/index.ts](../examples/ai-sdk-sub-agents/index.ts) exposes `askResearcher` and `askWriter` tools whose `execute` calls a Vercel AI SDK `ToolLoopAgent` worker:
-
-```ts no-check
-requests: {
-  supervise: {
-    schemas: { input: taskInputSchema, output: answerSchema },
-    model: 'supervisor',
-    system: 'You are a supervisor. Use askResearcher for facts and askWriter for the final wording.',
-    prompt: ({ input }) => input.task,
-    tools: {
-      askResearcher: {
-        description: 'Ask the researcher sub-agent for notes.',
-        inputSchema: z.object({ prompt: z.string() }),
-        execute: createSubAgentExecute(subAgents, 'researcher'),
-      },
-      askWriter: { /* ...same shape, delegates to 'writer' */ },
-    },
-  },
-},
-```
-
-The machine stays portable: delegation lives entirely on the host side of the boundary.
-
-Beyond tools, the host can provide **any async actor**. The machine declares a named actor source; the host supplies its implementation. That actor can be a remote agent call, a queue round trip, or another framework's runtime. See [Hosts and executors](hosts.md).
-
-## Sibling coordination through events
-
-<!-- event-based sibling coordination from examples/debate-sub-agents/index.ts -->
-
-A parent can invoke several child agents at once and pass messages between them, using each child's `on:` handlers as its inbox. [examples/debate-sub-agents/index.ts](../examples/debate-sub-agents/index.ts) runs a debate this way:
-
-```ts no-check
-invoke: [
-  { id: 'affirmative', src: 'affirmative', input: ({ context }) => ({ stance: 'affirmative', question: context.question }) },
-  { id: 'negative', src: 'negative', input: ({ context }) => ({ stance: 'negative', question: context.question }) },
-],
-initial: 'requesting',
-states: {
-  requesting: {
-    always: ({ context, children }, enq) => {
-      const turn = turnAt(context.transcript.length);
-      enq.sendTo(children[turn.stance], {
-        type: 'DEBATE.ARGUMENT_REQUESTED',
-        round: turn.round,
-        transcript: context.transcript,
-      });
-      return { target: 'awaiting' };
-    },
-  },
-  // ...
-},
-```
-
-Each debater idles until it receives `DEBATE.ARGUMENT_REQUESTED`, composes an argument, and sends `DEBATE.ARGUMENT_SUBMITTED` back. The parent appends to a shared transcript and requests the next turn. Machines share state only through the messages they send.
+<!-- viz: three composition topologies side by side: parent invoking a child agent machine; one machine with host tools delegating to worker agents; a parent with two sibling children exchanging events -->
 
 ## Executor inheritance
 
 <!-- nested executor inheritance from src/run-agent.ts and examples/subflows -->
 
-`runAgent` rebinds the executors you pass (`generateText`/`streamText`/`decide`) onto every unbound agent request, **including requests inside invoked child machines, at any depth**.
+`runAgent` rebinds the executors you pass (`generateText`, `streamText`, `decide`) onto every unbound agent request. This includes requests inside invoked child machines, at any depth.
 
 - A child request inherits the same host-backed executors as the parent.
 - It shares the run's `maxModelCalls` budget, `onTrace`, `onChunk`, and `onResult`.
 
-One `executors: { generateText }` on `runAgent(parentMachine, ...)` covers the parent's requests and the child's.
+A single `executors: { generateText }` on `runAgent(parentMachine, ...)` covers both the parent's requests and the child's.
 
-The rules:
+How a child machine is referenced decides whether it inherits. Register the child under `actors` and invoke it by name, and its requests inherit. Pass the machine object inline as `invoke: { src: childMachine }`, and there is no string-keyed source for `runAgent` to replace, so its requests stay unbound.
+
+Inheritance follows these rules:
 
 | Case                                                                   | Inherits? | Why                                                                              |
 | ---------------------------------------------------------------------- | --------- | -------------------------------------------------------------------------------- |
@@ -155,11 +40,11 @@ The rules:
 | Logic object constructed inside an action                              | No        | Unregistered, so neither `runAgent` nor `provideExecutors` can see it            |
 | Direct-object child machine (`invoke: { src: childMachine }`)          | No        | No string-keyed source to replace. Register it under `actors` and invoke by name |
 
-**Missing executors fail fast.** If a reachable request needs an executor kind you didn't pass (e.g. a child's `mode: 'stream'` request but no `streamText`), binding throws before any actor runs, naming the invoke chain and request `src`.
+Missing executors fail fast. If a reachable request needs an executor kind you did not pass, such as a child's `mode: 'stream'` request when you passed no `streamText`, binding throws before any actor runs. The error names the invoke chain and the request `src`.
 
 ### Dynamic binding
 
-This works even though the branch count is known only at runtime:
+Inheritance also works when the branch count is known only at runtime.
 
 ```ts no-check
 const agentSetup = setupAgent({
@@ -187,9 +72,9 @@ const machine = agentSetup.createMachine({
 await runAgent(machine, { executors: { generateText } });
 ```
 
-`actors.worker` is the machine's current post-`provide` implementation. By the time the entry action runs, `runAgent` has replaced it with the host-bound worker. [The fan-out example](../examples/fan-out/index.ts) uses this exact shape.
+`actors.worker` is the machine's current implementation after `provide`. By the time the entry action runs, `runAgent` has replaced it with the host-bound worker. [The fan-out example](../examples/fan-out/index.ts) uses this shape.
 
-This does **not** inherit:
+The following does not inherit executors:
 
 ```ts no-check
 entry: ({ context }, enq) => {
@@ -198,36 +83,174 @@ entry: ({ context }, enq) => {
 };
 ```
 
-Register the logic and spawn it through `actors`, as above. Use `.withExecutor(...)` only when that one logic should deliberately carry its own host execution.
+Register the logic and spawn it through `actors`, as shown earlier. Use `.withExecutor(...)` only when that one logic should carry its own host execution.
 
 ### Child binding in uncontrolled mode
 
-[Controlled and uncontrolled](any-stack.md#controlled-and-uncontrolled) covers the two ways a host binds executors. The one composition delta: `runAgent` recursively binds registered child machines, `provideExecutors` binds only the machine passed to it. In uncontrolled mode, bind each machine explicitly and replace the parent's child source with the bound child:
+Read about the two ways a host binds executors in [Controlled and uncontrolled](any-stack.md#controlled-and-uncontrolled). Inheritance works the same way in both. `provideExecutors` binds registered child machines recursively, exactly as `runAgent` does, and each child machine is bound with its own schemas. The rules in the table above apply unchanged, so a direct-object child still inherits nothing.
 
 ```ts
-const boundChild = provideExecutors(childMachine, executors);
-const boundParent = provideExecutors(parentMachine, executors, {
-  actors: { child: boundChild },
-});
+const boundParent = provideExecutors(parentMachine, executors);
 
 createActor(boundParent, { input }).start();
 ```
 
-Dynamic spawning is equivalent under both APIs when the spawned source is registered on the machine being bound. The difference is recursive traversal into child machines, not whether the branch count is static or dynamic.
+Pass `options.actors` when you want to replace a child source with a specific implementation, such as a hand-bound child or a test double. `agent.userInput` is left unbound, so supply a handler through `options.actors` when the machine invokes it.
+
+Dynamic spawning behaves the same under both APIs when the spawned source is registered on the machine being bound. The only difference is recursive traversal into child machines. Whether the branch count is static or dynamic does not matter.
+
+## Agent machines as child actors
+
+<!-- child-actor composition from examples/subflows/index.ts -->
+
+Register a child machine under `actors:` on the parent's `setupAgent(...)`, then invoke it by name. The parent treats the child like any other invoked actor, with typed `input` and final output in `onDone`.
+
+[examples/subflows/index.ts](../examples/subflows/index.ts) delegates a topic to a research child.
+
+```ts
+const parentSetup = setupAgent({
+  context: z.object({ topic: z.string(), research: z.string().nullable() }),
+  input: z.object({ topic: z.string() }),
+  output: z.object({ research: z.string() }),
+  actors: { child: childMachine },
+});
+
+const subflowsMachine = parentSetup.createMachine({
+  context: ({ input }) => ({ topic: input.topic, research: null }),
+  initial: "delegating",
+  states: {
+    delegating: {
+      invoke: {
+        id: "child",
+        src: "child",
+        input: ({ context }: { context: { topic: string } }) => ({ topic: context.topic }),
+        onDone: ({ output }) => ({ target: "done", context: { research: output.research } }),
+      },
+    },
+    done: { type: "final", output: ({ context }) => ({ research: context.research ?? "" }) },
+  },
+});
+```
+
+The child is its own `setupAgent(...)` agent, taking `{ topic }` and returning `{ research }`. Its `researchTopic` request inherits the parent run's executors automatically, with no per-child binding. See [Executor inheritance](#executor-inheritance).
+
+### Observing child actors
+
+<!-- onTransition vs inspect/inspectTransitions from src/run-agent.ts -->
+
+`runAgent` offers two ways to observe:
+
+- `onTransition` fires for the root machine's transitions only. Use it for parent progress.
+- `inspect` is the raw, system-wide stream covering the root, every invoked child, and spawned actors. It is the only way to see a child's states. Attribute each event with `event.actorRef.id`, which is the invoke id, or with `event.actorRef.src`.
+
+The `inspectTransitions(handler)` helper wraps `inspect`. It filters to `@xstate.transition` events and passes the handler a typed snapshot and actorRef, so you do not write the type check and casts yourself.
+
+```ts
+import { inspectTransitions, runAgent } from "@statelyai/agent";
+
+await runAgent(parentMachine, {
+  executors,
+  onTransition: (snapshot) => console.log("parent:", snapshot.value),
+  inspect: inspectTransitions((snapshot, actorRef) => {
+    console.log(`[${actorRef.id}]`, snapshot.value); // child transitions included
+  }),
+});
+```
+
+[examples/subflows/index.ts](../examples/subflows/index.ts) uses both channels side by side.
+
+## Sub-agents as host-owned tools
+
+<!-- host-owned sub-agent tools from examples/ai-sdk-sub-agents/index.ts -->
+
+A sub-agent does not have to be a machine. In this pattern the machine sees a single text request with tools, and the host implements those tools by delegating to worker agents built with another framework.
+
+[examples/ai-sdk-sub-agents/index.ts](../examples/ai-sdk-sub-agents/index.ts) exposes `askResearcher` and `askWriter` tools whose `execute` calls a Vercel AI SDK `ToolLoopAgent` worker.
+
+```ts no-check
+requests: {
+  supervise: {
+    schemas: { input: taskInputSchema, output: answerSchema },
+    model: 'supervisor',
+    system: 'You are a supervisor. Use askResearcher for facts and askWriter for the final wording.',
+    prompt: ({ input }) => input.task,
+    tools: {
+      askResearcher: {
+        description: 'Ask the researcher sub-agent for notes.',
+        inputSchema: z.object({ prompt: z.string() }),
+        execute: createSubAgentExecute(subAgents, 'researcher'),
+      },
+      askWriter: { /* ...same shape, delegates to 'writer' */ },
+    },
+  },
+},
+```
+
+Delegation lives entirely on the host side of the boundary, so the machine stays portable.
+
+The host can also provide any async actor, not only tools. The machine declares a named actor source and the host supplies its implementation. That actor can be a remote agent call, a queue round trip, or another framework's runtime. See [Hosts and executors](hosts.md).
+
+## Sibling coordination through events
+
+<!-- event-based sibling coordination from examples/debate-sub-agents/index.ts -->
+
+A parent can invoke several child agents at once and pass messages between them. Each child's `on:` handlers act as its inbox. [examples/debate-sub-agents/index.ts](../examples/debate-sub-agents/index.ts) runs a debate this way.
+
+Turn order is a plain function of the transcript length, so the parent holds no extra state.
+
+```ts no-check
+// Whose turn it is at transcript position `index`: A, B, A, B, …
+function turnAt(index: number) {
+  return {
+    stance: index % 2 === 0 ? 'affirmative' : 'negative',
+    round: Math.floor(index / 2) + 1,
+  } as const;
+}
+
+invoke: [
+  { id: 'affirmative', src: 'affirmative', input: ({ context }) => ({ stance: 'affirmative', question: context.question }) },
+  { id: 'negative', src: 'negative', input: ({ context }) => ({ stance: 'negative', question: context.question }) },
+],
+initial: 'requesting',
+states: {
+  requesting: {
+    always: ({ context, children }, enq) => {
+      const turn = turnAt(context.transcript.length);
+      enq.sendTo(children[turn.stance], {
+        type: 'DEBATE.ARGUMENT_REQUESTED',
+        round: turn.round,
+        transcript: context.transcript,
+      });
+      return { target: 'awaiting' };
+    },
+  },
+  awaiting: {
+    on: {
+      'DEBATE.ARGUMENT_SUBMITTED': ({ context, event }) => {
+        const transcript = [
+          ...context.transcript,
+          { stance: event.stance, round: event.round, text: event.text },
+        ];
+        // Two turns per round.
+        return transcript.length >= context.rounds * 2
+          ? { target: 'concluding', context: { transcript } }
+          : { target: 'requesting', context: { transcript } };
+      },
+    },
+  },
+  // ...
+},
+```
+
+Each debater idles until it receives `DEBATE.ARGUMENT_REQUESTED`, composes an argument, and sends `DEBATE.ARGUMENT_SUBMITTED` back. The parent appends the argument to the shared transcript and requests the next turn. Machines share state only through the messages they send.
+
+<!-- viz: debate parent machine: requesting -> awaiting loop, with DEBATE.ARGUMENT_REQUESTED sent to the current stance child and DEBATE.ARGUMENT_SUBMITTED returning -->
 
 ## Fan-out
 
-This alpha ships no dedicated fan-out primitive. Use XState dynamic spawn when each branch should be a visible child actor with independent progress and persisted identity:
+This alpha ships no dedicated fan-out primitive. Use XState dynamic spawn when each branch should be a visible child actor with independent progress and persisted identity. That is the `enq.spawn(actors.worker, ...)` shape shown in [Dynamic binding](#dynamic-binding).
 
-```ts no-check
-entry: ({ context, actors }, enq) => {
-  context.jobs.forEach((job, index) => {
-    enq.spawn(actors.worker, { id: `worker-${index}`, input: { job } });
-  });
-};
-```
-
-Use `Promise.all(...)` inside a host actor or tool when the branches are implementation detail and the machine only needs their combined result. See [fan-out](../examples/fan-out/index.ts) for visible dynamic branches and [deep research](../examples/deep-research/index.ts) for a larger planner-worker-reducer flow.
+Use `Promise.all(...)` inside a host actor or tool when the branches are an implementation detail and the machine only needs their combined result. See [fan-out](../examples/fan-out/index.ts) for visible dynamic branches, and [deep research](../examples/deep-research/index.ts) for a larger planner-worker-reducer flow.
 
 ## Related
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -5,19 +5,26 @@ description: Watch an agent run locally in the Stately Inspector, ship its versi
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-Two ways to observe a run:
+This page covers how to watch an agent run, in development and in production, and how the trace stream relates to the replayable event log.
 
-- **Locally**, watch it live in the [Stately Inspector](https://stately.ai/docs/inspector), a browser-based viewer that renders a running state machine as a diagram and lights it up state by state.
-- **In production**, ship the versioned trace stream to any [OpenTelemetry](https://opentelemetry.io) backend with the [`@statelyai/agent/otel`](#otel-export) bridge: one handler, GenAI-semconv spans, your exporter. OpenTelemetry is the vendor-neutral standard for traces; Honeycomb, Langfuse, LangSmith, Braintrust, Datadog, and Grafana all ingest it.
+There are two ways to observe a run.
 
-No hosted platform, no adapter to install. Every trace pairs with a replayable event log and settled snapshot, so a traced run can be reproduced and resumed.
+- Locally, watch it live in the [Stately Inspector](https://stately.ai/docs/inspector). The inspector is a browser-based viewer that renders a running state machine as a diagram and highlights each state as it is entered.
+- In production, ship the versioned trace stream to any [OpenTelemetry](https://opentelemetry.io) backend with the [`@statelyai/agent/otel`](#otel-export) bridge. OpenTelemetry is the vendor-neutral standard for traces. Honeycomb, Langfuse, LangSmith, Braintrust, Datadog, and Grafana all ingest it.
 
-Two streams, not one:
+Neither requires a hosted platform or an installed adapter. Every trace pairs with a replayable event log and a settled snapshot, so a traced run can be reproduced and resumed.
 
-- **`result.events`**, the replay record: a versioned `AgentLogEntry[]` of machine input, effect completions/failures, externally sent events, and timer firings. Each entry has stable identity, acceptance time, machine identity/version, and verification hashes.
-- **`AgentTraceEvent[]`**, the richer observational stream described below: request lifecycle, chunks, transitions, emissions, timestamps, run boundaries.
+A run produces two separate streams.
 
-Feed only `result.events` to `replay`, never trace events. See [The event log](event-log.md#export-events-from-runagent).
+- `result.events` is the replay record. It is a versioned `AgentLogEntry[]` of machine input, effect completions and failures, externally sent events, and timer firings. Each entry carries a stable identity, an acceptance time, the machine identity and version, and verification hashes.
+- `AgentTraceEvent[]` is the observational stream described on this page. It covers the request lifecycle, chunks, transitions, emissions, timestamps, and run boundaries.
+
+Pass only `result.events` to `replay`. Trace events are not a replay record. See [The event log](event-log.md#export-events-from-runagent).
+
+<!-- viz: run observation surfaces: runAgent emitting onTrace / onTransition / on / onEvent / inspect, and where each one feeds (OTel bridge, inspector, replay log) -->
+
+<!-- viz: trace event sequence for one run: run.start -> request.start -> stream.chunk* -> request.end -> machine.transition -> run.end -->
+
 
 ## The versioned trace stream
 
@@ -30,11 +37,13 @@ The `onTrace` callback fires a single ordered stream of `AgentTraceEvent`s. Ever
 | `seq`            | Monotonic within a `runId`, so events are re-orderable after the fact.                                                                                                           |
 | `timestamp`      | ISO string, set when the event is produced.                                                                                                                                      |
 | `machineId`      | The machine's `id`.                                                                                                                                                              |
-| `machineVersion` | `machineVersion` option, else the machine's own `version` (`createMachine({ version })`), else its structural hash. Same identity stamped onto settled snapshots as `agentMeta`. |
+| `machineVersion` | The machine's version. See the fallback order below.                                                                                                                            |
 
-`schemaVersion` is bumped **only** on a breaking change to the envelope or a payload shape, so a consumer can gate on it. It is identical across `runAgent`, `provideExecutors`, and `traceTransitions`.
+`machineVersion` is the machine's own `version` from `createMachine({ version })`. A machine that declares no version falls back to its structural hash. The same identity is stamped onto settled snapshots as `agentMeta`.
 
-The payload is a discriminated union on `type`:
+`schemaVersion` is bumped only on a breaking change to the envelope or to a payload shape, so a consumer can gate on it. It is identical across `runAgent`, `provideExecutors`, and `traceTransitions`.
+
+The payload is a discriminated union on `type`.
 
 | `type`               | Key fields                                              | Notes                                                                                                                                                                    |
 | -------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -47,9 +56,9 @@ The payload is a discriminated union on `type`:
 | `emit`               | `event`                                                 | An event the machine emitted with `enq.emit(...)`; controlled path only.                                                                                                 |
 | `run.end`            | `status` (`done` \| `idle` \| `error`) + variant fields | `done`: `output`, `snapshot`. `idle`: `snapshot`, `pendingUserInputs?`, `persistedSnapshot?`. `error`: `cause`, `error`, `snapshot`. Run boundary; controlled path only. |
 
-Each `request` is an `AgentStepRequest`: a text request carries `src`; a decision carries `model` instead. Both carry `id` and `kind`.
+Each `request` is an `AgentStepRequest`. A text request carries `src`, and a decision carries `model` instead. Both carry `id` and `kind`.
 
-Two timestamps, neither of them machine time:
+Two timestamps appear in the system, and neither is machine time.
 
 - Trace `timestamp` records when an observation was emitted.
 - Replay-entry `recordedAt` records when the host accepted the durable machine input.
@@ -60,7 +69,7 @@ Put time in the event payload when transition logic depends on it.
 
 ### Controlled (`runAgent`)
 
-On `runAgent`, `onTrace` emits the full stream, run boundary included:
+On `runAgent`, `onTrace` emits the full stream, including run boundaries.
 
 ```ts
 import { runAgent, serializeTraceEvent, type AgentTraceEvent } from "@statelyai/agent";
@@ -72,11 +81,11 @@ await runAgent(machine, {
 });
 ```
 
-`serializeTraceEvent(event)` returns a JSONL-safe plain-JSON form, stripping values that don't survive `JSON.stringify` (actor refs, snapshot internals). Use it for any file, queue, or wire sink; skip it for in-process consumers that want the live objects.
+`serializeTraceEvent(event)` returns a JSONL-safe plain-JSON form. It strips values that do not survive `JSON.stringify`, such as actor refs and snapshot internals. Use it for any file, queue, or wire sink. Skip it for in-process consumers that want the live objects.
 
 ### Streaming with `createAgentRun`
 
-`createAgentRun(machine, options)` wraps `runAgent` in a handle that exposes the same trace stream as an async iterator, alongside the same `result` promise:
+`createAgentRun(machine, options)` wraps `runAgent` in a handle that exposes the same trace stream as an async iterator, alongside the same `result` promise.
 
 ```ts
 import { createAgentRun } from "@statelyai/agent";
@@ -91,18 +100,18 @@ for await (const event of run.events) {
 const result = await run.result; // done | idle | error, exactly as runAgent
 ```
 
-- **Starts immediately**: the run is in flight when `createAgentRun` returns, not on first iteration.
-- **Buffered, never blocking**: events are queued unboundedly, so a slow or absent consumer never applies backpressure to the run. Await `result` first and drain `events` after if you prefer.
-- **Completes after `run.end`**: the iterator yields `run.end`, then finishes. It also closes if the run settles without one (a bind-time throw).
-- **`result` mirrors `runAgent`**: same `done | idle | error` value, and it rejects only where `runAgent` rejects (bind-time programmer errors like a missing executor or an illegal resume event). A run-level failure resolves with `{ status: 'error' }`.
-- **`onTrace` still fires**: pass `options.onTrace` and it receives every event too. The wrapper composes, it does not replace your sink.
-- **Resumes identically**: options pass straight through, so a persisted `snapshot` (+ resume `event`) streams that run from its own `run.start`.
+- The run starts immediately. It is in flight when `createAgentRun` returns, not on the first iteration.
+- Events are buffered and never block. The queue is unbounded, so a slow or absent consumer applies no backpressure to the run. You can await `result` first and drain `events` afterwards.
+- The iterator yields `run.end` and then finishes. It also closes if the run settles without a `run.end`, such as after a bind-time throw.
+- `result` mirrors `runAgent`. It resolves to the same `done | idle | error` value and rejects only where `runAgent` rejects, on bind-time programmer errors such as a missing executor or an illegal resume event. A run-level failure resolves with `{ status: 'error' }`.
+- `onTrace` still fires. Pass `options.onTrace` and it receives every event as well. The wrapper composes with your sink rather than replacing it.
+- Resume behaves the same. Options pass straight through, so a persisted `snapshot` and resume `event` stream that run from its own `run.start`.
 
-`events` is single-consumer: a second `for await` picks up only what the first hasn't pulled, one shared cursor rather than a replay. Breaking out early (or calling `events.return()`) stops delivery but does **not** cancel the run (`result` still settles), so pass `options.signal` to abort the work itself.
+`events` has a single consumer. A second `for await` picks up only what the first has not pulled, because the two share one cursor. Breaking out early, or calling `events.return()`, stops delivery but does not cancel the run, and `result` still settles. Pass `options.signal` to abort the work itself.
 
 ### Uncontrolled (`provideExecutors` + `traceTransitions`)
 
-On the [uncontrolled path](any-stack.md#controlled-and-uncontrolled), `provideExecutors`' `onTrace` emits the request-level events; `traceTransitions` on the actor's `inspect` folds `machine.transition` events into the **same** `runId`/`seq` stream:
+On the [uncontrolled path](any-stack.md#controlled-and-uncontrolled), `onTrace` on `provideExecutors` emits the request-level events. `traceTransitions` on the actor's `inspect` folds `machine.transition` events into the same `runId` and `seq` stream.
 
 ```ts
 import { createActor } from "xstate";
@@ -120,23 +129,23 @@ const actor = createActor(bound, { inspect: traceTransitions(onTrace) });
 actor.start();
 ```
 
-The tracing gap, compared to `runAgent`:
+This path traces less than `runAgent` does.
 
-- **No `run.start` / `run.end`.** A `createActor` has no run boundary, so the stream starts at the first transition and never emits a settle event.
-- **No `emit` events.** In this XState build, emitted events are delivered through `actor.on(...)`, not the inspection protocol, so an `inspect` handler can't see them. Subscribe with `actor.on('*', ...)` if you need them.
-- **No child traces.** `provideExecutors` does not descend into invoked child machines, so a child with its own agent invokes needs its own `provideExecutors(...)` call and its own stream.
+- There is no `run.start` or `run.end`. A `createActor` has no run boundary, so the stream starts at the first transition and never emits a settle event.
+- There are no `emit` events. In this XState build, emitted events are delivered through `actor.on(...)` rather than the inspection protocol, so an `inspect` handler cannot see them. Subscribe with `actor.on('*', ...)` if you need them.
+- There are no child traces. `provideExecutors` does not descend into invoked child machines, so a child with its own agent invokes needs its own `provideExecutors(...)` call and its own stream.
 
 ## Observation callbacks
 
-`onTrace` is one of several `runAgent` callbacks. All are purely observational: they return `void` and cannot control the run.
+`onTrace` is one of several `runAgent` callbacks. All of them are observational only. They return `void` and cannot control the run.
 
-- **`onTrace(event)`**: the whole ordered run ledger described above (the eval trace / JSONL / telemetry slot). Uncontrolled mode gets the same stream via `provideExecutors` + `traceTransitions`.
-- **`onChunk(chunk, info)`**: each streamed chunk of a `mode: 'stream'` request, with the `AgentRequest` that produced it (parallel streams stay distinguishable).
-- **`onResult(request, result)`**: once per resolved text or decision request (decision retries fire per attempt), with normalized `result.output` and the verbatim executor result in `result.raw`. Return `usage` alongside `output` and `raw` becomes your token meter; the shipped adapter does, so `raw as AiSdkGenerateResult` carries `usage`, `finishReason`, `toolCalls`, `toolResults`.
-- **`onEvent(entry)`**: each newly created versioned `AgentLogEntry` around a replayable external input. Entries are JSON-validated and carry ids, timestamps, machine identity/version, and replay hashes; seeded resume history is not re-emitted.
-- **`onTransition(snapshot, event)`**: every machine transition, with the new snapshot and causing event.
-- **`on: { EVENT: handler, '*': handler }`**: events the machine emits with `enq.emit(...)`, keyed by emitted event type (`'*'` catches all).
-- **`inspect(inspectionEvent)`**: raw xstate inspection passthrough for the whole actor system (also how the [Stately Inspector](#local-inspection) attaches). `onTransition` covers the root only; to watch a child machine's states (see [multi-agent](multi-agent.md)), filter `inspectionEvent.type === '@xstate.transition'` and read `inspectionEvent.actorRef`. The `inspectTransitions(handler)` helper does that filtering and hands over the typed snapshot + actorRef.
+- `onTrace(event)` receives the versioned trace stream described above. Use it for eval traces, JSONL logs, and telemetry.
+- `onChunk(chunk, info)` receives each streamed chunk of a `mode: 'stream'` request, along with the `AgentRequest` that produced it. Parallel streams stay distinguishable.
+- `onResult(request, result)` fires once per resolved text or decision request, and once per attempt for decision retries. `result.output` is the normalized output and `result.raw` is the verbatim executor result. If your executor returns `usage` alongside `output`, `raw` carries it. The shipped adapter does, so `raw as AiSdkGenerateResult` carries `usage`, `finishReason`, `toolCalls`, and `toolResults`.
+- `onEvent(entry)` receives each newly created versioned `AgentLogEntry` around a replayable external input. Entries are JSON-validated and carry ids, timestamps, machine identity and version, and replay hashes. Seeded resume history is not re-emitted.
+- `onTransition(snapshot, event)` receives every machine transition, with the new snapshot and the causing event.
+- `on: { EVENT: handler, '*': handler }` receives events the machine emits with `enq.emit(...)`, keyed by emitted event type. `'*'` catches all of them.
+- `inspect(inspectionEvent)` is a raw XState inspection passthrough for the whole actor system. The [Stately Inspector](#local-inspection) attaches this way. `onTransition` covers the root machine only. To watch a child machine's states, filter for `inspectionEvent.type === '@xstate.transition'` and read `inspectionEvent.actorRef`. The `inspectTransitions(handler)` helper does that filtering and passes a typed snapshot and actorRef. See [Multi-agent composition](multi-agent.md).
 
 ```ts
 await runAgent(machine, {
@@ -151,15 +160,15 @@ await runAgent(machine, {
 });
 ```
 
-`onEvent` is write-through observation, not transactional durability: the live XState actor has already accepted the event, and this synchronous callback cannot await an asynchronous store before the transition. For append-before-continue crash safety, use [the step path](steps.md#durable-append-before-continue), where the host commits each completion envelope before exposing the derived state.
+`onEvent` is write-through observation, not transactional durability. The live XState actor has already accepted the event, and this synchronous callback cannot await an asynchronous store before the transition happens. For append-before-continue crash safety, use [the step path](steps.md#durable-append-before-continue), where the host commits each completion envelope before exposing the derived state.
 
-`onTrace`, `onTransition`, and `on` differ in level:
+`onTrace`, `onTransition`, and `on` observe at different levels.
 
-- `onTrace`: the whole ordered run ledger (evals, exports).
-- `onTransition`: XState's terms (state values, events).
-- `on`: the domain events the machine emits at authored moments (a progress UI, an SSE stream, a log line).
+- `onTrace` gives every event in the run, in order. Use it for evals and exports.
+- `onTransition` gives XState terms: state values and events.
+- `on` gives the domain events the machine emits at authored moments. Use it for a progress UI, an SSE stream, or a log line.
 
-Declare emitted schemas in `setupAgent` and both `enq.emit(...)` and the `on` handlers are fully typed:
+Declare emitted schemas in `setupAgent` and both `enq.emit(...)` and the `on` handlers are fully typed.
 
 ```ts no-check
 const agentSetup = setupAgent({
@@ -177,17 +186,17 @@ onDone: ({ context, output }, enq) => {
 },
 ```
 
-Emitted events are fire-and-forget observation, not control flow: they never target states, and a run behaves identically with no handlers attached.
+Emitted events are fire-and-forget observation, not control flow. They never target states, and a run behaves identically with no handlers attached.
 
 ## Local inspection
 
-The Stately Inspector is a live diagram view of a running machine: connect a run to it and every transition highlights as it happens. Point a run at it through `runAgent`'s `inspect` option (a raw XState inspection passthrough: system-wide, children included), using `createInspector` from [`@statelyai/sdk`](https://www.npmjs.com/package/@statelyai/sdk).
+The Stately Inspector is a live diagram view of a running machine. Connect a run to it and every transition highlights as it happens. Point a run at it through `runAgent`'s `inspect` option, using `createInspector` from [`@statelyai/sdk`](https://www.npmjs.com/package/@statelyai/sdk). `inspect` is a raw XState inspection passthrough, so it covers the whole actor system, children included.
 
-`createInspector`:
+`createInspector` does the following:
 
-- runs from Node and other server runtimes, with no in-browser machine required
-- normalizes XState v5 and v6 inspection events
-- opens the inspector UI in your browser once connected, unless you set `autoOpen: false`
+- Runs from Node and other server runtimes. No in-browser machine is required.
+- Normalizes XState v5 and v6 inspection events.
+- Opens the inspector UI in your browser once connected, unless you set `autoOpen: false`.
 
 ```ts
 import { createInspector } from "@statelyai/sdk";
@@ -201,21 +210,21 @@ const inspector = createInspector({
 await runAgent(machine, {
   input,
   executors,
-  inspect: inspector.inspect, // the machine lights up in the inspector
+  inspect: inspector.inspect,
 });
 
 inspector.destroy();
 ```
 
-`inspector.roomId`, `relayUrl`, and `inspectorUrl` describe the negotiated room; let the SDK construct them instead of hand-writing registration messages or actor identifiers.
+`inspector.roomId`, `relayUrl`, and `inspectorUrl` describe the negotiated room. Let the SDK construct them instead of writing registration messages or actor identifiers by hand.
 
-For serverless/edge runtimes (Cloudflare Workers/Durable Objects), `@statelyai/sdk/relay` ships `createInspectionRelay`, a runtime-neutral relay with bounded late-join replay that a Durable Object can host directly, so per-request lifetimes and hibernation don't break the stream.
+For serverless and edge runtimes such as Cloudflare Workers and Durable Objects, `@statelyai/sdk/relay` ships `createInspectionRelay`. It is a runtime-neutral relay with bounded late-join replay that a Durable Object can host directly, so per-request lifetimes and hibernation do not break the stream.
 
-The inspector renders the running actor as the same diagram you author, so the whole flow is visible as one live machine. See [`examples/email-drafter-inspector`](../examples/email-drafter-inspector/index.ts) for a full session (it keeps one long-lived actor instead of the `runAgent` loop, but the wiring is identical).
+The inspector renders the running actor as the same diagram you author, so the whole flow is visible as one live machine. See [`examples/email-drafter-inspector`](../examples/email-drafter-inspector/index.ts) for a full session. That example keeps one long-lived actor instead of using the `runAgent` loop, but the inspector wiring is identical.
 
 ## OTel export
 
-OpenTelemetry models work as **spans**: timed, nested units that carry attributes, which an exporter ships to whatever backend you use. `@statelyai/agent/otel` maps the trace stream onto [OpenTelemetry GenAI](https://github.com/open-telemetry/semantic-conventions-genai) spans, the standard's conventions for model calls and agent runs. That is the whole integration: pass a `tracer` from **your existing SDK setup** and hand the handler to `onTrace`.
+OpenTelemetry models work as **spans**, which are timed, nested units that carry attributes. An exporter ships them to your backend. `@statelyai/agent/otel` maps the trace stream onto [OpenTelemetry GenAI](https://github.com/open-telemetry/semantic-conventions-genai) spans, the standard's conventions for model calls and agent runs. To integrate, pass a `tracer` from your existing SDK setup and pass the returned handler to `onTrace`.
 
 ```sh
 npm install @opentelemetry/api
@@ -238,7 +247,7 @@ try {
 }
 ```
 
-**Ships no exporter, owns no SDK lifecycle.** `@opentelemetry/api` is an optional peer dependency, the `Tracer` is yours, and where the spans go is your exporter's business. Nothing else is installed at runtime.
+The bridge ships no exporter and owns no SDK lifecycle. `@opentelemetry/api` is an optional peer dependency, you own the `Tracer`, and your exporter decides where the spans go. Nothing else is installed at runtime.
 
 The run span nests under whatever span is active when the run starts, so an agent run inside an HTTP handler lands in that request's trace.
 
@@ -270,13 +279,13 @@ Attributes follow the [GenAI semantic conventions](https://github.com/open-telem
 | `agent.request_id`, `agent.request_kind`, `agent.request_src`, `agent.request_attempt`    | The request. `request_src` is absent on a decision; `request_attempt` appears on a retry. |
 | `agent.seq`                                                                               | Every span event, so events stay re-orderable downstream.                                 |
 
-- **No prompt or response bodies by default.** Semconv marks message content opt-in, and bodies are large and frequently sensitive, so the bridge records output _sizes_ (`agent.output_length`) instead. Pass `captureContent: true` for JSON-stringified `gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions`.
-- **`dispose()` is not optional.** It ends any span still open, which is how a run that never emitted `run.end` (a crash, an uncontrolled actor) stops leaking one.
-- **`attributes`** sets the same key/values on every span the bridge creates: deployment, tenant, eval id.
+- The bridge records no prompt or response bodies by default. Semconv marks message content opt-in, and bodies are large and often sensitive, so the bridge records output sizes as `agent.output_length` instead. Pass `captureContent: true` to record JSON-stringified `gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions`.
+- Always call `dispose()`. It ends any span still open, so a run that never emitted `run.end`, after a crash or on an uncontrolled actor, does not leak one.
+- `attributes` sets the same key/value pairs on every span the bridge creates, such as deployment, tenant, or eval id.
 
 ### Uncontrolled mode
 
-On the [uncontrolled path](#uncontrolled-provideexecutors--tracetransitions) there is no `run.start` / `run.end`, so the run span opens on the **first** event of a `runId` and stays open until you dispose. Same handler, same tree:
+The uncontrolled path traces less than `runAgent` does, as described in [Uncontrolled](#uncontrolled-provideexecutors--tracetransitions). One of those gaps changes the span tree: with no `run.start` or `run.end`, the run span opens on the first event of a `runId` and stays open until you dispose the handler. The handler is otherwise the same.
 
 ```ts
 const tracer = new NodeTracerProvider().getTracer("my-app");
@@ -288,17 +297,17 @@ actor.subscribe({ complete: () => onTrace.dispose() });
 actor.start();
 ```
 
-Those run spans carry `agent.unfinished: true` (no settle event ever confirmed how they ended) and no `agent.status`. One handler per long-lived actor, disposed when the actor stops, keeps handler state bounded.
+Those run spans carry `agent.unfinished: true` and no `agent.status`, because no settle event confirmed how they ended. Use one handler per long-lived actor and dispose it when the actor stops. This keeps handler state bounded.
 
 ### Vendor endpoints
 
-The bridge emits plain OTel spans, so a vendor is a **URL and a set of headers** on your own exporter. Nothing in the wiring above changes per vendor, and no vendor SDK enters your machine.
+The bridge emits plain OTel spans, so a vendor is a URL and a set of headers on your own exporter. Nothing in the wiring above changes per vendor, and no vendor SDK enters your machine.
 
 ```sh
 npm install @opentelemetry/sdk-trace-node @opentelemetry/exporter-trace-otlp-http
 ```
 
-One wiring, with the vendor's URL and headers swapped in:
+The wiring is the same for every vendor. Substitute the vendor's URL and headers.
 
 ```ts
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
@@ -313,7 +322,7 @@ const provider = new NodeTracerProvider({ spanProcessors: [new BatchSpanProcesso
 const onTrace = createOtelTraceHandler({ tracer: provider.getTracer("my-app") });
 ```
 
-Endpoints and header names drift, so each vendor's linked docs page is the authority.
+Endpoints and header names change over time. Each vendor's linked docs page is the authority.
 
 | Vendor     | Endpoint                                               | Headers                                                                                 | Docs                                                                                |
 | ---------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
@@ -325,42 +334,44 @@ Endpoints and header names drift, so each vendor's linked docs page is the autho
 
 - Regional hosts swap the subdomain: LangSmith `eu.`/`apac.`/`aws.`, Braintrust `api-eu.`, Langfuse `us.`/`jp.`/`hipaa.` or self-hosted, Honeycomb `api.eu1.`.
 - Datadog's host depends on your site, and Datadog still recommends the Agent or Collector for production traffic. Its `trace.agent.datadoghq.com` intake is proprietary, not OTLP.
-- Braintrust also runs the offline scoring side; see [Evals](evals.md) for scoring the same runs from `runAgent`'s output and event log.
+- Braintrust also runs offline scoring. See [Evals](evals.md) for scoring the same runs from `runAgent`'s output and event log.
 
-See [`examples/langsmith-otel`](../examples/langsmith-otel/index.ts) for the full runnable wiring: real OTel SDK, real OTLP exporter, keyless run that prints the exported span tree.
+See [`examples/langsmith-otel`](../examples/langsmith-otel/index.ts) for the full runnable wiring. It uses a real OTel SDK and a real OTLP exporter, and prints the exported span tree from a keyless run.
 
 ### Model spans via AI SDK telemetry
 
-The `request.*` events span the model call as `runAgent` sees it: one span per request, with usage on `event.raw`. For provider-level detail (token timing, the exact request the SDK sent), the Vercel AI SDK emits its own OpenTelemetry spans when passed `experimental_telemetry`.
+The `request.*` events span the model call as `runAgent` sees it: one span per request, with usage on `event.raw`. For provider-level detail such as token timing and the exact request the SDK sent, the Vercel AI SDK emits its own OpenTelemetry spans when you pass `experimental_telemetry`.
 
-`createAiSdkExecutors` does **not** forward `experimental_telemetry` (request `metadata` only carries adapter conventions like `maxSteps`). Enable it by supplying the text executors yourself (the raw `ai` functions are valid executors; see [models and providers](models-and-providers.md#reusing-models-from-other-frameworks)) and keeping the adapter's `decide`:
+`createAiSdkExecutors` does not forward `experimental_telemetry`. Wrap the adapter's `generateText` instead of replacing it: open your own span, call through to the adapter, and end the span when the call settles. The adapter keeps handling structured output, tool loops, and `decide`.
 
-```ts no-check
-import { generateText, streamText } from "ai";
+```ts
+import { trace } from "@opentelemetry/api";
 import { createAiSdkExecutors } from "@statelyai/agent/ai-sdk";
+import { runAgent, type AgentRequestExecutors } from "@statelyai/agent";
 
-const telemetry = { isEnabled: true, functionId: "agent" } as const;
+const adapter = createAiSdkExecutors({ models });
+const tracer = trace.getTracer("my-app");
 
-const executors = {
-  ...createAiSdkExecutors({ models }), // keeps decide (and structured output)
+const executors: AgentRequestExecutors = {
+  ...adapter,
   generateText: (request, info) =>
-    generateText({
-      model: resolveModel(request.model),
-      system: request.system,
-      prompt: request.prompt ?? "",
-      abortSignal: info?.signal,
-      experimental_telemetry: telemetry,
+    tracer.startActiveSpan(`model ${request.model}`, async (span) => {
+      try {
+        return await adapter.generateText(request, info);
+      } finally {
+        span.end();
+      }
     }),
 };
 
 await runAgent(machine, { input, executors });
 ```
 
-Trade-off: raw `ai` executors do structured output best-effort (`JSON.parse` + validate), so keep `createAiSdkExecutors`' `generateText` for reliable structured requests and add telemetry per-request via a wrapper only where you need the provider spans. The AI SDK's spans nest under whatever span is active when the executor runs, so they slot beneath the bridge's `chat` span for that request.
+Any span the AI SDK emits inside the call nests under whatever span is active when the executor runs, so provider spans appear beneath both your wrapper span and the bridge's `chat` span for that request.
 
 ## Replay from a trace
 
-A trace names a run; a snapshot resumes it. The `runId` scoping the trace stream also identifies the settled snapshot: capture the `runId` off any trace event, store the settled snapshot under it, and later resume exactly what you traced.
+The `runId` that scopes the trace stream also identifies the settled snapshot. Capture the `runId` from any trace event, store the settled snapshot under it, and resume that run later.
 
 ```ts
 let runId: string | undefined;
@@ -374,11 +385,11 @@ const result = await runAgent(machine, {
 });
 
 if (result.status === "idle" && runId) {
-  // Persist keyed by the run's identity; resume it later, event and all.
-  store.set(runId, persistSnapshot(result.persistedSnapshot ?? result.snapshot));
+  // Key the stored snapshot by runId.
+  store.set(runId, result.persistedSnapshot ?? result.snapshot);
 }
 
-// Later, same machine and same trace lineage:
+// Later, with the same machine:
 const resumed = await runAgent(machine, {
   snapshot: store.get(runId!),
   event: { type: "APPROVE" },
@@ -387,7 +398,7 @@ const resumed = await runAgent(machine, {
 });
 ```
 
-Because the snapshot is stamped with the same `machineVersion` the trace carries, a resume against a structurally changed machine is caught (see [Human in the loop](human-in-the-loop.md#persist-and-resume-across-processes)). A traced run is a reproducible run.
+The snapshot is stamped with the same `machineVersion` the trace carries, so a resume against a structurally changed machine is caught. Read more about resuming across processes in [Human in the loop](human-in-the-loop.md#persist-and-resume-across-processes).
 
 ## Related
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -5,80 +5,56 @@ description: Common agent patterns (ReAct, reflection, plan-and-execute, RAG, su
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-Every well-known agent pattern is a control-flow shape: a loop, a branch, a fan-out, a handoff. This library makes each one an explicit XState machine you can read, test, and run. Below is a use-case map: pick a pattern, open its example, copy the one file.
-
-## Lifting an example
-
-Each pattern is a single self-contained `index.ts`: no shared harness, no local imports. To lift one:
-
-1. Copy the one example file into your project as `index.ts`.
-2. Install the runtime deps (the provider package major must match your installed `ai` major; this repo is on `ai@6`, so `@ai-sdk/openai@3`, not 4):
-
-   ```sh
-   pnpm add @statelyai/agent@alpha ai@^6 zod@^4 xstate@6.0.0-alpha.25 @ai-sdk/openai@^3
-   pnpm add -D @types/node typescript tsx
-   ```
-
-3. The examples use Node globals (`process`, `console`, `import.meta.url`), so give TypeScript a `tsconfig.json` with `"module"`/`"moduleResolution"` set to `nodenext`, `"strict": true`, and `"types": ["node"]`.
-4. Run it: `OPENAI_API_KEY=... npx tsx index.ts` (or swap in [any host](hosts.md)).
-
-<!-- peer ranges from package.json#peerDependencies and example schema dependency from package.json#devDependencies -->
-
-Peer ranges from `@statelyai/agent`: `ai@^6.0.67`, `xstate@>=6.0.0-alpha.25 <6.0.0`, optional `@opentelemetry/api@^1`. The examples use Zod 4 directly. The `@alpha` tag floats, so pin the exact version it installs once you have a build that works.
-
-## Running from the repo
-
-Examples live under `examples/`, one flat directory per example with an `index.ts` entrypoint. Clone the repo, install, then run any one directly:
-
-```bash
-OPENAI_API_KEY=... npx tsx examples/<name>/index.ts
-```
-
-- Every example is dual-mode: run it against a real model as above, or drive it with injected mock executors in a test (no key, no network).
-- Most expect `OPENAI_API_KEY`; each file notes what it needs at the top. `anthropic-sdk-host` wants `ANTHROPIC_API_KEY`; the two Cloudflare examples target a Workers runtime, not Node/`tsx`.
-- Swap the host without touching the machine ([Use in any stack](any-stack.md)). The exhaustive index, with framework-comparison notes, is [examples/README.md](../examples/README.md).
+This page maps common agent patterns to runnable examples. Each pattern is a control-flow shape such as a loop, a branch, a fan-out, or a handoff, written as an explicit XState machine. Pick a pattern, open its example, and copy the file. Each section ends with a canonical example, meaning the smallest example that demonstrates the pattern completely. Start there. See [Lifting an example](#lifting-an-example) at the end of this page for the dependencies and TypeScript settings an example needs.
 
 ## Core ideas
 
-The core ideas: text requests, decisions, messages, and JSON authoring.
+These examples cover text requests, decisions, messages, and JSON authoring.
 
-- [twenty-questions](../examples/twenty-questions/index.ts): a decision loop where the model picks one legal event (ASK or GUESS) per turn; guard-enforced legality, machine-held score, play-again reset.
+- [twenty-questions](../examples/twenty-questions/index.ts): a decision loop where the model picks one legal event, ASK or GUESS, per turn. Legality is guard-enforced, the score lives in the machine, and a play-again transition resets it.
 - [joke](../examples/joke/index.ts): a minimal streaming text workflow.
-- [email-drafter](../examples/email-drafter/agent-logic.ts): reusable text logic, parts-based [messages](messages.md), schema-typed state and transition meta.
-- [game-agent](../examples/game-agent/index.ts): `allowedEvents` narrowed as a function of input, gating moves by HP.
-- [go-fish](../examples/go-fish/index.ts): hidden-information play with a checking-win → agent → human loop; the model chooses requests, the machine enforces the rules.
-- [json-agent](../examples/json-agent/index.ts): a full workflow (decision, text request, idle human step) authored as a real `.json` file. See [Machines as data](machines-as-data.md).
-- [described-workflow](../examples/described-workflow/index.ts): a plain XState machine with zero invokes (prompts live in state `description`s and `meta`), run via `runAgent`'s `getRequests` option.
+- [email-drafter](../examples/email-drafter/agent-logic.ts): reusable text logic, parts-based [messages](messages.md), and schema-typed state and transition meta.
+- [json-agent](../examples/json-agent/index.ts): a full workflow with a decision, a text request, and an idle human step, authored as a `.json` file. See [Machines as data](machines-as-data.md).
+- [described-workflow](../examples/described-workflow/index.ts): a plain XState machine with no invokes. Prompts live in state `description` and `meta` fields, and the machine runs through `runAgent`'s `getRequests` option.
 
-**Canonical example: [`twenty-questions`](../examples/twenty-questions/index.ts).**
+Start with [`twenty-questions`](../examples/twenty-questions/index.ts).
+
+### Games
+
+In a game, the machine owns turn order and move legality. The model picks among the moves the current state allows.
+
+- [game-agent](../examples/game-agent/index.ts): `allowedEvents` narrowed as a function of input, gating moves by HP.
+- [go-fish](../examples/go-fish/index.ts): hidden-information play with a check-win, agent, human loop. The model chooses requests and the machine enforces the rules.
 
 ## Reasoning and tool loops
 
-For tool use, start with **Tool calling**: your SDK runs the tool loop inside one request, in one machine state. **ReAct** is the same loop unrolled into explicit states, for when individual turns need gating (approval before a tool, a spend guard, a snapshot mid-loop).
+For tool use, start with tool calling, where your SDK runs the tool loop inside one request, in one machine state. ReAct is the same loop unrolled into explicit states. Use it when individual turns need gating, such as approval before a tool, a spend guard, or a snapshot mid-loop.
 
-- **Tool calling** ([tool-calling](../examples/tool-calling/index.ts)): the SDK's loop runs inside a state you control, bounded by `metadata.maxSteps`.
-- **ReAct** ([react-agent](../examples/react-agent/index.ts)): every turn is gateable, persistable, and inspectable, under a step-budget guard.
-- **Plan-and-execute** ([plan-and-execute](../examples/plan-and-execute/index.ts)): structured planner output; execution states iterate the plan.
-- **Reflection** ([reflection-writer](../examples/reflection-writer/index.ts)): generate and critique are two states; a guard caps revisions.
-- **Evaluator-optimizer** ([ai-sdk-evaluator-optimizer](../examples/ai-sdk-evaluator-optimizer/index.ts)): the scoring gate is a guard, so the loop terminates by construction.
-- **Self-correcting codegen** ([code-assistant](../examples/code-assistant/index.ts)): a sandboxed check actor and a `maxAttempts` bound ending in an explicit `failed` outcome.
-- **Tree search (LATS)** ([lats](../examples/lats/index.ts)): selection, expansion, and reflection scoring as separate states under a rollout budget.
+<!-- viz: tool calling vs ReAct: one state whose single request contains the SDK's internal tool loop, beside the same loop unrolled into think -> act -> observe states with a step-budget guard on the loop-back transition -->
 
-**Canonical example: [`react-agent`](../examples/react-agent/index.ts).**
+- Tool calling ([tool-calling](../examples/tool-calling/index.ts)): the SDK's loop runs inside a state you control, bounded by the request's `maxSteps`.
+- ReAct ([react-agent](../examples/react-agent/index.ts)): every turn can be gated, persisted, and inspected, under a step-budget guard.
+- Plan-and-execute ([plan-and-execute](../examples/plan-and-execute/index.ts)): the planner returns structured output, and execution states iterate the plan.
+- Reflection ([reflection-writer](../examples/reflection-writer/index.ts)): generate and critique are two states, and a guard caps revisions.
+- Evaluator-optimizer ([ai-sdk-evaluator-optimizer](../examples/ai-sdk-evaluator-optimizer/index.ts)): the scoring gate is a guard, so the loop always terminates.
+- Self-correcting codegen ([code-assistant](../examples/code-assistant/index.ts)): a sandboxed check actor and a `maxAttempts` bound, ending in an explicit `failed` outcome.
+- Tree search, LATS ([lats](../examples/lats/index.ts)): selection, expansion, and reflection scoring as separate states under a rollout budget.
+
+Start with [`react-agent`](../examples/react-agent/index.ts).
 
 ## Retrieval
 
-- **RAG** ([rag](../examples/rag/index.ts)): retrieve and answer are separate typed states; conversational memory lives in context.
-- **Corrective RAG (CRAG)** ([corrective-rag](../examples/corrective-rag/index.ts)): self-correction as explicit branch states, not buried conditionals.
-- **Adaptive RAG** ([adaptive-rag](../examples/adaptive-rag/index.ts)): routing, grading, and a bounded query rewrite each get their own state.
-- **Deep research** ([deep-research](../examples/deep-research/index.ts)): researchers spawn per query; coverage reflection gates one optional follow-up.
-- **SQL agent** ([sql-agent](../examples/sql-agent/index.ts)): query generation, DB execution, and synthesis are separately testable states.
+- RAG ([rag](../examples/rag/index.ts)): retrieve and answer are separate typed states, and conversational memory lives in context.
+- Corrective RAG, CRAG ([corrective-rag](../examples/corrective-rag/index.ts)): self-correction is modeled as explicit branch states rather than nested conditionals.
+- Adaptive RAG ([adaptive-rag](../examples/adaptive-rag/index.ts)): routing, grading, and a bounded query rewrite each get their own state.
+- Deep research ([deep-research](../examples/deep-research/index.ts)): researchers spawn per query, and a coverage reflection gates one optional follow-up.
+- SQL agent ([sql-agent](../examples/sql-agent/index.ts)): query generation, database execution, and synthesis are separately testable states.
 
-**Canonical example: [`corrective-rag`](../examples/corrective-rag/index.ts).**
+Start with [`corrective-rag`](../examples/corrective-rag/index.ts).
 
 ## Routing and chaining
 
-Routing is one decision state whose legal events are the branches. Each branch is a real state, so an unreachable branch is a lint finding, not a silent dead end.
+Routing is one decision state whose legal events are the branches. Each branch is a real state, so an unreachable branch shows up as a lint finding.
 
 ```mermaid
 flowchart LR
@@ -90,16 +66,16 @@ flowchart LR
   O --> D
 ```
 
-- **Routing** ([ai-sdk-routing](../examples/ai-sdk-routing/index.ts)): the route is a decision over legal events; each branch is its own state.
-- **Prompt chaining** ([ai-sdk-marketing-chain](../examples/ai-sdk-marketing-chain/index.ts)): a linear state sequence, each link independently typed and inspectable.
-- **Parallel review** ([ai-sdk-parallel-review](../examples/ai-sdk-parallel-review/index.ts)): parallel states fan out; the join is a plain aggregation state.
-- **Triage** ([triage](../examples/triage/index.ts)): structured output validated against a schema before it leaves the state.
+- Routing ([ai-sdk-routing](../examples/ai-sdk-routing/index.ts)): the route is a decision over legal events, and each branch is its own state.
+- Prompt chaining ([ai-sdk-marketing-chain](../examples/ai-sdk-marketing-chain/index.ts)): a linear state sequence where each link is independently typed and inspectable.
+- Parallel review ([ai-sdk-parallel-review](../examples/ai-sdk-parallel-review/index.ts)): parallel states fan out, and the join is a plain aggregation state.
+- Triage ([triage](../examples/triage/index.ts)): structured output validated against a schema before it leaves the state.
 
-**Canonical example: [`ai-sdk-routing`](../examples/ai-sdk-routing/index.ts).**
+Start with [`ai-sdk-routing`](../examples/ai-sdk-routing/index.ts).
 
 ## Multi-agent
 
-A supervisor is a routing state over typed workers, and the graph is the org chart. One level up, hierarchical teams nest the same shape: each team is a machine with a typed boundary, and the coordinator can send one bounded revision round back down.
+A supervisor is a routing state over typed workers, so the graph matches the org chart. Hierarchical teams nest the same shape. Each team is a machine with a typed boundary, and the coordinator can send one bounded revision round back down.
 
 ```mermaid
 flowchart TB
@@ -111,7 +87,7 @@ flowchart TB
   S --> F["final"]
 ```
 
-Orchestrator-worker fans the same idea out in parallel and joins deterministically. Swarm handoff drops the hub entirely: agents are peers and a handoff is a transition, persisted across turns.
+Orchestrator-worker fans the same idea out in parallel and joins deterministically. Swarm handoff has no hub. Agents are peers, and a handoff is a transition that persists across turns.
 
 ```mermaid
 flowchart LR
@@ -125,56 +101,94 @@ flowchart LR
   end
 ```
 
-- **Supervisor** ([supervisor](../examples/supervisor/index.ts)): a routing request's structured output hands off to a typed worker; the graph is the org chart.
-- **Swarm handoff** ([swarm-handoff](../examples/swarm-handoff/index.ts)): handoffs are transitions between typed child actors, persisted across turns.
-- **Orchestrator-worker** ([ai-sdk-orchestrator-worker](../examples/ai-sdk-orchestrator-worker/index.ts)): fan-out and join are plain `Promise.all` over host actors.
-- **Fan-out (map-reduce)** ([fan-out](../examples/fan-out/index.ts)): dynamic parallelism from a planner, then a deterministic reduce state.
-- **Hierarchical teams** ([hierarchical-teams](../examples/hierarchical-teams/index.ts)): each team is a nested machine with a typed boundary.
-- **Whole-org workflow** ([trading-team](../examples/trading-team/index.ts)): one composite workflow whose reject-and-revise loop is states, not retries.
-- **Sub-agents** ([subflows](../examples/subflows/index.ts), [ai-sdk-sub-agents](../examples/ai-sdk-sub-agents/index.ts), [debate-sub-agents](../examples/debate-sub-agents/index.ts)): each child keeps its own executor binding; parents stay typed against results.
+- Supervisor ([supervisor](../examples/supervisor/index.ts)): a routing request's structured output hands off to a typed worker.
+- Swarm handoff ([swarm-handoff](../examples/swarm-handoff/index.ts)): handoffs are transitions between typed child actors, persisted across turns.
+- Orchestrator-worker ([ai-sdk-orchestrator-worker](../examples/ai-sdk-orchestrator-worker/index.ts)): fan-out and join use `Promise.all` over host actors.
+- Fan-out, or map-reduce ([fan-out](../examples/fan-out/index.ts)): dynamic parallelism driven by a planner, then a deterministic reduce state.
+- Hierarchical teams ([hierarchical-teams](../examples/hierarchical-teams/index.ts)): each team is a nested machine with a typed boundary.
+- Whole-org workflow ([trading-team](../examples/trading-team/index.ts)): one composite workflow whose reject-and-revise loop is modeled as states rather than retries.
+- Sub-agents ([subflows](../examples/subflows/index.ts), [ai-sdk-sub-agents](../examples/ai-sdk-sub-agents/index.ts), [debate-sub-agents](../examples/debate-sub-agents/index.ts)): each child keeps its own executor binding, and parents stay typed against the results.
 
-**Canonical example: [`supervisor`](../examples/supervisor/index.ts).** See [Multi-agent](multi-agent.md) for sub-agents and child actors.
+Start with [`supervisor`](../examples/supervisor/index.ts). Read more about [Multi-agent](multi-agent.md) for sub-agents and child actors.
 
 ## Control and safety
 
-- **Human in the loop** ([human-in-the-loop](../examples/human-in-the-loop/index.ts)): an idle state is a durable pause; the snapshot is plain JSON you store anywhere.
-- **Guardrails** ([guardrails](../examples/guardrails/index.ts)): gate states with guards, not prompt pleading; an illegal path is unreachable.
-- **Context compaction** ([context-compaction](../examples/context-compaction/index.ts)): a `compacting` state folds old history into a running summary past a threshold.
-- **Customer support** ([customer-support](../examples/customer-support/index.ts)): sensitive actions gate on an idle state; the model can't act past the guard.
+<!-- viz: guardrail gate: acting state reachable only through an idle approval state; a REJECT transition returns to the previous state and the direct edge to the sensitive action does not exist -->
 
-Longer pauses and durable threads:
+- Human in the loop ([human-in-the-loop](../examples/human-in-the-loop/index.ts)): an idle state is a durable pause, and the snapshot is plain JSON you can store anywhere.
+- Guardrails ([guardrails](../examples/guardrails/index.ts)): guards gate states, so an illegal path is unreachable rather than discouraged in the prompt.
+- Context compaction ([context-compaction](../examples/context-compaction/index.ts)): a `compacting` state folds old history into a running summary once history passes a threshold.
+- Customer support ([customer-support](../examples/customer-support/index.ts)): sensitive actions are gated behind an idle state, so the model cannot act past the guard.
 
-- [long-running-onboarding](../examples/long-running-onboarding/index.ts): a multi-day coordinator with durable typed state, two idle states, delegated IT provisioning, JSON snapshot resume.
+These examples cover longer pauses and durable threads.
+
+- [long-running-onboarding](../examples/long-running-onboarding/index.ts): a multi-day coordinator with durable typed state, two idle states, delegated IT provisioning, and JSON snapshot resume.
 - [file-snapshot-store](../examples/file-snapshot-store/index.ts): a file-backed snapshot store for durable threads across processes.
 
-**Canonical example: [`human-in-the-loop`](../examples/human-in-the-loop/index.ts).** See [Human in the loop](human-in-the-loop.md) for the idle-first pause and snapshot resume.
+Start with [`human-in-the-loop`](../examples/human-in-the-loop/index.ts). Read more about the idle pause and snapshot resume in [Human in the loop](human-in-the-loop.md).
 
 ## Hosts and runtimes
 
-The same machines against different SDKs and runtimes. See [Hosts](hosts.md) and [Event log](event-log.md).
+These examples run the same machines against different SDKs and runtimes. See [Hosts](hosts.md) and [Event log](event-log.md).
+
+<!-- viz: host boundary: one agent machine in the center naming model refs, with executor implementations around it for AI SDK, OpenAI SDK, Anthropic SDK, and Workers AI; arrow labels show the executor contract crossing the boundary -->
+
 
 - [ai-sdk-host](../examples/ai-sdk-host/index.ts): running with Vercel AI SDK host actors.
 - [ai-sdk-game-host](../examples/ai-sdk-game-host/index.ts): a step-path Vercel AI SDK runner that appends every model call to the event log.
-- [openai-sdk-host](../examples/openai-sdk-host/index.ts): the same executor contract against the raw `openai` package (Chat Completions), no AI SDK in between.
-- [anthropic-sdk-host](../examples/anthropic-sdk-host/index.ts): the same contract against the raw `@anthropic-ai/sdk` package (Messages API).
+- [openai-sdk-host](../examples/openai-sdk-host/index.ts): the same executor contract against the raw `openai` package and its Chat Completions API, with no AI SDK in between.
+- [anthropic-sdk-host](../examples/anthropic-sdk-host/index.ts): the same contract against the raw `@anthropic-ai/sdk` package and its Messages API.
 - [cloudflare-workers-ai-host](../examples/cloudflare-workers-ai-host/index.ts): a Workers AI host that persists only the event log and resumes by replay.
 - [cloudflare-agent-host](../examples/cloudflare-agent-host/index.ts): a Cloudflare Agents host persisting snapshots in Durable Object state.
+
+The two Cloudflare examples target the Workers runtime, not Node, so `tsx` does not run them. Each is its own package with a `wrangler` dev server and a `vitest` suite. Run them from the repo with `pnpm --filter @statelyai/example-cloudflare-workers-ai-host test` and `pnpm --filter @statelyai/example-cloudflare-agent-host test`, or `pnpm run test:cloudflare` for both. See [Running from the repo](#running-from-the-repo).
 - [parallel-streams](../examples/parallel-streams/index.ts): fan-out over parallel worker streams relayed through a side channel.
 - [sse-transport](../examples/sse-transport/index.ts): relaying provider stream chunks over an SSE transport.
 
-**Canonical example: [`ai-sdk-host`](../examples/ai-sdk-host/index.ts).**
+Start with [`ai-sdk-host`](../examples/ai-sdk-host/index.ts).
 
 ## Evaluation, migration, observability
 
-- [simulated-user-evaluation](../examples/simulated-user-evaluation/index.ts): a target chatbot and simulated user alternate under a turn bound, then an independent judge scores the transcript.
-- [retrofit](../examples/retrofit/index.ts): a tangled hand-rolled agent (`before.ts`) refactored stepwise into a machine, each step shippable, with `simulateAgent` tests pinning before/after behavior. The worked proof for [Migrating from a loop](from-a-loop.md).
-- [langsmith-otel](../examples/langsmith-otel/index.ts): `createOtelTraceHandler` from `@statelyai/agent/otel` exporting real spans over OTLP to LangSmith (LangChain's hosted tracing product); keyless it exports to memory and prints the span tree. See [Observability](observability.md).
+- [simulated-user-evaluation](../examples/simulated-user-evaluation/index.ts): a target chatbot and a simulated user alternate under a turn bound, then an independent judge scores the transcript.
+- [retrofit](../examples/retrofit/index.ts): a hand-rolled agent in `before.ts` refactored step by step into a machine, with each step shippable and `simulateAgent` tests pinning behavior before and after. This is the worked example for [Migrating from a loop](from-a-loop.md).
+- [langsmith-otel](../examples/langsmith-otel/index.ts): `createOtelTraceHandler` from `@statelyai/agent/otel` exporting spans over OTLP to LangSmith, LangChain's hosted tracing product. Without a key it exports to memory and prints the span tree. See [Observability](observability.md).
 
-**Canonical example: [`retrofit`](../examples/retrofit/index.ts).**
+Start with [`retrofit`](../examples/retrofit/index.ts).
+
+## Lifting an example
+
+Most patterns are one self-contained `index.ts`, with no shared harness and no local imports. A few ship as a small directory, such as `email-drafter` and `retrofit`. To lift one into your project:
+
+1. Copy the example file into your project as `index.ts`.
+2. Install the runtime dependencies. The provider package major version must match your installed `ai` major version. This repo uses `ai@6`, so it uses `@ai-sdk/openai@3` rather than 4.
+
+   ```sh
+   pnpm add @statelyai/agent@alpha ai@^6.0.67 zod@^4 xstate@6.0.0-alpha.25 @ai-sdk/openai@^3
+   pnpm add -D @types/node typescript tsx
+   ```
+
+3. The examples use the Node globals `process`, `console`, and `import.meta.url`. Give TypeScript a `tsconfig.json` with `"module"` and `"moduleResolution"` set to `nodenext`, `"strict": true`, and `"types": ["node"]`.
+4. Run it with `OPENAI_API_KEY=... npx tsx index.ts`, or swap in [any host](hosts.md).
+
+<!-- peer ranges from package.json#peerDependencies and example schema dependency from package.json#devDependencies -->
+
+`@statelyai/agent` declares these peer ranges: `ai@^6.0.67`, `xstate@>=6.0.0-alpha.25 <6.0.0`, and optionally `@opentelemetry/api@^1`. The examples use Zod 4 directly. The `@alpha` tag floats, so pin the exact version it installs once you have a working build.
+
+## Running from the repo
+
+Examples live under `examples/`, with one flat directory per example and an `index.ts` entrypoint. Clone the repo, install dependencies, then run any example directly.
+
+```bash
+OPENAI_API_KEY=... npx tsx examples/<name>/index.ts
+```
+
+- Every example runs in two modes. Run it against a real model as shown above, or drive it with injected mock executors in a test, with no key and no network.
+- Most examples expect `OPENAI_API_KEY`. Each file notes its requirements at the top. `anthropic-sdk-host` needs `ANTHROPIC_API_KEY`. The two Cloudflare examples target a Workers runtime rather than Node and `tsx`.
+- You can swap the host without changing the machine. See [Use in any stack](any-stack.md). The full index, with framework-comparison notes, is [examples/README.md](../examples/README.md).
 
 ## Related
 
-- [examples/README.md](../examples/README.md): the exhaustive example index, including framework-comparison notes.
-- [Use in any stack](any-stack.md): take any of these machines from local `runAgent` to your server or edge runtime, unchanged.
-- [Migrating from a hand-rolled loop](from-a-loop.md): already have a `while` loop? Convert it step by step.
+- [examples/README.md](../examples/README.md): the full example index, including framework-comparison notes.
+- [Use in any stack](any-stack.md): run any of these machines from local `runAgent` on your server or edge runtime, unchanged.
+- [Migrating from a hand-rolled loop](from-a-loop.md): convert an existing `while` loop step by step.
 - [Thinking in state machines](thinking-in-state-machines.md): how to find the states before you pick a pattern.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -5,37 +5,46 @@ description: The two durable artifacts an agent run produces, what each one hold
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
+This page describes what an agent run stores durably, where each artifact lives, and how to restore from it.
+
 ## Two durable artifacts
 
-An agent run produces exactly two things worth writing to disk, plus run state that only exists while the process does.
+An agent run produces two artifacts worth writing to disk, plus run state that exists only while the process does.
 
-- **The event log** is the authoritative journal: an ordered array of every external input the machine received, and the only artifact from which the run can be fully reconstructed.
-- **The persisted snapshot** is a compaction cache: the machine's serialized state at one quiescent point, so a resume can skip replaying the log from index 0.
-- **In-memory run state** (the live actor, in-flight effects, stream chunks) is derived and disposable; `runAgent` stops its actor on every settle path, so nothing durable ever depends on it.
+- The **event log** is an ordered array of every external input the machine received. It is the only artifact a run can be fully reconstructed from.
+- The **persisted snapshot** is the machine's serialized state at one quiescent point. It lets a resume skip replaying the log from index 0.
+- In-memory run state is the live actor, in-flight effects, and stream chunks. It is derived and disposable. `runAgent` stops its actor on every settle path, so no durable artifact depends on it.
 
-The log is the source of truth. A snapshot is an optimization over it, and can always be thrown away.
+The log is the source of truth. A snapshot is a cache over the log and can be discarded at any time.
+
+<!-- viz: durability model: event log (append-only, source of truth) -> replay -> snapshot (cache at quiescent points) -> resume, with in-memory run state marked disposable -->
+
 
 ## The artifact table
 
+The table covers the two durable artifacts plus the run state that is not durable. Messages and stores are not artifacts and are described after it.
+
 | Artifact                                  | What it holds                                                                                                                                                                                                          | When written                                                                       | Survives                                                                                     | Restore with                                                                    | Full guide                                                                    |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| **Event log entries** (`AgentLogEntry[]`) | One envelope per external input: the `@agent.init` event, effect completions and errors with outputs inline, externally sent events, timer firings, plus identity, timestamp, machine version, and verification hashes | Per accepted external input, via `result.events`, `onEvent`, or a step-path append | Process death, redeploy, machine-version change (with an explicit `machineVersion`), forking | `replay(machine, entries)`, or `runAgent(machine, { events })` with no snapshot | [The event log](event-log.md)                                                 |
+| **Event log entries** (`AgentLogEntry[]`) | One envelope per external input: the `@agent.init` event, effect completions and errors with outputs inline, externally sent events, timer firings, plus identity, timestamp, machine version, and verification hashes | Per accepted external input, via `result.events`, `onEvent`, or a step-path append | Process death, redeploy, machine-version change, forking | `replay(machine, entries)`, or `runAgent(machine, { events })` with no snapshot | [The event log](event-log.md)                                                 |
 | **Persisted snapshot**                    | The machine's serialized state at a quiescent point: state value, context, and restored pending invokes                                                                                                                | At a settle point (`result.snapshot`) or from an actor's `getPersistedSnapshot()`  | Process death, redeploy, days of waiting                                                     | `runAgent(machine, { snapshot, event })`                                        | [Human in the loop](human-in-the-loop.md#persist-and-resume-across-processes) |
-| **Messages and context**                  | Conversation history and any accumulated data live in machine `context`, so they ride inside both artifacts. Nothing separate to store                                                                                 | With whichever artifact you write                                                  | Same as its carrier                                                                          | Restoring either artifact                                                       | [Messages](messages.md)                                                       |
-| **In-flight effect state**                | Which model calls are owed right now                                                                                                                                                                                   | Never snapshot-able mid-flight                                                     | Only the log survives this                                                                   | `replay`, which re-derives owed effects including still-owed dynamic spawns     | [The step path](steps.md#crash-recovery-and-resume)                           |
-| **Stores**                                | Where the two artifacts land                                                                                                                                                                                           | On `append` / `save`                                                               | Whatever the backing database does                                                           | `store.read(threadId)` / `store.load(id)`                                       | [Stores](#stores)                                                             |
+| **In-flight effect state**                | Which model calls are owed right now                                                                                                                                                                                   | Not written directly. It is implied by the log's recorded completions              | Process death, through the log only. A mid-flight snapshot cannot carry it                   | `replay`, which re-derives owed effects including still-owed dynamic spawns     | [The step path](steps.md#crash-recovery-and-resume)                           |
+
+Messages and any other accumulated data live in machine `context`, so they ride inside both artifacts. There is nothing separate to store or restore. See [Messages](messages.md).
+
+Stores are where the two artifacts land. See [Stores](#stores) below.
 
 Two rules follow from the table:
 
-- **Snapshot only at quiescent points.** A mid-flight snapshot cannot carry in-flight effect state; the log can. Compact at idle, resume from the snapshot plus the entries appended since.
-- **Context must be JSON-serializable.** Both artifacts round-trip through `JSON.stringify`. Keep sessions, db clients, and sockets in closures and store only their ids.
+- Snapshot only at quiescent points. A mid-flight snapshot cannot carry in-flight effect state, but the log can. Compact at idle, then resume from the snapshot plus the entries appended since.
+- Keep context JSON-serializable. Both artifacts round-trip through `JSON.stringify`. Keep sessions, database clients, and sockets in closures, and store only their ids.
 
 ## Stores
 
-Two protocols, both `interface`-first so a userland store interoperates:
+Two store protocols are defined as interfaces, so a userland store interoperates with the library.
 
-- **`AgentEventLogStore`**: append-only with optimistic concurrency on log length. `append({ threadId, expectedIndex, entries })`, `read`, `length`, `fork`. A stale writer loses with `AgentEventLogConflictError`. See [the store contract](event-log.md#the-store-contract).
-- **`AgentSnapshotStore`**: `load(id)` / `save(id, snapshot)`. A key-to-JSON upsert.
+- `AgentEventLogStore` is append-only with optimistic concurrency on log length. It has `append({ threadId, expectedIndex, entries })`, `read`, `length`, and `fork`. A stale writer fails with `AgentEventLogConflictError`. See [the store contract](event-log.md#the-store-contract).
+- `AgentSnapshotStore` has `load(id)` and `save(id, snapshot)`. It is a key-to-JSON upsert.
 
 Shipped implementations:
 
@@ -45,21 +54,21 @@ Shipped implementations:
 | SQLite event log    | `createSqliteEventLogStore({ database })` from `@statelyai/agent/sqlite` | Node's built-in `node:sqlite`, no dependencies, Node >= 22.18 |
 | SQLite snapshots    | `createSqliteSnapshotStore({ database })` from `@statelyai/agent/sqlite` | Shares one `DatabaseSync` handle with the event log store     |
 
-Both SQLite stores take a file path, `':memory:'`, or an existing handle, and create their tables on demand. Postgres and Redis adapters are [on the roadmap](roadmap.md), not shipped; write your own against the protocol and prove it with `assertEventLogStoreConformance`.
+Both SQLite stores take a file path, `':memory:'`, or an existing handle. They create their tables on demand. Postgres and Redis adapters are [on the roadmap](roadmap.md) and are not shipped. To use another database, write a store against the protocol and check it with `assertEventLogStoreConformance`.
 
 ## Recipes
 
-Each of these is written up in full on its owning page:
+Each recipe is written up in full on its owning page.
 
-- **Crash recovery**: resume from the log alone, with recorded model calls replayed rather than re-billed. See [log-only resume](event-log.md#log-only-resume-crash-recovery), and [append before continue](steps.md#durable-append-before-continue) for the step-path guarantee.
-- **Resume with an event (human in the loop)**: run to idle, store the snapshot, load it later and deliver the human's event. See [persist and resume across processes](human-in-the-loop.md#persist-and-resume-across-processes).
-- **Time travel**: `replay(machine, entries.slice(0, n))` rebuilds the state as of any point in the log, without executing anything. See [crash recovery and resume](steps.md#crash-recovery-and-resume).
-- **Fork and branch**: `store.fork({ threadId, newThreadId, atEventId })` copies a prefix onto a new thread; `diffEventLogs` reports what diverged. See [fork and diff](event-log.md#fork-and-diff).
-- **Verify a log**: `verifyReplay` requires verification hashes on every entry and fails at the first mismatch. See [strict replay verification](event-log.md#strict-replay-verification).
+- Crash recovery: resume from the log alone. Recorded model calls are replayed instead of re-executed. See [log-only resume](event-log.md#log-only-resume-crash-recovery) and [append before continue](steps.md#durable-append-before-continue).
+- Resume with an event: run to idle, store the snapshot, then load it later and deliver the human's event. See [persist and resume across processes](human-in-the-loop.md#persist-and-resume-across-processes).
+- Time travel: `replay(machine, entries.slice(0, n))` rebuilds the state as of any point in the log without executing anything. See [crash recovery and resume](steps.md#crash-recovery-and-resume).
+- Fork and branch: `store.fork({ threadId, newThreadId, upToIndex })` copies the prefix `[0, upToIndex)` onto a new thread. `diffEventLogs` reports what diverged. See [fork and diff](event-log.md#fork-and-diff).
+- Verify a log: `replay(machine, entries, { verify: 'strict' })` requires verification hashes on every entry and fails at the first mismatch. See [strict replay verification](event-log.md#strict-replay-verification).
 
 ## Related
 
-- [The event log](event-log.md): the durability hub, the JSON wire contract, and the SQLite stores in detail.
-- [Human in the loop](human-in-the-loop.md): idle states, the natural compaction points.
+- [The event log](event-log.md): the log envelope, the JSON wire contract, and the SQLite stores.
+- [Human in the loop](human-in-the-loop.md): idle states, which are the compaction points.
 - [The step path](steps.md): owning the loop and persisting between model calls.
-- [Choosing a run mode](choosing-a-run-mode.md): which artifacts each mode gives you by default.
+- [Choosing a run mode](choosing-a-run-mode.md): which artifacts each mode produces by default.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ description: Install @statelyai/agent and run your first agent machine end to en
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-The [overview](index.md) has the copy-paste version; this page builds the same shape up piece by piece.
+This page builds an agent piece by piece, from installation to a live model call. For a single copy-paste example, see the [overview](index.md).
 
 ## Installation
 
@@ -15,19 +15,21 @@ The [overview](index.md) has the copy-paste version; this page builds the same s
 pnpm add @statelyai/agent@alpha xstate@alpha zod ai@^6 @ai-sdk/openai@^3
 ```
 
-- The `@alpha` tag floats. Install it once, then pin what it resolved to (`npm ls @statelyai/agent`) so a later alpha cannot change the API under you.
-- `xstate` is the one required peer, at **v6 alpha.25 or newer**. Node 22.18 or newer.
-- Provider packages must match your `ai` major. `@ai-sdk/openai@^3` pairs with `ai@^6`; a bare `@ai-sdk/openai` resolves to `@latest`, whose `LanguageModel` spec version may not match your `ai` peer.
-- The package is **ESM-first**; every entry also ships a CommonJS build, so `require()` works. The examples use top-level `await`, which needs ESM: set `"type": "module"` in `package.json` (or use `.mts` files).
+- The `@alpha` tag floats. Install it once, then run `npm ls @statelyai/agent` and pin the resolved version, so a later alpha cannot change the API.
+- `xstate` is the only required peer dependency, at v6 alpha.25 or newer. Node must be 22.18 or newer.
+- Provider packages must match your `ai` major version. `@ai-sdk/openai@^3` pairs with `ai@^6`. A bare `@ai-sdk/openai` resolves to `@latest`, whose `LanguageModel` spec version may not match your `ai` peer.
+- The package is ESM-first. Every entry point also ships a CommonJS build, so `require()` works. The examples use top-level `await`, which requires ESM. Set `"type": "module"` in `package.json`, or use `.mts` files.
 
 ## First agent
 
-A comment moderator. The model reads a comment and picks one of three events; the machine owns the trust threshold that decides whether publishing is even legal.
+The first agent is a comment moderator. The model reads a comment and picks one of three events. The machine owns the trust threshold that decides whether publishing is legal.
 
-Two pieces do the work:
+Two functions do the work:
 
-- `setupAgent` declares the schemas and events, then `createMachine` authors the control flow from them.
-- `createScriptedExecutors` plays back canned answers through the executor contract, so this first version runs end to end with **no API key**.
+- `setupAgent` declares the schemas and events. `createMachine` authors the control flow from them.
+- `createScriptedExecutors` plays back canned answers through the executor contract, so this first version runs end to end without an API key.
+
+<!-- viz: moderation machine: reviewing -> published/flagged/blocked, with the trust >= 50 guard on PUBLISH and the retry back into reviewing when the guard rejects -->
 
 ```ts
 import { createScriptedExecutors, runAgent, setupAgent } from "@statelyai/agent";
@@ -52,7 +54,7 @@ const agentSetup = setupAgent({
 });
 
 const moderationMachine = agentSetup.createMachine({
-  // Comments start flagged; only the machine can clear one.
+  // Comments start flagged.
   context: ({ input }) => ({ ...input, outcome: "flagged", reason: null }),
   output: ({ context }) => ({ outcome: context.outcome, reason: context.reason }),
   initial: "reviewing",
@@ -68,13 +70,15 @@ const moderationMachine = agentSetup.createMachine({
         }),
       },
       on: {
-        // The guard owns the threshold, not the model: under 50 this returns
-        // undefined, so PUBLISH is illegal and the model has to choose again.
+        // Returns undefined below a trust score of 50, which rejects PUBLISH.
         PUBLISH: ({ context }) =>
           context.trust >= 50
             ? { target: "published", context: { outcome: "published" } }
             : undefined,
-        FLAG: ({ event }) => ({ target: "flagged", context: { reason: event.reason } }),
+        FLAG: ({ event }) => ({
+          target: "flagged",
+          context: { outcome: "flagged", reason: event.reason },
+        }),
         BLOCK: () => ({ target: "blocked", context: { outcome: "blocked" } }),
       },
     },
@@ -87,7 +91,7 @@ const moderationMachine = agentSetup.createMachine({
 const result = await runAgent(moderationMachine, {
   input: { comment: "honestly this update is terrible", trust: 20 },
   executors: createScriptedExecutors({
-    decisions: [{ type: "FLAG", reason: "Borderline tone." }],
+    decisions: [{ type: "PUBLISH" }, { type: "FLAG", reason: "Borderline tone." }],
   }),
 });
 
@@ -102,11 +106,13 @@ Save it as `agent.ts` in a project with `"type": "module"` in its `package.json`
 npx tsx agent.ts
 ```
 
-It prints `{ outcome: 'flagged', reason: 'Borderline tone.' }`. The scripted decision took the place of a model call. Everything else (the guard, the retry, the final state, the schema-checked output) is the real machine.
+It prints `{ outcome: 'flagged', reason: 'Borderline tone.' }`. The scripted decisions replaced the model calls. The first decision consumes the `PUBLISH` entry, and the trust guard rejects it because the author's trust score is 20. The decision is requested again, consumes the `FLAG` entry, and the machine reaches `flagged`. The guard, the retry, the final state, and the schema-checked output all come from the real machine.
+
+The `model` value is a plain string. The `models` registry is optional and only narrows the type of that string. It is never consulted at run time, and scripted executors ignore it because they route on the request name.
 
 ### Real model executors
 
-Swap the executors. The machine does not change: add a `models` registry (which also types the `model:` keys), then hand `runAgent` the AI SDK adapter instead of the script.
+To call a real model, replace the executors. The machine does not change. Add a `models` registry, which also types the `model` keys, then pass the AI SDK adapter to `runAgent` instead of the script.
 
 ```ts no-check
 import { openai } from "@ai-sdk/openai";
@@ -115,7 +121,7 @@ import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
 const models = defineModels({ fast: openai("gpt-5.4-mini") });
 
 const agentSetup = setupAgent({
-  models, // adds typed `model` keys; everything else is unchanged
+  models,
   // …the same schemas and events
 });
 
@@ -130,21 +136,21 @@ export OPENAI_API_KEY=sk-...
 npx tsx agent.ts
 ```
 
-Now the model picks the event, and `reason` is whatever it wrote. Keep the scripted set around: it is what your tests run against (see [Testing without an API key](#testing-without-an-api-key)).
+The model now picks the event, and `reason` contains the text it wrote. Keep the scripted executors, because your tests run against them. See [Testing without an API key](#testing-without-an-api-key).
 
-What the machine does that a prompt call cannot:
+The machine adds three properties that a direct prompt call does not have:
 
-- **The model only ever picks a legal event.** `allowedEvents` is intersected with the events the current state actually accepts, so the choice set moves with the machine.
-- **A guard can overrule the model.** A `PUBLISH` on a low-trust author is rejected before it reaches state (`failure: 'rejected-by-guard'`) and the decision retries with that feedback. The threshold lives in one place and cannot be prompted away.
-- **The outcome is a state, not a parsed string.** Every path ends in a known final state with schema-checked output, and the whole graph renders as a diagram.
+- The model can only pick a legal event. `allowedEvents` is intersected with the events the current state accepts, so the choice set changes as the machine moves.
+- A guard can override the model. A `PUBLISH` for a low-trust author is rejected before it changes state, with `failure: 'rejected-by-guard'`, and the decision retries with that feedback. The threshold is defined in one place and a prompt cannot change it.
+- The outcome is a state, not a parsed string. Every path ends in a known final state with schema-checked output, and the graph renders as a diagram.
 
 ## The `setupAgent` surface
 
-`setupAgent` returns a **setup** (not a running agent) you author machines from, like XState's `setup()`. Context, input, output, and event payloads are Standard Schemas, so Zod works directly and the machine's types come from them.
+`setupAgent` returns a **setup**, which you author machines from. It is not a running agent. It works like XState's `setup()`. Context, input, output, and event payloads are Standard Schemas, so Zod works directly and the machine's types come from those schemas.
 
 The `model` value is a key into the `models` registry, or any string your [host](hosts.md#typed-model-aliases) resolves at run time.
 
-Every machine can invoke these built-in actor sources. They are reserved `src` strings; the invoke's `input` shapes each call.
+Every machine can invoke the following built-in actor sources. They are reserved `src` strings. The invoke's `input` shapes each call.
 
 | `src`                | Purpose                                                 |
 | -------------------- | ------------------------------------------------------- |
@@ -155,7 +161,7 @@ Every machine can invoke these built-in actor sources. They are reserved `src` s
 
 ### Named requests
 
-A **request** is a typed, reusable model call: named schemas, a model, and a prompt built from its input. It is the testable counterpart to an inline `agent.generateText`.
+A **request** is a typed, reusable model call. It has named schemas, a model, and a prompt built from its input. Use a request instead of an inline `agent.generateText` when you want to test the call by name.
 
 ```ts no-check
 const agentSetup = setupAgent({
@@ -190,25 +196,31 @@ See [Text requests](text-requests.md) for tools, streaming, and messages.
 
 ## Running
 
-`runAgent` drives the machine and calls your **executors** whenever it needs a model. It settles with a `status`:
+`runAgent` drives the machine and calls your **executors** whenever the machine needs a model. It settles with one of three statuses.
 
-- `done`: reached a final state; `result.output` matches your output schema.
-- `idle`: waiting on a human. See [Human in the loop](human-in-the-loop.md).
-- `error`: something threw.
+| Status  | Meaning                                                                          |
+| ------- | -------------------------------------------------------------------------------- |
+| `done`  | The machine reached a final state. `result.output` matches your output schema.    |
+| `idle`  | The machine is waiting on a human. See [Human in the loop](human-in-the-loop.md). |
+| `error` | Something threw.                                                                  |
 
-Every variant carries `result.events`, a versioned, JSON-safe `AgentLogEntry[]` of the replayable external inputs (identity, timestamp, machine version, state/effect hashes). Pass it to `replay(machine, result.events)` to reconstruct the final snapshot without re-running model or tool calls; `verifyReplay` requires every hash. See [The event log](event-log.md#export-events-from-runagent).
+<!-- viz: runAgent lifecycle: start -> model call loop -> settle at done, idle, or error, with idle resuming back into the loop -->
 
-For a run that must go straight through to a final state, `generateResult(machine, options)` resolves with the done result: `result.output` plus metadata (`result.snapshot`, replayable `result.events`, aggregated `result.usage`), like `generateText`'s `text` + call metadata. It throws `AgentIdleError` if the machine pauses.
+Every status carries `result.events`, a versioned JSON-safe `AgentLogEntry[]` of the replayable external inputs. Each entry records identity, timestamp, machine version, and state and effect hashes. Pass the array to `replay(machine, result.events)` to reconstruct the final snapshot without re-running model or tool calls. Pass `{ verify: 'strict' }` to require every hash to match. See [The event log](event-log.md#export-events-from-runagent).
+
+If a run must reach a final state, use `generateResult(machine, options)` instead. It resolves with the done result: `result.output`, plus `result.snapshot`, replayable `result.events`, and aggregated `result.usage`. It throws `AgentIdleError` if the machine pauses.
 
 ### Other ways to run the same machine
 
-`runAgent` is the default, not the only option. `provideExecutors` binds the executors onto the machine and hands it back for a plain `createActor`; the step path lets a durable host own the loop and the persistence. The machine is identical in all three. See [Choosing a run mode](choosing-a-run-mode.md).
+`runAgent` is the default, but not the only option. `provideExecutors` binds the executors onto the machine and returns it for use with a plain `createActor`. The step path lets a durable host own the loop and the persistence. The machine is identical in all three modes. See [Choosing a run mode](choosing-a-run-mode.md).
 
 ### Testing without an API key
 
-`createScriptedExecutors` is the same helper the first run used: FIFO queues of scripted answers, one entry consumed per model call. `decisions` feeds `agent.decide`, `text` feeds every text request.
+`createScriptedExecutors` is the helper the first run used. It holds FIFO queues of scripted answers and consumes one entry per model call. `decisions` feeds `agent.decide`, and `text` feeds every text request.
 
 ```ts
+import { createScriptedExecutors, generateResult } from "@statelyai/agent";
+
 const executors = createScriptedExecutors({
   decisions: [{ type: "FLAG", reason: "Borderline tone." }],
   text: [{ note: "Repeat offender." }],
@@ -222,15 +234,15 @@ const result = await generateResult(moderationMachine, {
 expect(result.output).toEqual({ outcome: "flagged", reason: "Borderline tone." });
 ```
 
-- An entry may be a **function of the request**, for branching or looping machines: `(request) => request.name === "moderatorNote" ? … : …`.
-- A `PUBLISH` rejected by the guard consumes an entry and retries with the next one, so scripts assert retry behavior directly.
-- Running dry throws an error naming the pending request.
+- An entry can be a function of the request, which is useful for branching or looping machines. For example: `(request) => request.name === "moderatorNote" ? … : …`.
+- A `PUBLISH` rejected by the guard consumes an entry and retries with the next one, so a script can assert retry behavior.
+- If the queue runs out, the executor throws an error naming the pending request.
 
-Executors are plain functions, so a hand-written mock is just an object; see [Hosts and executors](hosts.md#scripted-executors). To assert a whole playthrough without a run loop at all, `simulateAgent` walks the step path from a by-`src` script. See [Testing and verification](verify.md).
+Executors are plain functions, so you can also write a mock by hand as an object. See [Hosts and executors](hosts.md#scripted-executors). To assert a full playthrough without a run loop, use `simulateAgent`, which walks the step path from a script keyed by `src`. See [Testing and verification](verify.md).
 
 ### Live visualization
 
-The [Stately Inspector](https://stately.ai/docs/inspector) is a web UI that draws a running machine as a diagram and highlights each state as it is entered. Install `@statelyai/sdk`, create an inspector, and pass its handler to `runAgent`'s `inspect` option. The run opens the diagram in your browser and updates it live:
+The [Stately Inspector](https://stately.ai/docs/inspector) is a web UI that draws a running machine as a diagram and highlights each state as the machine enters it. Install `@statelyai/sdk`, create an inspector, and pass its handler to the `inspect` option of `runAgent`. The run opens the diagram in your browser and updates it as the machine runs.
 
 ```ts
 import { createInspector } from "@statelyai/sdk";
@@ -241,11 +253,11 @@ const inspector = createInspector();
 await runAgent(moderationMachine, {
   input: { comment: "honestly this update is terrible", trust: 20 },
   executors: createAiSdkExecutors({ models }),
-  inspect: inspector.inspect, // opens the diagram and lights it up live
+  inspect: inspector.inspect,
 });
 ```
 
-It is the same machine you authored, so it also renders in [Stately Studio](https://stately.ai/editor) and the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode). See [Observability](observability.md) for production tracing.
+The same machine also renders in [Stately Studio](https://stately.ai/editor) and the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode). For production tracing, see [Observability](observability.md).
 
 ## Related
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,30 +5,38 @@ description: Work deliberately deferred past the 2.0 alpha, and why.
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-What gates 2.0 stable, and what is honestly not shipped yet. Everything not listed as gating is additive and waits on real usage feedback; if one of these blocks you, open an issue.
+This page lists what gates the 2.0 stable release, what is planned but not shipped, and what is not planned. If one of these items blocks you, open an issue.
 
 ## Road to v2 stable (gating)
 
-v2 leaves alpha only when its durable formats can be promised. Changing a persisted format after stable is worse than staying alpha longer, so these land in order and formats freeze last.
+v2 leaves alpha once its durable formats can be committed to. Changing a persisted format after the stable release is worse than staying in alpha longer, so these items land in order and the formats freeze last.
 
-- **Runtime semantics complete first.** The durable-execution seams still moving (step request envelope, execution info, event-log contract, dynamic actor binding) settle before any freeze.
-- **Stable XState v6.** The alpha pins `xstate@6.0.0-alpha.*`. The persisted snapshot format is XState's, so a stable v6 is a hard dependency: if it slips, v2 stays alpha rather than freezing on an alpha format.
-- **Node LTS matrix.** Declare and CI-test the supported active LTS versions.
-- **Format freeze.** The durable formats freeze together, with documented versioning rules: the `AgentLogEntry` envelope (`AGENT_EVENT_SCHEMA_VERSION`, including the reserved `@agent.init` event and verification hashes), the `AgentEventLogStore` protocol, and the `AgentTraceEvent` envelope (`AGENT_TRACE_SCHEMA_VERSION`). Persisted snapshots are compaction caches, versioned by XState.
-- **Upgrade tests.** Fixture snapshots and traces from the frozen formats, replayed in CI against every release, so a break is caught before it ships.
-- **RC cycle.** At least one release candidate with formats frozen and real hosts running against it before `2.0.0`.
+- Runtime semantics complete first. The durable-execution seams that are still moving settle before any freeze. These are the step request envelope, execution info, the event-log contract, and dynamic actor binding.
+- Stable XState v6. The alpha pins `xstate@6.0.0-alpha.*`. The persisted snapshot format is XState's, so a stable v6 is a hard dependency. If v6 slips, v2 stays in alpha rather than freezing on an alpha format.
+- Node LTS matrix. Declare and CI-test the supported active LTS versions.
+- Format freeze. The durable formats freeze together, with documented versioning rules. The formats are the `AgentLogEntry` envelope, versioned by `AGENT_EVENT_SCHEMA_VERSION` and including the reserved `@agent.init` event and verification hashes, the `AgentEventLogStore` protocol, and the `AgentTraceEvent` envelope, versioned by `AGENT_TRACE_SCHEMA_VERSION`. Persisted snapshots are compaction caches and are versioned by XState.
+- Upgrade tests. Fixture snapshots and traces from the frozen formats are replayed in CI against every release, so a break is caught before it ships.
+- RC cycle. At least one release candidate ships with formats frozen and real hosts running against it before `2.0.0`.
 
-## Not shipped yet
+## Planned
 
-- **Postgres and Redis storage adapters.** Core ships the persistence contracts, an in-memory event-log store, and SQLite (`createSqliteEventLogStore` / `createSqliteSnapshotStore` from `@statelyai/agent/sqlite`). No Postgres or Redis packages.
-- **OpenTelemetry exporter.** `@statelyai/agent/otel` ships `createOtelTraceHandler` (trace-to-span mapping), but no exporter or SDK lifecycle; bring your own provider, or build on `onTrace` with `serializeTraceEvent(event)` for JSONL-safe output.
-- **SSE/WebSocket transport helpers.** Host your own stream over `onChunk` (an SSE example ships in `examples/sse-transport`).
-- **Agent-specific dynamic fan-out helper.** Fan-out works today via XState `spawn(...)` or `Promise.all(...)`; core has no higher-level helper for branch binding and progress.
-- **Visualization tooling.** Stately Studio and the VS Code extension own diagramming and inspection.
+These items are not shipped yet. They are additive and wait on usage feedback.
 
-## Near-term, non-gating
+### Not shipped
 
-- **Managed step-path helper.** A collapsed driver over the [step path](steps.md) loop. Deferred because the loop is ~15 lines of host-owned code by design.
-- **Idle persist/revive helper.** The persist, return handle, resume-with-event recipe (see [human in the loop](human-in-the-loop.md)) is a documented pattern each host rewrites; a helper lands once real stores show the common shape.
-- **Plan executor.** Multi-event commands are an explicit [decide loop](decisions.md#multi-event-commands-the-decide-loop) today; the executor layer that simulates a proposed plan up front and replans on divergence is next, as a documented pattern first.
-- **Live-path mid-flight resume for fan-out.** Event-log [replay](event-log.md) already re-derives still-owed spawned effects; restoring a live `runAgent` snapshot persisted mid-flight still drops frozen children.
+- Postgres and Redis storage adapters. Core ships the persistence contracts, an in-memory event-log store, and SQLite through `createSqliteEventLogStore` and `createSqliteSnapshotStore` from `@statelyai/agent/sqlite`. There are no Postgres or Redis packages.
+- OpenTelemetry exporter. `@statelyai/agent/otel` ships `createOtelTraceHandler` for trace-to-span mapping, but no exporter and no SDK lifecycle. Bring your own provider, or build on `onTrace` with `serializeTraceEvent(event)` for JSONL-safe output.
+- SSE and WebSocket transport helpers. Host your own stream over `onChunk`. An SSE example ships in `examples/sse-transport`.
+- Agent-specific dynamic fan-out helper. Fan-out works today through XState `spawn(...)` or `Promise.all(...)`. Core has no higher-level helper for branch binding and progress.
+
+### Near-term, non-gating
+
+- Managed step-path helper. This is a collapsed driver over the [step path](steps.md) loop. It is deferred because the loop is around 15 lines of host-owned code by design.
+- Idle persist and revive helper. The recipe of persisting a snapshot, returning a handle, and resuming with an event is a documented pattern that each host rewrites. See [Human in the loop](human-in-the-loop.md). A helper lands once real stores show the common shape.
+- Plan executor. Multi-event commands use an explicit [decide loop](decisions.md#the-decide-loop-for-multi-event-commands) today. The executor layer that simulates a proposed plan up front and replans on divergence comes next, as a documented pattern first.
+- Live-path mid-flight resume for fan-out. Event-log [replay](event-log.md) already re-derives spawned effects that are still owed. Restoring a live `runAgent` snapshot that was persisted mid-flight still drops frozen children.
+- Tool-call gating, meaning an interrupt before selected tool calls. This is planned. The alpha carried it as a request metadata convention that core never acted on, so it was removed.
+
+## Not planned
+
+- Visualization tooling. Stately Studio and the VS Code extension handle diagramming and inspection. See [Scope](scope.md#non-goals).

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -5,11 +5,16 @@ description: What Stately Agent owns, what the host owns, and where specialized 
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-`@statelyai/agent` is a portable control-flow tool, not an agent framework. It owns the executable machine: states, legal transitions, typed requests, decisions, composition, suspension, resume, and deterministic testing. The host owns every external capability.
+This page describes what `@statelyai/agent` implements, what your host implements, and where other libraries fit.
 
-That boundary is what makes a machine portable. Agent frameworks that bundle a model client, a search client, a memory store, and a server all at once tie your control flow to those choices. Here the machine only ever describes work; the host decides how it happens, so the same machine runs against a different SDK, provider, or database with no edits.
+`@statelyai/agent` is a control-flow library, not an agent framework. It owns the executable machine: states, legal transitions, typed requests, decisions, composition, suspension, resume, and deterministic testing. The host owns every external capability.
 
-In practice the machine says _what_:
+This boundary is what makes a machine portable. An agent framework that bundles a model client, a search client, a memory store, and a server ties your control flow to those choices. Here, the machine describes work and the host decides how the work happens. The same machine runs against a different SDK, provider, or database without edits.
+
+The machine declares what happens:
+
+<!-- viz: ownership boundary diagram: machine (states, requests, decisions) | executors/actors seam | host capabilities (model SDK, search, memory, sandbox, store, telemetry) -->
+
 
 ```ts no-check
 searching: {
@@ -17,52 +22,50 @@ searching: {
 }
 ```
 
-and the host says _how_, binding `searchWeb` to whichever search client, cache, and auth it uses.
+The host decides how it happens, binding `searchWeb` to the search client, cache, and auth it uses.
 
 ## Ownership boundary
 
 <!-- ownership boundaries derived from src/run-agent.ts, src/steps.ts, src/types.ts, and the host/example adapters -->
 
-| Concern                                                                 | Owner                            | Stately Agent integration point                                 |
-| ----------------------------------------------------------------------- | -------------------------------- | --------------------------------------------------------------- |
-| Workflow states, branching, loops, parallelism, retries, approval gates | Machine                          | XState machine configuration                                    |
-| Model calls and structured output                                       | Host or model SDK                | `AgentRequestExecutors`                                         |
-| Tools and tool loops                                                    | Host or model SDK                | request `tools` and `metadata`                                  |
-| Search, RAG, crawling, data APIs                                        | Specialized library or service   | tool, executor, or `actors` implementation                      |
-| Long-term and semantic memory                                           | Database or memory library       | load into machine input; expose reads/writes as actors or tools |
-| Sandboxes, filesystems, generated artifacts                             | Sandbox or workspace library     | host actors and artifact handles in machine context             |
-| MCP discovery, auth, sessions, and transport                            | MCP client or host framework     | pass discovered tool descriptors into requests                  |
-| Evaluation datasets, scorers, experiments, and dashboards               | Evaluation library               | consume `onTrace`, `onResult`, snapshots, and machine outputs   |
-| Snapshot persistence                                                    | Host store                       | `AgentSnapshotStore` and `persistSnapshot(...)`                 |
-| Queues, schedules, leases, deployment, HTTP/SSE/WebSocket               | Runtime or application framework | step API, snapshots, callbacks, emitted events                  |
-| Telemetry export                                                        | Observability library            | `onTrace` and `inspect`                                         |
+| Concern                                                                 | Owner                            | Stately Agent integration point                        |
+| ----------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------ |
+| Workflow states, branching, loops, parallelism, retries, approval gates | Machine                          | Machine configuration                                  |
+| Model calls and structured output                                       | Host or model SDK                | `AgentRequestExecutors`                                |
+| Tools and tool loops                                                    | Host or model SDK                | Request `tools` and `metadata`                         |
+| Search, RAG, crawling, data APIs                                        | Specialized library or service   | Request `tools`, executors, or `actors`                |
+| Long-term and semantic memory                                           | Database or memory library       | Machine `input`, plus `actors` for reads and writes    |
+| Sandboxes, filesystems, generated artifacts                             | Sandbox or workspace library     | `actors`, plus artifact handles in machine context     |
+| MCP discovery, auth, sessions, and transport                            | MCP client or host framework     | Request `tools`                                        |
+| Evaluation datasets, scorers, experiments, and dashboards               | Evaluation library               | `onTrace`, `onResult`, snapshots, and machine output   |
+| Snapshot persistence                                                    | Host store                       | `AgentSnapshotStore` and `getPersistedSnapshot()`      |
+| Queues, schedules, leases, deployment, HTTP/SSE/WebSocket               | Runtime or application framework | Step path, snapshots, callbacks, and emitted events    |
+| Telemetry export                                                        | Observability library            | `onTrace` and `inspect`                                |
 
-The repository includes examples for the orchestration shape, not replacement implementations of those systems:
+The repository examples show the orchestration shape. They are not replacement implementations of the systems listed above.
 
-- [Deep research](../examples/deep-research/index.ts) models planning, concurrent research, reflection, and synthesis. Its search implementation still belongs to the host.
-- [Trading team](../examples/trading-team/index.ts) models parallel analysts, debate, risk review, and approval. Market feeds and order execution remain external.
+- [Deep research](https://github.com/statelyai/agent/blob/main/examples/deep-research/index.ts) models planning, concurrent research, reflection, and synthesis. The host still supplies the search implementation.
+- [Trading team](https://github.com/statelyai/agent/blob/main/examples/trading-team/index.ts) models parallel analysts, debate, risk review, and approval. Market feeds and order execution remain external.
 
 ## Core criteria
 
-A feature belongs in core when portable machine intent cannot otherwise be expressed or handed to an arbitrary host without framework-specific glue. Good core candidates improve one of these seams:
+The rules for what belongs in core live in [CONTRIBUTING.md](https://github.com/statelyai/agent/blob/main/CONTRIBUTING.md).
 
-- authoring typed, inspectable control flow;
-- describing external work without executing it;
-- binding that work in any host;
-- suspending, persisting, and resuming without changing the machine;
-- stepping and replaying deterministically;
-- observing a run without coupling it to one telemetry or evaluation vendor.
+## Non-goals
 
-A feature does not belong in core merely because popular agent applications need it. Search clients, vector stores, browser automation, code sandboxes, skills, prompt registries, eval scorers, and deployment servers are useful precisely because specialized libraries can evolve them independently.
+- Visualization tooling. Stately Studio and the VS Code extension handle diagramming and inspection.
+- Search clients, vector stores, browser automation, code sandboxes, skills, prompt registries, eval scorers, and deployment servers. These evolve independently as specialized libraries.
 
 ## Integration recipes
 
+The seam between tools and actors is fixed. Tools are chosen by the model within one request. Actors are steps the machine orchestrates.
+
 - Wrap an async capability as an XState actor and provide it through `actors`.
 - Pass SDK-native tools through a request's `tools` map.
-- Put host-only hints in request `metadata`; core preserves it without interpreting it.
-- Close over auth, tenant, tracing, and service clients when constructing executors or actors.
-- Persist JSON-safe snapshots and external artifact handles, not live clients or binary resources, in machine context.
-- Feed traces to an evaluation or observability library through `onTrace`; do not make the machine aware of the destination.
+- Put host-only hints in request `metadata`. Core preserves `metadata` without interpreting it.
+- Close over auth, tenant, tracing, and service clients when you construct executors or actors.
+- Store JSON-safe snapshots and external artifact handles in machine context. Do not store live clients or binary resources there.
+- Send traces to an evaluation or observability library through `onTrace`. The machine does not need to know the destination.
 
 ## Related
 

--- a/docs/snippet-globals.ts
+++ b/docs/snippet-globals.ts
@@ -103,8 +103,6 @@ declare const rawOutput: any;
 
 declare const snapshot: any;
 
-declare const persistSnapshot: (snapshot: any) => Promise<void>;
-
 declare const store: any;
 
 declare const executors: any;

--- a/docs/steps.md
+++ b/docs/steps.md
@@ -5,31 +5,35 @@ description: Drive an agent machine one external input at a time over an append-
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
+This page describes the step path, the low-level way to drive an agent machine when your host owns the loop and persists between model calls.
+
 ## Step path use cases
 
-Most users should use [`runAgent`](hosts.md). The step path is the low-level alternative for durable hosts that own the loop.
+Most hosts should use [`runAgent`](hosts.md). The step path is the alternative for durable hosts that own the loop.
 
-The **step path** is not a separate entry point. It is a set of root exports from `@statelyai/agent` (`getAgentEffects`, `executeAgentRequest`, `resolveDecision`, `replay`, `initEntry`, `createReplayEntry`, ...) for hosts that own the loop and persist between model calls:
+The **step path** is not a separate entry point. It is a set of root exports from `@statelyai/agent`, including `getAgentEffects`, `executeAgentRequest`, `resolveDecision`, `replay`, `initEntry`, and `createReplayEntry`. Use it in these cases:
 
-- **Durable execution hosts:** designed for engines like Cloudflare Workflows or Temporal, and for any queue-driven or serverless-per-turn host that must resume from the last completed step. No integration for a specific engine ships today; you wire the loop yourself.
-- **One invocation per turn:** a serverless function that runs one frontier, persists, and returns.
+- Durable execution hosts. The step path targets engines such as Cloudflare Workflows or Temporal, and any queue-driven or serverless host that must resume from the last completed step. No integration for a specific engine ships today, so you wire the loop yourself.
+- One invocation per turn. A serverless function runs one frontier, persists the log, and returns.
 
-For a live, in-process run, use [`runAgent`](hosts.md) instead: it owns an actor and settles `done | idle | error`. The step path is the same machine driven by hand, so a crashed process resumes without re-billing model calls.
+For a live, in-process run, use [`runAgent`](hosts.md) instead. It owns an actor and settles `done`, `idle`, or `error`. The step path drives the same machine by hand, so a crashed process resumes without repeating model calls that already completed.
 
 ## The loop in six moves
 
-The durability model this path assumes (the log is the source of truth, external inputs only, determinism, concurrency as serialization) is described in [The event log](event-log.md#the-model). The loop that drives it is six moves:
+The step path assumes the durability model described in [The event log](event-log.md#the-model): the log is the source of truth, only external inputs are recorded, transitions are deterministic, and concurrency is handled by serializing appends. The loop has six moves.
 
-1. Start a log with `initEntry(machine, input)` (the reserved `@agent.init` first envelope carries the machine input, identity, timestamp, and verification hashes).
-2. `initialTransition(machine, input)` gives the first `{ snapshot, actions }`.
-3. `getAgentEffects(machine, snapshot, actions, { history })` lowers the frontier into an ordered `AgentEffect[]`.
-4. Execute one async effect and append its completion event to the log (run `execute` effects inline; they produce no entry).
-5. `transition(machine, snapshot, event)` folds the completion back in.
-6. Repeat while `snapshot.status === "active"`. No async effect owed means **idle**: persist the log and resume later.
+1. Start a log with `initEntry(machine, input)`. The reserved `@agent.init` first envelope carries the machine input, identity, timestamp, and verification hashes.
+2. Call `initialTransition(machine, input)` to get the first `{ snapshot, actions }`.
+3. Call `getAgentEffects(machine, snapshot, actions, { history })` to lower the frontier into an ordered `AgentEffect[]`.
+4. Execute one async effect and append its completion event to the log. Run `execute` effects inline, because they produce no entry.
+5. Call `transition(machine, snapshot, event)` to fold the completion back in.
+6. Repeat while `snapshot.status === "active"`. If no async effect is owed, the machine is idle. Persist the log and resume later.
+
+<!-- viz: the six-move loop as a flow: initEntry -> initialTransition -> getAgentEffects -> execute one effect -> append entry -> transition -> loop back, with an idle exit branch when no async effect is owed -->
 
 ## Loop wiring
 
-Taught from [examples/ai-sdk-game-host/index.ts](../examples/ai-sdk-game-host/index.ts), the canonical wiring for this path. One host-owned primitive resolves a single frontier effect into the event to append (or `undefined` for a fire-and-forget action):
+The following wiring comes from [examples/ai-sdk-game-host/index.ts](../examples/ai-sdk-game-host/index.ts), the reference example for this path. The host defines one function that resolves a single frontier effect into the event to append, or returns `undefined` for a fire-and-forget action.
 
 ```ts no-check
 import { initialTransition, transition, type AnyMachineSnapshot, type EventObject } from "xstate";
@@ -63,7 +67,7 @@ async function resolveEffect(
   }
   // `decision`: pick a legal event (guard-gated by snapshot.can), append it directly.
   if (effect.kind === "decision") {
-    return resolveDecision(effect.request, executors.decide!, {
+    return resolveDecision(effect.request, executors, {
       canTake: (event) => snapshot.can(event as never),
     });
   }
@@ -102,21 +106,25 @@ async function runTurn(input: unknown, executors: AgentRequestExecutors) {
 }
 ```
 
-Per-effect resolution, by kind:
+The loop walks the frontier in order and stops at the first effect that produces an event. `execute` effects produce no event, so they all run inline and the walk continues past them. Once one event is produced, the loop appends it and folds it in, then derives a fresh frontier. Effects that were owed but not yet resolved are re-derived on the next pass, so nothing is lost by stopping early.
 
-- **`text`** (`agent.generateText` / a `createTextLogic` invoke): resolve with the model via `executeAgentRequest`, then append `effect.toDoneEvent(output)` (or `effect.toErrorEvent(error)`).
-- **`decision`** (`agent.decide`): `resolveDecision(effect.request, decide, { canTake })`, wiring `canTake` to `snapshot.can` so guard-rejected choices are caught and retried. A decision has no output of its own; the chosen machine event is what you append.
-- **`task`** (any other invoke or spawn): a plain host-run actor. Run it in your own runtime, then append `effect.toDoneEvent(output)` / `effect.toErrorEvent(error)`.
-- **`delay`** (an `after(...)` timer): the host owns the clock. Schedule the delay (a workflow sleep, a timer, a queue delay); when it fires, append `effect.event` as a normal external entry.
-- **`execute`** (a fire-and-forget action: a custom entry action, `sendTo`, `cancel`): run `effect.exec()` once at the frontier. Never recorded, never replayed.
+Resolve each effect according to its kind.
 
-**Idle.** A frontier that produces no completion event (all `execute`, or nothing owed) means the machine is waiting on an external event or a timer. Persist `entries` and leave the loop; resume later by appending the event and folding it in (or by `replay`).
+- `text`, from `agent.generateText` or a `createTextLogic` invoke. Resolve it with the model through `executeAgentRequest`, then append `effect.toDoneEvent(output)` or `effect.toErrorEvent(error)`.
+- `decision`, from `agent.decide`. Call `resolveDecision(effect.request, executors, { canTake })` and wire `canTake` to `snapshot.can`, so guard-rejected choices are caught and retried. A decision has no output of its own. Append the chosen machine event.
+- `task`, from any other invoke or spawn. Run the actor in your own runtime, then append `effect.toDoneEvent(output)` or `effect.toErrorEvent(error)`.
+- `delay`, from an `after(...)` timer. The host owns the clock. Schedule the delay as a workflow sleep, a timer, or a queue delay. When it fires, append `effect.event` as a normal external entry.
+- `execute`, from a fire-and-forget action such as a custom entry action, `sendTo`, or `cancel`. Call `effect.exec()` once at the frontier. These effects are never recorded and never replayed.
 
-For the resume-by-replay flavor of this same loop (persist nothing but the event log, rebuild the frontier with `replay` each turn), see [examples/cloudflare-workers-ai-host/index.ts](../examples/cloudflare-workers-ai-host/index.ts). That example simulates durability: its `entries` array lives in process memory for the duration of one run. It shows the shape a real Worker would use, with a real store (KV, D1, a Durable Object) in place of the array.
+If a frontier produces no completion event, either because every effect is `execute` or because nothing is owed, the machine is idle and waiting on an external event or a timer. Persist `entries` and leave the loop. Resume later by appending the event and folding it in, or by calling `replay`.
+
+For the resume-by-replay version of this loop, which persists only the event log and rebuilds the frontier with `replay` each turn, see [examples/cloudflare-workers-ai-host/index.ts](../examples/cloudflare-workers-ai-host/index.ts). That example only simulates durability, because its `entries` array lives in process memory for one run. A real Worker uses the same structure with a store such as KV, D1, or a Durable Object in place of the array.
 
 ### Token usage on this path
 
-`executeAgentRequest` always returns the raw executor result alongside the output. Use it when you want a token budget in the machine: `getCallUsage(raw)` normalizes it, and the reserved [`@agent.usage`](usage-and-budgets.md#the-agentusage-event) event is applied as an ordinary event in the fold: journaled like any other external input, so replay reproduces the counter.
+`executeAgentRequest` returns the raw executor result alongside the output. Use the raw result when you want a token budget in the machine. `getCallUsage(raw)` normalizes it, and you apply the reserved [`@agent.usage`](usage-and-budgets.md#the-agentusage-event) event as an ordinary event in the fold. It is journaled like any other external input, so replay reproduces the counter.
+
+Append the usage event before the call's own done event. A budget guard then reads the new token total in the same step that consumes the output. This is the ordering `runAgent` uses.
 
 ```ts
 import { AGENT_USAGE_EVENT_TYPE, executeAgentRequest, getCallUsage } from "@statelyai/agent";
@@ -124,8 +132,6 @@ import { AGENT_USAGE_EVENT_TYPE, executeAgentRequest, getCallUsage } from "@stat
 if (effect.kind === "text") {
   const { output, raw } = await executeAgentRequest(effect, executors);
 
-  // Apply usage BEFORE the call's own result, so a budget guard reads the
-  // tokens in the same step that consumes the output (runAgent's ordering).
   const usage = getCallUsage(raw);
   if (usage) {
     append({ type: AGENT_USAGE_EVENT_TYPE, usage });
@@ -134,11 +140,11 @@ if (effect.kind === "text") {
 }
 ```
 
-Where `append(event)` is the loop's own `entries.push(createReplayEntry(machine, entries, event))` plus `transition(...)`. Add `kind`/`id`/`src`/`model` to the event for the attribution `runAgent` stamps. Same opt-in rule as everywhere: a machine that declares no `'@agent.usage'` transition takes nothing, so only append it when the machine declares one.
+In this example, `append(event)` is the loop's own `entries.push(createReplayEntry(machine, entries, event))` followed by `transition(...)`. Add `kind`, `id`, `src`, and `model` to the event to record the attribution that `runAgent` stamps. Usage is opt-in: a machine that declares no `'@agent.usage'` transition ignores the event, so append it only when the machine declares one.
 
 ### Standalone decision resolution
 
-`getAgentEffects` surfaces a decision effect whose request's `events` field holds only the events legal from the current snapshot ([`allowedEvents`](decisions.md) intersected with XState guards). Resolve it to the chosen, validated event with `resolveDecision`, without running the whole loop:
+`getAgentEffects` surfaces a decision effect whose request has an `events` field holding only the events that are legal from the current snapshot. That set is [`allowedEvents`](decisions.md) intersected with the XState guards. Resolve it to the chosen, validated event with `resolveDecision`, without running the whole loop.
 
 ```ts
 import { getAgentEffects, resolveDecision } from "@statelyai/agent";
@@ -146,17 +152,22 @@ import { getAgentEffects, resolveDecision } from "@statelyai/agent";
 const effects = getAgentEffects(machine, snapshot, actions, { history: entries });
 const effect = effects.find((e) => e.kind === "decision")!;
 
-const event = await resolveDecision(effect.request, decide, {
+const event = await resolveDecision(effect.request, executors, {
   canTake: (candidate) => snapshot.can(candidate),
 });
 // { type: 'ATTACK', target: 'orc' }
 ```
 
-`resolveDecision` retries on an unknown event type, an invalid payload, or a guard rejection, and throws `AgentDecisionExhaustedError` when the retry budget runs out (`renderDecisionAttempts` formats the attempts for a log). Its `snapshot.can(event)` check closes the gap at apply time. See [Decisions](decisions.md#validation-and-retries).
+`resolveDecision(request, executors, options)` takes the whole executor set, the same object `executeAgentRequest` takes, and uses its `decide` slot. An executor set with no `decide` function throws an `AgentError` with code `'missing-decide-executor'`. The call retries on an unknown event type, an invalid payload, or a guard rejection, up to `maxRetries` retries after the first attempt, which defaults to 2. It throws `AgentDecisionExhaustedError` when the retry budget runs out. Use `renderDecisionAttempts` to format the attempts for a log. The `snapshot.can(event)` check validates the choice at apply time. See [Decisions](decisions.md#validation-and-retries).
 
 ## Durable append before continue
 
-For an initialized thread, treat the transition after an effect as tentative until its completion envelope commits:
+On an initialized thread, treat the transition after an effect as tentative until its completion envelope commits.
+
+The sample below uses two host-supplied pieces. `store` is any `AgentEventLogStore`, such as `createInMemoryEventLogStore()` or the SQLite store; see [the store contract](event-log.md#the-store-contract). `executeEffect` is your own version of the `resolveEffect` function shown above, returning the event to append.
+
+<!-- viz: append-before-continue sequence: read log -> replay -> execute effect with requestId as idempotency key -> optimistic append at expectedIndex -> commit or conflict -> reload and replay the winning history -->
+
 
 ```ts no-check
 const entries = await store.read(threadId);
@@ -181,27 +192,30 @@ await store.append({
 const committed = replay(machine, [...entries, entry]);
 ```
 
-- The effect must run before its result can be appended, so a crash in that narrow window can retry it.
-- Every owed effect has a replay-stable `requestId`; pass it to the provider or tool as an idempotency key.
-- The event store guarantees one winning control-state append, not exactly-once behavior from an arbitrary external API.
+- The effect runs before its result can be appended, so a crash in that window causes the effect to run again on resume.
+- Every owed effect has a replay-stable `requestId`. Pass it to the provider or tool as an idempotency key.
+- The event store guarantees one winning control-state append. It does not guarantee exactly-once behavior from an external API.
 
-This pure driver is what the step path buys a durable host. `runAgent` owns a live XState actor; its `onEvent` sees accepted transitions synchronously and cannot await an asynchronous store before XState advances. A future durable runner can wrap this exact replay/effect/append loop, but passing a store to today's actor-backed runner would only provide write-through recording, not the same guarantee.
+`runAgent` cannot provide this guarantee. It owns a live XState actor, and its `onEvent` callback sees accepted transitions synchronously, so it cannot await an asynchronous store before XState advances. A future durable runner can wrap this same replay, effect, and append loop. Passing a store to today's actor-backed runner would only provide write-through recording.
 
 ## Ordering guarantee
 
-`getAgentEffects` emits a single transition's effects in **document order**. An entry action, then a `spawn`, then a `sendTo` to that spawned child yields `execute`, `task`, `execute` in that order, never a reordered set. This is load-bearing: the `sendTo` must run after the child it targets is started. Effects visible only on the snapshot (children spawned by an earlier transition still pending) append after the action-derived effects, deduped by site id.
+`getAgentEffects` emits a single transition's effects in document order. An entry action, then a `spawn`, then a `sendTo` targeting that spawned child yields `execute`, `task`, `execute` in that order. The order matters, because the `sendTo` must run after the child it targets is started. Effects that are visible only on the snapshot, such as children spawned by an earlier transition that are still pending, are appended after the action-derived effects and deduped by site id.
 
 ## requestId and idempotency
 
-Every non-`execute` effect carries a `requestId` of the form `site#occurrence`: the invoke/spawn site id, then a **1-based occurrence** derived from the event log (`job#1`, `job#2` on re-entry). Because it is derived from the log, the same log yields identical requestIds on every replay.
+Every effect except `execute` carries a `requestId` in the form `site#occurrence`. The `site` is the invoke or spawn site id. The `occurrence` is a 1-based counter derived from the event log, so re-entering a site produces `job#1`, then `job#2`. Because the counter is derived from the log, the same log yields identical `requestId` values on every replay.
 
-Use it as the **idempotency key** for at-least-once effect execution. A host runs the effect, then appends its completion; a crash in that window re-runs the effect on resume. An idempotent downstream (keyed by `requestId`) closes the gap. Errors count as completions: `xstate.error.actor` with the effect's `actorId` routes `onError` and increments the occurrence, so a retry is a fresh occurrence (`#2`, `#3`, …), not a re-run of the same one.
+Use the `requestId` as the idempotency key for at-least-once effect execution. A host runs the effect and then appends its completion, so a crash in that window re-runs the effect on resume. A downstream service that is idempotent on `requestId` removes the duplicate. Errors count as completions: an `xstate.error.actor` event with the effect's `actorId` routes to `onError` and increments the occurrence, so a retry is a new occurrence such as `#2` or `#3`, not a repeat of the same one.
 
 ## Crash recovery and resume
 
-`replay(machine, entries)` folds an event log without executing anything and returns `{ snapshot, effects }`: the final snapshot plus the effects still owed at the frontier. This is crash recovery, fork resume, and time travel in one call.
+`replay(machine, entries)` folds an event log without executing anything and returns `{ snapshot, effects }`, the final snapshot plus the effects still owed at the frontier. Use it for crash recovery, fork resume, and time travel.
 
-Still-owed **dynamic spawns** are recovered too. A fan-out that spawned N branches and recorded 2 of N completions before a crash: `replay` re-derives the one owed branch task (with its correct `requestId`), so completing it finishes the run identically to the uninterrupted path (pinned in `src/effects.test.ts`).
+`replay` also recovers still-owed dynamic spawns. If a fan-out spawned N branches and recorded 2 of N completions before a crash, `replay` re-derives the one owed branch task with its correct `requestId`. Completing that task finishes the run the same way an uninterrupted run would. This behavior is covered in `src/effects.test.ts`.
+
+<!-- viz: crash recovery: persisted event log -> replay -> {snapshot, owed effects}, showing a fan-out with 2 of 3 branch completions recorded and the third branch re-derived -->
+
 
 ```ts
 import { replay } from "@statelyai/agent";
@@ -211,23 +225,27 @@ const { snapshot, effects } = replay(gameMachine, entries, options);
 // resolve `effects`, append the completion, replay again (or fold with transition for speed).
 ```
 
-`verifyReplay(machine, entries)` re-checks the recorded envelopes against a fresh fold, so a tampered or diverged log fails loudly (`AgentReplayDivergenceError`, or `AgentReplayMachineMismatchError` when the log came from a different machine).
+The rule is: use `replay` for a cold resume, when a fresh process rebuilds the frontier from the log, and fold with `transition` inside a live loop, when you already hold the current snapshot.
 
-**Compaction.** A snapshot taken mid-flight cannot carry in-flight effect state; the event log can. So snapshot only at **quiescent / idle** points. Resume from an idle snapshot plus the entries appended since, or replay the whole log from index 0. Both yield the identical state. See [The event log](event-log.md) for the `AgentEventLogStore` protocol and the snapshot-as-compaction cache.
+`replay(machine, entries, { verify: 'strict' })` re-checks the recorded envelopes against a fresh fold. A tampered or diverged log throws `AgentReplayDivergenceError`, or `AgentReplayMachineMismatchError` when the log came from a different machine.
+
+### Compaction
+
+A snapshot taken mid-flight cannot carry in-flight effect state, but the event log can. Take a snapshot only at quiescent or idle points. To resume, use an idle snapshot plus the entries appended since it was taken, or replay the whole log from index 0. Both produce the same state. See [The event log](event-log.md) for the `AgentEventLogStore` protocol and the snapshot-as-compaction cache.
 
 ## Event log exclusions
 
-`execute` effects (fire-and-forget custom actions, `sendTo`, `cancel`) run once at the frontier and are **skipped on replay** (replay re-derives them). They are not durable state.
+`execute` effects, which cover fire-and-forget custom actions, `sendTo`, and `cancel`, run once at the frontier and are skipped on replay, because replay re-derives them. They are not durable state.
 
-Anything that must survive a crash has to be an **invoke or spawn of a registered actor source**, so it surfaces as a `text` / `decision` / `task` effect whose completion is recorded (the completion-event rule). A side effect written as a plain fire-and-forget action is not recoverable; model it as an invoke if its result must be replayed.
+Anything that must survive a crash has to be an invoke or spawn of a registered actor source, so that it surfaces as a `text`, `decision`, or `task` effect whose completion is recorded. A side effect written as a fire-and-forget action is not recoverable. Model it as an invoke if its result must be replayed.
 
 ## Known limits
 
-See `src/effects.ts`:
+These limits are documented in `src/effects.ts`.
 
-- **Every spawn is host-executed on this path.** A spawned machine surfaces as a `task` the host runs, not a live nested child actor. No live nested child machines yet.
-- **Streaming output has no log channel.** A `text` effect carries its `mode` and `executeAgentRequest` dispatches to `streamText`, but chunks are a live-host concern; only the final output lands in the log.
-- **`decision` effects assume the chosen event exits the invoking state.** A decision whose chosen event keeps the machine in the same invoking state is not modeled here.
+- Every spawn is host-executed on this path. A spawned machine surfaces as a `task` that the host runs, not as a live nested child actor. Live nested child machines are not supported yet.
+- Streaming output has no log channel. A `text` effect carries its `mode` and `executeAgentRequest` dispatches to `streamText`, but chunks are a live-host concern. Only the final output lands in the log.
+- `decision` effects assume the chosen event exits the invoking state. A decision whose chosen event leaves the machine in the same invoking state is not modeled here.
 
 ## Related
 

--- a/docs/text-requests.md
+++ b/docs/text-requests.md
@@ -5,11 +5,15 @@ description: Declare typed model calls on an agent machine and invoke them from 
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
+This page covers declaring text requests, invoking them from a state, and reading structured or streamed output.
+
 ## Request declarations in setupAgent
 
 <!-- requests config surface from src/setup-agent.ts and src/text-logic.ts -->
 
-A **text request** is a typed model call your machine invokes by name: declared once with its own input/output schemas, a model reference, and a prompt built from that input. The machine decides when to call; the host executes it. Pass a `requests` map to `setupAgent`; each entry becomes an invokable actor under the same name.
+A **text request** is a typed model call that your machine invokes by name. You declare it once with its own input and output schemas, a model reference, and a prompt built from that input. The machine decides when the call happens. The host executes it.
+
+Pass a `requests` map to `setupAgent`. Each entry becomes an invokable actor under the same name.
 
 ```ts
 import { z } from "zod";
@@ -18,7 +22,10 @@ import { defineModels } from "@statelyai/agent/ai-sdk";
 import { openai } from "@ai-sdk/openai";
 
 // Model IDs here are illustrative; substitute your provider's current models.
-const models = defineModels({ quick: openai("gpt-5.4-mini") });
+const models = defineModels({
+  quick: openai("gpt-5.4-mini"),
+  careful: openai("gpt-5.4"),
+});
 const answerSchema = z.object({ answer: z.string() });
 
 const agentSetup = setupAgent({
@@ -38,16 +45,20 @@ const agentSetup = setupAgent({
 ```
 
 - Each schema field accepts any [Standard Schema](https://standardschema.dev) validator.
-- Both slots are optional: omit `output` and the request resolves to `string`; omit `input` and the invoke needs no `input`. A request with neither writes `schemas: {}` (the key itself stays required on `requests` entries; standalone `createTextLogic` can omit `schemas` entirely).
-- Each request-shaping field (`system`, `prompt`, `messages`, `temperature`, `maxOutputTokens`, and the rest) is a static value or a `({ input }) => value` function.
+- Both schema slots are optional. Omit `output` and the request resolves to `string`. Omit `input` and the invoke needs no `input`. A request with neither writes `schemas: {}`. The `schemas` key itself stays required on `requests` entries, while a standalone `createTextLogic` can omit it entirely.
+- Each request-shaping field, such as `system`, `prompt`, `messages`, `temperature`, and `maxOutputTokens`, is either a static value or a `({ input }) => value` function.
 
 ### Model references
 
-`model` is a key into the `models` registry, or any bare string the [host](hosts.md#typed-model-aliases) resolves at run time. See [Authoring forms](machines.md#authoring-forms).
+`model` is a key into the `models` registry, or any bare string that the [host](hosts.md#typed-model-aliases) resolves at run time. See [Authoring forms](machines.md#authoring-forms).
+
+### Standalone requests
+
+The samples later on this page use `createTextLogic`, which declares the same request as a standalone value instead of an entry in the `requests` map. The two forms take identical options. See [Reusable request logic with createTextLogic](#reusable-request-logic-with-createtextlogic).
 
 ## Invoking a request from a state
 
-Invoke by name with `src`, pass `input`, read the typed result in `onDone` (full machine in the [quickstart](quickstart.md)):
+Invoke the request by name with `src`, pass `input`, and read the typed result in `onDone`. The [quickstart](quickstart.md) shows a full machine.
 
 ```ts no-check
 // inside states: { ... }
@@ -61,13 +72,13 @@ answering: {
 },
 ```
 
-In `onDone`, `output` is already validated against the request's output schema and typed from it (`{ answer: string }` here) - read `output.answer` directly, no parsing step in the machine.
+In `onDone`, `output` is already validated against the request's output schema and typed from it. In this example the type is `{ answer: string }`, so you read `output.answer` directly. The machine needs no parsing step.
 
-> **Note: route on `request.name`.** Every lowered request carries its `setupAgent({ requests })` key as `name`, so a mock executor (or a router picking providers per request) tells requests apart with `request.name === 'answerQuestion'`. Do not sniff `system`/`prompt` text. See [examples/context-compaction/index.test.ts](../examples/context-compaction/index.test.ts).
+> **Note:** Route on `request.name`. Every lowered request carries its `setupAgent({ requests })` key as `name`. A mock executor, or a router that picks providers per request, tells requests apart with `request.name === 'answerQuestion'`. Do not inspect the `system` or `prompt` text. See [examples/context-compaction/index.test.ts](../examples/context-compaction/index.test.ts).
 
 ### Narrowing an unknown output outside the machine
 
-The `parseOutput(schema, output)` helper validates a value against a schema and returns it parsed, throwing on mismatch. Use it in host code holding a raw, still-untyped output (from a persisted snapshot, or an inline `agent.generateText` result typed `unknown`). Never needed inside `onDone`.
+The `parseOutput(schema, output)` helper validates a value against a schema and returns the parsed value. It throws on a mismatch. Use it in host code that holds a raw, still-untyped output, such as a value from a persisted snapshot or an inline `agent.generateText` result typed `unknown`. You never need it inside `onDone`.
 
 ```ts
 import { parseOutput } from "@statelyai/agent";
@@ -79,9 +90,9 @@ const answer = parseOutput(answerSchema, rawOutput); // typed as { answer: strin
 
 <!-- output-mode derivation from src/text-logic.ts (getAgentOutputMode) -->
 
-Output is **structured** when the schema describes an object, an array, or a top-level union of them (`z.union`/`z.discriminatedUnion`), and plain text otherwise: `output: z.object({ ... })` returns a validated object, `output: z.string()` returns the model's text.
+Output is structured when the schema describes an object, an array, or a top-level union of them built with `z.union` or `z.discriminatedUnion`. Otherwise the output is plain text. An `output: z.object({ ... })` schema returns a validated object. An `output: z.string()` schema returns the model's text.
 
-> **For host implementers: the structured-output envelope.** Every structured request is sent wrapped in the [structured-output envelope](./hosts.md#the-structured-output-envelope): a root object `{ result: <your schema> }` that the host must unwrap before validation. This keeps a bare union or array root portable, since providers that reject a union/array _root_ still accept it nested under `result`. Machine authors always declare and receive the bare schema; the envelope is invisible to the machine.
+> **Note for host implementers:** Every structured request is sent wrapped in the [structured-output envelope](./hosts.md#the-structured-output-envelope), a root object `{ result: <your schema> }`. The host must unwrap it before validation. The envelope keeps a bare union or array root portable, because providers that reject a union or array at the root still accept it nested under `result`. Machine authors declare and receive the bare schema. The envelope is invisible to the machine.
 
 ```ts
 export const triageTicket = createTextLogic({
@@ -93,42 +104,43 @@ export const triageTicket = createTextLogic({
       reply: z.string(),
     }),
   },
-  model: "ticketTriage",
+  model: "quick",
   system: "Triage the support ticket: sentiment, category, and a short reply.",
   prompt: ({ input }) => input.ticket,
 });
 ```
 
-The mode is derived from the schema automatically; you never set it. See [examples/triage/index.ts](../examples/triage/index.ts).
+The mode is derived from the schema automatically. You never set it. See [examples/triage/index.ts](../examples/triage/index.ts).
 
 ### Reasoning
 
 <!-- reasoning opt-in from src/text-logic.ts (AgentTextRequest.reasoning) -->
 
-Set `reasoning: true` on a structured request to add an optional string `reasoning` field to the [envelope](./hosts.md#the-structured-output-envelope), listed **before** `result` so property order nudges the model to reason before answering:
+Set `reasoning: true` on a structured request to add an optional string `reasoning` field to the [envelope](./hosts.md#the-structured-output-envelope). The field is listed before `result`, so the property order prompts the model to reason before answering:
 
 ```ts
 export const triageTicket = createTextLogic({
   schemas: { input: z.object({ ticket: z.string() }), output: triageSchema },
-  model: "ticketTriage",
+  model: "quick",
   reasoning: true, // opt in
   prompt: ({ input }) => input.ticket,
 });
 ```
 
-The reasoning never enters machine context or output; it surfaces only on the raw executor result (`result.reasoning` on `createAiSdkExecutors`' `generateText`), on `runAgent`'s `onResult(request, { raw })`, and as a `reasoning` field on the `request.end` `onTrace` event. Ignored for text-mode requests.
+The reasoning never enters machine context or output. It surfaces in three places: on the raw executor result as `result.reasoning` from the `generateText` executor of `createAiSdkExecutors`, on `runAgent`'s `onResult(request, { raw })`, and as a `reasoning` field on the `request.end` `onTrace` event. Text-mode requests ignore the option.
 
 ## Streaming requests
 
 <!-- stream mode from src/text-logic.ts and examples/joke -->
+<!-- viz: sequence diagram of a streaming request: state invokes the request -> host streamText executor -> chunks delivered to runAgent onChunk while the invoke is pending -> final text resolves onDone -->
 
-A request streams when its `mode` is `'stream'`; without `mode` it is single-shot (`'generate'`). A streaming request resolves to the final text, with intermediate chunks delivered to `runAgent`'s `onChunk`.
+A request streams when its `mode` is `'stream'`. Without `mode`, the request is single-shot, equivalent to `'generate'`. A streaming request resolves to the final text and delivers intermediate chunks to `runAgent`'s `onChunk`.
 
 ```ts no-check
 export const tellJoke = createTextLogic({
   mode: "stream",
   schemas: { input: z.object({ topic: z.string() }), output: z.string() },
-  model: "jokeWriter",
+  model: "quick",
   system: "You tell short, punchy jokes.",
   prompt: ({ input }) => `Tell a joke about ${input.topic}.`,
 });
@@ -140,19 +152,19 @@ const result = await runAgent(machine, {
 });
 ```
 
-- `onChunk` fires per chunk alongside the request that produced it, so parallel streams stay distinguishable.
-- `onChunk` is purely observational.
-- A `mode: 'stream'` request needs a `streamText` executor; without one, `runAgent` fails at bind time.
+- `onChunk` fires once per chunk and receives the request that produced it, so parallel streams stay distinguishable.
+- `onChunk` is observational only. It cannot change the run.
+- A `mode: 'stream'` request needs a `streamText` executor. Without one, `runAgent` fails at bind time.
 
 See [examples/joke/index.ts](../examples/joke/index.ts).
 
 ## Tools and multi-step loops
 
-<!-- tools and metadata.maxSteps from src/types.ts (AgentTool) and src/ai-sdk/index.ts -->
+<!-- tools and maxSteps from src/types.ts (AgentTool), src/text-logic.ts and src/ai-sdk/index.ts -->
 
-A text request can carry `tools`: a map of tool name to a tool. Tools are whatever your SDK produces, since the type is a minimal structural contract. See [Tools](tools.md) for the contract, attachment, and how the host runs the tool loop.
+A text request can carry `tools`, a map of tool name to tool. The tool type is a minimal structural contract, so tools from any SDK work. See [Tools](tools.md) for the contract, how to attach tools, and how the host runs the tool loop.
 
-To let one request run a bounded tool-call loop, set `metadata.maxSteps`. The shipped AI SDK adapter forwards it as `stopWhen: stepCountIs(maxSteps)`; a request with no `maxSteps` stays single-step.
+To let one request run a bounded tool-call loop, set the typed `maxSteps` field on the request. The shipped AI SDK adapter forwards it as `stopWhen: stepCountIs(maxSteps)`. A request with no `maxSteps` stays single-step. The adapter also reads `metadata.maxSteps` as a fallback, and the typed field wins when both are present.
 
 ```ts no-check
 export const research = createTextLogic({
@@ -160,17 +172,17 @@ export const research = createTextLogic({
   model: "careful",
   prompt: ({ input }) => input.question,
   tools: { getWeather },
-  metadata: { maxSteps: 5 },
+  maxSteps: 5,
 });
 ```
 
-> **Note:** `metadata` is host-owned per-call data, passed through untouched by core. A host that does not understand a key ignores it, so requests stay portable across hosts.
+> **Note:** `metadata` is host-owned per-call data. Core passes it through untouched. A host that does not understand a key ignores it, so requests stay portable across hosts.
 
 ## Reusable request logic with createTextLogic
 
 <!-- createTextLogic from src/text-logic.ts and examples/email-drafter -->
 
-Inline `requests:` (above) is the default. Reach for `createTextLogic` when a request should be standalone (exported, tested on its own, or shared across machines) and registered under `actors`. Each `requests` entry is exactly what `setupAgent` builds internally from `createTextLogic`, so the two are interchangeable. See [Which authoring form when](machines.md#authoring-forms).
+The inline `requests` map shown above is the default form. Use `createTextLogic` when a request should be standalone, meaning exported, tested on its own, or shared across machines, and registered under `actors`. `setupAgent` builds each `requests` entry from `createTextLogic` internally, so the two forms are interchangeable. See [Authoring forms](machines.md#authoring-forms).
 
 ```ts
 import { createTextLogic, setupAgent, type AgentMessage } from "@statelyai/agent";
@@ -183,7 +195,7 @@ export const draftEmail = createTextLogic({
     }),
     output: z.object({ to: z.string(), subject: z.string(), body: z.string() }),
   },
-  model: "emailDrafter",
+  model: "careful",
   system: "Draft a polished email from the request.",
   messages: ({ input }) => [...input.messages, userMessage(input.prompt)],
 });
@@ -191,11 +203,11 @@ export const draftEmail = createTextLogic({
 const agentSetup = setupAgent({ models, context, input, output, actors: { draftEmail } });
 ```
 
-Because `draftEmail` is a value, a test can import it and drive it with a fake executor, no machine required. [examples/email-drafter/agent-logic.ts](../examples/email-drafter/agent-logic.ts) shows structured, streaming, and message-based `createTextLogic` requests across a multi-state workflow.
+Because `draftEmail` is a value, a test can import it and drive it with a fake executor without a machine. [examples/email-drafter/agent-logic.ts](../examples/email-drafter/agent-logic.ts) shows structured, streaming, and message-based `createTextLogic` requests across a multi-state workflow.
 
 ## Related
 
-- [Tools](tools.md): defining tools, attaching them to a request, and how the host runs the tool loop.
-- [Hosts](hosts.md): the executors that run text requests and how model aliases reach a provider.
-- [Messages](messages.md): the `messages` field a request can send instead of a bare `prompt`.
-- [Decisions](decisions.md): the other request kind, choosing a legal machine event instead of producing text.
+- Read more about [Tools](tools.md), including defining tools, attaching them to a request, and how the host runs the tool loop.
+- Read more about [Hosts](hosts.md), including the executors that run text requests and how model aliases reach a provider.
+- Read more about [Messages](messages.md), the `messages` field a request can send instead of a bare `prompt`.
+- Read more about [Decisions](decisions.md), the other request kind, which chooses a legal machine event instead of producing text.

--- a/docs/thinking-in-state-machines.md
+++ b/docs/thinking-in-state-machines.md
@@ -5,13 +5,17 @@ description: A design tutorial. Take one hand-rolled agent loop, name the states
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-You already have a state machine. It is spread across a `while` loop, a few booleans, an `if` ladder, and a comment that says "don't call this twice". This page teaches the translation: how to find those states, name them, and write them down.
+This page shows how to find the states hidden in an agent loop, name them, and write them down as a machine. A typical loop already contains a state machine, spread across a `while` loop, a few booleans, and an `if` ladder.
 
-One example carries the whole page: a **support triage agent**. It classifies a ticket, drafts a reply, has the reply reviewed, and sometimes hands off to a human. If you want the mechanical refactor of an existing codebase instead, read [Migrating from a hand-rolled loop](from-a-loop.md); this page is about the design move that comes first.
+The example is a support triage agent. It classifies a ticket, drafts a reply, has the reply reviewed, and sometimes hands off to a human.
+
+For the mechanical refactor of an existing codebase, see [Migrating from a hand-rolled loop](from-a-loop.md). This page covers the design work that comes first.
+
+> **Version requirement.** Build the machine with the `xstate` install this package peers on, v6 alpha.25 or newer. See [Installation](quickstart.md#installation). Machines authored for XState v5 usually port with few changes, but a machine object imported from a separate `xstate@5` install does not bind. Write event-transition guards as functions that return `undefined`. XState v6 drops named string guards on `on`, and the function form is what makes `snapshot.can(event)` reflect the guard.
 
 ## The loop to model
 
-Here is the agent as most people write it first. It works.
+The following loop is a working version of the agent.
 
 ```ts no-check
 async function triage(ticket: string) {
@@ -25,7 +29,7 @@ async function triage(ticket: string) {
       category = await classify(ticket);
       if (category === "unknown") escalated = true;
     } else if (escalated) {
-      const reply = await waitForHumanReply(ticket, draft); // blocks. for days.
+      const reply = await waitForHumanReply(ticket, draft); // can block for days
       return reply;
     } else if (!draft) {
       draft = await writeReply(ticket, category);
@@ -34,7 +38,7 @@ async function triage(ticket: string) {
       if (verdict === "send") return draft;
       if (verdict === "escalate") escalated = true;
       if (verdict === "revise") {
-        if (revisions >= 2) return draft; // give up revising
+        if (revisions >= 2) return draft; // stop revising
         revisions++;
         draft = null;
       }
@@ -43,16 +47,16 @@ async function triage(ticket: string) {
 }
 ```
 
-Nothing here is wrong. But four things about it are hard:
+The loop is correct, but four things are hard to do with it:
 
-- **Testing** means mocking `classify`, `writeReply`, and `review` and hoping the branch order is right.
-- **Resuming** is impossible: `waitForHumanReply` holds the process, and the four locals are not written down anywhere.
-- **Observing** it means adding `console.log` at every branch, because the loop never names where it is.
-- **Bounding** it lives in one `revisions >= 2` check that a future edit will quietly step around.
+- Testing requires mocking `classify`, `writeReply`, and `review`, and assuming the branch order is right.
+- Resuming is not possible. `waitForHumanReply` holds the process open, and the four local variables are not written down anywhere.
+- Observing the run requires a `console.log` at every branch, because the loop never names where it is.
+- Bounding the work depends on one `revisions >= 2` check that a later edit can bypass.
 
 ## The implicit states
 
-Read the loop again and ignore the code. Ask: **at any instant, what is this agent in the middle of?** The answers are the states, and they are already in the source, wearing disguises.
+Read the loop again and ask what the agent is in the middle of at any instant. The answers are the states. They are already in the source, under other names.
 
 | In the loop                          | The state it is really in |
 | ------------------------------------ | ------------------------- |
@@ -63,19 +67,21 @@ Read the loop again and ignore the code. Ask: **at any instant, what is this age
 | `escalated`, blocked in `await`      | `awaitingHuman`           |
 | `return draft`                       | `sent` (final)            |
 
-The disguises to look for, in any loop:
+<!-- viz: support triage machine: classifying -> routing (choice) -> drafting -> reviewing -> sending/awaitingHuman, with the REVISE loop back to drafting capped by revisions < 2 -->
 
-- **A nullable local** (`draft`) is a state boundary: "before we have it" and "after we have it" are different states.
-- **A boolean flag** (`escalated`) is a state you named as an adjective.
-- **A string verdict** (`"send" | "revise" | "escalate"`) is an event set.
-- **A counter compared to a constant** (`revisions >= 2`) is a guard.
-- **A blocking `await` on a person** is not work at all. It is a wait.
+Look for the following patterns in any loop:
 
-Two states can look identical and still be different states. `drafting` after classification and `drafting` after a revision run the same code, but only the second one increments a counter. Where the loop needed a flag to tell them apart, the machine tells them apart by which transition arrived.
+- A nullable local variable such as `draft` marks a state boundary. Before the value exists and after it exists are different states.
+- A boolean flag such as `escalated` is a state named as an adjective.
+- A string verdict such as `"send" | "revise" | "escalate"` is an event set.
+- A counter compared to a constant such as `revisions >= 2` is a guard.
+- A blocking `await` on a person is a wait, not work.
 
-## Modeling move 1: states as prompts
+Two states can run the same code and still be different states. `drafting` after classification and `drafting` after a revision run the same code, but only the second increments a counter. The loop needs a flag to tell them apart. The machine tells them apart by which transition arrived.
 
-Each state that calls the model owns exactly one prompt. The model only ever does two things: **produce a value** or **choose an event**. `classify` and `writeReply` produce values, so they become text logic, with the prompt sitting next to the state that uses it.
+## States as prompts
+
+Each state that calls the model owns one prompt. The model does one of two things: it produces a value, or it chooses an event. `classify` and `writeReply` produce values, so they become text logic, and the prompt sits next to the state that uses it.
 
 ```ts no-check
 const classifyTicket = createTextLogic({
@@ -86,11 +92,11 @@ const classifyTicket = createTextLogic({
 });
 ```
 
-The `classifying` state invokes it, and its `onDone` says where the value lands and which state comes next. One prompt per state is the constraint that pays. A prompt that has to describe three jobs is a prompt that will do the wrong one; three states with one prompt each cannot.
+The `classifying` state invokes this logic. Its `onDone` sets where the value lands and which state comes next. Keep one prompt per state. A prompt that describes three jobs at once can do the wrong one.
 
-## Modeling move 2: transitions as legal moves
+## Transitions as legal moves
 
-`review` returned a string that the loop then branched on. In the machine, the model does not return a string to branch on. It **chooses an event**, from a list the machine hands it, and the transition is the branch:
+In the loop, `review` returned a string and the loop branched on it. In the machine, the model chooses an event from a list the machine supplies, and the transition is the branch.
 
 ```ts no-check
 reviewing: {
@@ -111,32 +117,32 @@ reviewing: {
 },
 ```
 
-The difference from a string verdict is enforcement. A returned string can be anything, and every caller re-validates it. A chosen event is checked against the snapshot before it takes effect: an event the state does not accept never happens. See [Decisions](decisions.md).
+A returned string can hold any value, and every caller has to validate it. A chosen event is checked against the snapshot before it takes effect, so an event the state does not accept never happens. See [Decisions](decisions.md).
 
-## Modeling move 3: guards as policy
+## Guards as policy
 
-`revisions >= 2` was a rule buried inside a branch. As a guard it becomes part of the graph, which means the model is subject to it rather than asked about it.
+`revisions >= 2` was a rule inside a branch. As a guard, it becomes part of the graph, and it applies to the model rather than being described to it.
 
-Write event transitions as functions returning `undefined` when the move is illegal:
+Write event transitions as functions that return `undefined` when the move is illegal.
 
 ```ts no-check
-// Wrong: the cap lives in the prompt, so the model can talk its way past it.
+// Wrong: the cap lives in the prompt.
 system: 'Ask to REVISE at most twice.',
 
-// Right: the cap is a transition, so REVISE stops being an available move.
+// Right: the cap is a transition.
 REVISE: ({ context, event }) =>
   context.revisions < 2
     ? { target: 'drafting', context: { note: event.note, revisions: context.revisions + 1 } }
     : undefined,
 ```
 
-Returning `undefined` does real work. The decision core checks each candidate with `snapshot.can(event)`, records the refusal as `rejected-by-guard`, and asks the model again with the remaining legal moves. **The machine's guards constrain the model.** That is the whole point.
+Returning `undefined` has an effect on the decision. The decision core checks each candidate with `snapshot.can(event)`, records the refusal as `rejected-by-guard`, and asks the model again with the remaining legal moves.
 
-## Modeling move 4: idle states as waits
+## Idle states as waits
 
-`await waitForHumanReply(...)` was the worst line in the loop: it holds a process open for something that may take days, and everything before it is lost if the process dies.
+`await waitForHumanReply(...)` holds a process open for work that may take days. If the process dies, everything before that line is lost.
 
-A wait is not work. It is a state with no invoke and an `on:` handler:
+A wait is a state with no invoke and an `on` handler.
 
 ```ts no-check
 awaitingHuman: {
@@ -146,11 +152,11 @@ awaitingHuman: {
 },
 ```
 
-When nothing is in flight, `runAgent` settles `{ status: 'idle', snapshot }` instead of hanging. Persist the snapshot, show the human their options (`getAcceptedEvents(snapshot)` lists exactly the legal ones), and resume later, in another process, by handing the snapshot back with the event. See [Human in the loop](human-in-the-loop.md).
+When no work is in flight, `runAgent` settles with `{ status: 'idle', snapshot }` instead of hanging. Persist the snapshot and show the person their options. [`getAcceptedEvents(snapshot)`](human-in-the-loop.md) lists the legal events. To resume later, in the same process or another one, pass the snapshot back with the event. See [Human in the loop](human-in-the-loop.md).
 
 ## The finished machine
 
-Same four model calls, same policy, no flags.
+The machine below makes the same four model calls and applies the same policy as the loop, without the flags. The `routing` state uses `type: "choice"`, which resolves its branch immediately, without an event or a model call. See [Choice states](machines.md#choice-states).
 
 ```ts
 import { z } from "zod";
@@ -190,6 +196,7 @@ const agentSetup = setupAgent({
     draft: z.string().nullable(),
     note: z.string(),
     revisions: z.number(),
+    via: z.enum(["model", "human"]),
   }),
   events: {
     SEND: {},
@@ -198,7 +205,7 @@ const agentSetup = setupAgent({
     HUMAN_REPLY: z.object({ reply: z.string() }),
   },
   input: z.object({ ticket: z.string() }),
-  output: z.object({ reply: z.string() }),
+  output: z.object({ reply: z.string(), via: z.enum(["model", "human"]) }),
   actors: { classifyTicket, writeReply },
 });
 
@@ -210,8 +217,9 @@ const triageMachine = agentSetup.createMachine({
     draft: null,
     note: "",
     revisions: 0,
+    via: "model" as const,
   }),
-  output: ({ context }) => ({ reply: context.draft ?? "" }),
+  output: ({ context }) => ({ reply: context.draft ?? "", via: context.via }),
   initial: "classifying",
   states: {
     classifying: {
@@ -221,8 +229,7 @@ const triageMachine = agentSetup.createMachine({
         onDone: ({ output }) => ({ target: "routing", context: { category: output } }),
       },
     },
-    // Deterministic, no model. `type: 'choice'` is a library pseudo-state
-    // (not native XState): it resolves its `choice` branch immediately, no event.
+    // `type: 'choice'` is a library pseudo-state, not native XState.
     routing: {
       type: "choice",
       choice: ({ context }) =>
@@ -248,12 +255,11 @@ const triageMachine = agentSetup.createMachine({
           prompt: `Ticket:\n${context.ticket}\n\nDraft:\n${context.draft}`,
           allowedEvents: ["SEND", "REVISE", "ESCALATE"],
         }),
-        onError: { target: "awaitingHuman" }, // out of retries: let a person decide
+        onError: { target: "awaitingHuman" }, // reached after retries are exhausted
       },
       on: {
         SEND: { target: "sending" },
         ESCALATE: { target: "awaitingHuman" },
-        // The cap is a transition, not a prompt: past 2, REVISE is not a legal move.
         REVISE: ({ context, event }) =>
           context.revisions < 2
             ? {
@@ -263,10 +269,13 @@ const triageMachine = agentSetup.createMachine({
             : undefined,
       },
     },
-    // No invoke: the wait is a state, and the snapshot is what you persist.
+    // No invoke. The run settles as idle here, and you persist the snapshot.
     awaitingHuman: {
       on: {
-        HUMAN_REPLY: ({ event }) => ({ target: "sending", context: { draft: event.reply } }),
+        HUMAN_REPLY: ({ event }) => ({
+          target: "sending",
+          context: { draft: event.reply, via: "human" as const },
+        }),
       },
     },
     sending: { type: "final" },
@@ -281,31 +290,24 @@ if (result.status === "done") console.log(result.output.reply);
 if (result.status === "idle") console.log("waiting on a human", result.snapshot);
 ```
 
-Every local from the loop is now either context or a state name, and the four hard things from the top are gone.
+Every local variable from the loop is now either context or a state name. The loop's `escalated` flag becomes `output.via`, which records whether the model or a human produced the reply.
 
-## What the machine bought you
+The revision cap behaves differently from the loop. The loop returned the current draft once `revisions >= 2`. The machine's guard returns `undefined`, so the third `REVISE` is rejected and the reviewer must choose `SEND` or `ESCALATE` instead. To reproduce the loop's behavior, target `sending` from the rejected branch instead of returning `undefined`.
 
-- **Testing without a model.** `createScriptedExecutors` replays canned answers with no key and no network; `simulateAgent` walks the pure step path and returns the `trail` of every step taken; `lintAgentMachine` catches unreachable states and empty decisions with no run at all. See [Testing and verification](verify.md).
-- **Resume that cannot re-run work.** A resumed snapshot starts _at_ the idle state, so `classify` and `writeReply` run exactly once however many times you resume. See [Human in the loop](human-in-the-loop.md).
-- **Replay from a log.** The ordered external inputs are the durable state; folding them back through the machine reconstructs the run exactly. See [The event log](event-log.md).
-- **Observability by name.** `onTrace` gives one ordered ledger of requests, transitions, and emits, and the [Stately Inspector](observability.md) highlights the diagram live. States have names now, so traces do too.
-- **Bounds you cannot step around.** Guards, `maxModelCalls`, and per-run token budgets are enforced outside the prompt. See [Usage and budgets](usage-and-budgets.md).
-- **A loop you can own.** When a durable host needs one model call per log append, hand the machine to the step path instead of `runAgent`: `getAgentEffects` lowers the pending work, you resolve one effect, append it, and fold it back with xstate's pure `transition`. Same machine, zero changes. See [The step path](steps.md).
+For what the machine gives you over the loop, see the [overview](index.md).
 
-## When you cannot rewrite the machine
+## Machines you cannot rewrite
 
-The design move above assumes you are writing the machine. Two cases where you are not:
+The design work above assumes you are writing the machine. Two cases do not require that.
 
-- **A machine that already exists**, with no agent-specific anything: any machine whose invokes resolve to values and whose events you can enumerate is drivable. Use `getAcceptedEvents(snapshot)` for the candidates and `resolveDecision` gated by `snapshot.can(event)`. See [plain-xstate](../examples/plain-xstate/index.ts).
-- **A machine with no invokes at all**, where prompts live in state `description`s, `meta`, or an external lookup. It runs unmodified through `runAgent`'s `getRequests` option: [Retrofit with `getRequests`](from-a-loop.md#retrofit-with-getrequests), runnable in [described-workflow](../examples/described-workflow/index.ts).
+- The machine already exists and contains nothing agent-specific. Any machine whose invokes resolve to values and whose events you can enumerate can be driven. Use [`getAcceptedEvents(snapshot)`](human-in-the-loop.md) for the candidates and call [`resolveDecision`](steps.md#standalone-decision-resolution) gated by `snapshot.can(event)`. See [plain-xstate](../examples/plain-xstate/index.ts).
+- The machine has no invokes, and prompts live in state `description` fields, in `meta`, or in an external lookup. It runs unmodified through the `getRequests` option of `runAgent`. See [Retrofit with `getRequests`](from-a-loop.md#retrofit-with-getrequests) and the runnable [described-workflow](../examples/described-workflow/index.ts) example.
 
-Prompts also do not have to live in the machine: strip them out, leave bare `src` strings, and bind a separate prompt map through `runAgent`'s `actors` option (shorthand for `machine.provide({ actors })`). The graph is identical either way, which is what lets a machine round-trip through JSON via `setupAgent.fromConfig`. See [Machines as data](machines-as-data.md).
-
-> **One version requirement.** The machine must be built with the `xstate` install this package peers on (v6 alpha.25 or newer). Machines authored for XState v5 usually port with little change, but a machine object imported from a separate `xstate@5` install will not bind. Write event-transition guards as functions returning `undefined`; v6 drops named string guards on `on:` in favor of this form, and that is what makes `snapshot.can(event)` reflect the guard.
+Prompts do not have to live in the machine. Remove them, leave bare `src` strings, and bind a separate prompt map through the `actors` option of `runAgent`, which is shorthand for `machine.provide({ actors })`. The graph is the same in both cases, which is what lets a machine round-trip through JSON with `setupAgent.fromConfig`. See [Machines as data](machines-as-data.md).
 
 ## Related
 
-- [Migrating from a hand-rolled loop](from-a-loop.md): the same translation applied mechanically to a working refund agent, one shippable step at a time.
-- [Agent machines](machines.md): the full authoring reference for states, requests, and transitions.
+- [Migrating from a hand-rolled loop](from-a-loop.md): the same translation applied to a working refund agent, one step at a time.
+- [Agent machines](machines.md): the authoring reference for states, requests, and transitions.
 - [Decisions](decisions.md): candidate events, retries, and guard rejection.
-- [Agent patterns](patterns.md): the shapes this decomposition tends to produce, one runnable file each.
+- [Agent patterns](patterns.md): common shapes this decomposition produces, one runnable file each.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -5,13 +5,15 @@ description: Define tools, attach them to a text request, and let the host run t
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-Tools belong to a **request**, not to machine states. The machine decides _when_ a request runs; the model picks which tools to call; the host executes them. The machine never sees the intermediate calls.
+Tools belong to a request, not to a machine state. The machine decides when a request runs. The model picks which tools to call. The host executes them. The machine does not see the intermediate tool calls.
+
+<!-- viz: data-flow figure of the tool loop: machine invokes a tool-carrying request -> host executor runs model/tool turns up to maxSteps -> final output validated -> single onDone transition back in the machine -->
 
 ## The tool contract
 
 <!-- AgentTool/AgentToolDescriptor from src/types.ts -->
 
-`AgentTool` is a minimal structural contract, so tools from any SDK drop in unchanged:
+`AgentTool` is a minimal structural contract, so tools from any SDK work without changes:
 
 | Field           | Type                                 | Meaning                                          |
 | --------------- | ------------------------------------ | ------------------------------------------------ |
@@ -21,11 +23,11 @@ Tools belong to a **request**, not to machine states. The machine decides _when_
 | `execute?`      | `(...args) => unknown`               | The implementation the host runs.                |
 | anything else   | `unknown`                            | Passed through untouched (`providerOptions`, …). |
 
-- A bare function is shorthand for `execute` (`AgentToolExecute`).
+- A bare function is shorthand for `execute`, typed as `AgentToolExecute`.
 - `AgentTools` is `Record<string, AgentTool | undefined>`, keyed by tool name.
-- `inputSchema` is deliberately widened to `object` so an SDK-native tool assigns with no cast. Core reads it as a Standard Schema when it can.
+- `inputSchema` is widened to `object` so an SDK-native tool assigns without a cast. Core reads it as a Standard Schema when it can.
 
-A native AI SDK tool owns its input typing, so `execute`'s argument needs no cast:
+A native AI SDK tool owns its input typing, so the argument to `execute` needs no cast:
 
 ```ts
 import { tool } from "ai";
@@ -38,7 +40,7 @@ const calculate = tool({
 });
 ```
 
-With no SDK, a plain object is enough. Core reads `description`/`inputSchema` and runs `execute`:
+Without an SDK, a plain object is enough. Core reads `description` and `inputSchema`, then runs `execute`:
 
 ```ts
 const calculate = {
@@ -53,7 +55,10 @@ const calculate = {
 
 ## Attaching tools to a request
 
-Put `tools` on any [text request](text-requests.md), inline in `setupAgent({ requests })` or on a standalone `createTextLogic`. `metadata.maxSteps` bounds the host-side tool loop; without it the request is single-step. `toolChoice` (`'auto' | 'none' | 'required' | { type: 'tool', name }`) constrains selection.
+Put `tools` on any [text request](text-requests.md), either inline in `setupAgent({ requests })` or on a standalone `createTextLogic`.
+
+- `maxSteps` is a typed field on the request. It bounds the host-side tool loop. Without it, the request is single-step.
+- `toolChoice` constrains selection. It accepts `'auto'`, `'none'`, `'required'`, or `{ type: 'tool', name }`.
 
 ```ts no-check
 import { z } from "zod";
@@ -75,7 +80,7 @@ const agentSetup = setupAgent({
       system: "Answer in one sentence. Use calculate for arithmetic.",
       prompt: ({ input }) => input.query,
       tools: { calculate },
-      metadata: { maxSteps: 5 }, // bounds the host-side loop
+      maxSteps: 5,
     },
   },
 });
@@ -97,7 +102,7 @@ export const toolCallingMachine = agentSetup.createMachine({
 });
 ```
 
-Run it with any executor set; the machine is unchanged between scripted and real models.
+Run the machine with any executor set. The machine is the same for scripted and real models.
 
 ```ts
 import { runAgent } from "@statelyai/agent";
@@ -109,29 +114,29 @@ const result = await runAgent(toolCallingMachine, {
 });
 ```
 
-Full version, with three real tools and progress via `onTransition`: [examples/tool-calling/index.ts](../examples/tool-calling/index.ts).
+For the full version, with three real tools and progress reported through `onTransition`, see [examples/tool-calling/index.ts](../examples/tool-calling/index.ts).
 
 ## Execution flow through the host
 
 <!-- toAiSdkTools / maxStepsSetting from src/ai-sdk/mappers.ts and src/ai-sdk/index.ts -->
 
-1. The machine invokes the request; core lowers it to an `AgentTextRequest` carrying `tools`, `toolChoice`, and `metadata`.
-2. The executor maps tools to its SDK. `createAiSdkExecutors` passes a native `tool({...})` through unchanged and wraps a plain descriptor or bare function in `tool()`; a tool with no `inputSchema` gets a permissive one.
-3. `metadata.maxSteps` becomes `stopWhen: stepCountIs(maxSteps)`. The loop runs entirely inside the executor.
+1. The machine invokes the request. Core lowers it to an `AgentTextRequest` carrying `tools`, `toolChoice`, and `metadata`.
+2. The executor maps tools to its SDK. `createAiSdkExecutors` passes a native `tool({...})` through unchanged and wraps a plain descriptor or bare function in `tool()`. A tool with no `inputSchema` gets a permissive one.
+3. `maxSteps` becomes `stopWhen: stepCountIs(maxSteps)`. The loop runs entirely inside the executor. The adapter still reads `metadata.maxSteps` as a fallback for requests written before `maxSteps` was typed, and the typed field wins.
 4. The final output is validated against the request's output schema and returned to `onDone`.
 
-Two consequences worth knowing:
+Two consequences follow:
 
-- **Tool-carrying requests do not retry.** The AI SDK adapter retries invalid structured output only when the request has no tools, since a tool loop may already have caused side effects.
-- **`metadata` is host-owned.** A host that does not understand a key ignores it, so requests stay portable.
+- Tool-carrying requests do not retry. The AI SDK adapter retries invalid structured output only when the request has no tools, because a tool loop may already have caused side effects.
+- `metadata` is host-owned. A host that does not understand a key ignores it, so requests stay portable.
 
-The raw executor result (tool calls and results included) reaches host code via `runAgent`'s `onResult(request, { raw })` and the `request.end` trace event. See [Observability](observability.md).
+The raw executor result, including tool calls and results, reaches host code through `runAgent`'s `onResult(request, { raw })` and the `request.end` trace event. See [Observability](observability.md).
 
 ## Tool results in messages
 
 <!-- message model from src/types.ts and src/utils.ts -->
 
-The portable message model has first-class tool parts, so a conversation that includes tool traffic is plain machine context:
+The message model includes tool parts, so a conversation that contains tool traffic is stored as plain machine context:
 
 - `ToolCallPart`: `{ type: 'tool-call', toolCallId, toolName, input }`.
 - `ToolResultPart`: `{ type: 'tool-result', toolCallId, toolName, output }`, where `output` is `{ type: 'text' | 'json' | 'error-text' | 'error-json' | 'content', value }`.
@@ -152,32 +157,22 @@ const recordToolResult = appendMessages([
 ]);
 ```
 
-You only build these by hand when the machine owns the loop (a ReAct-style machine, or replaying a transcript). With a host-run tool loop, the intermediate calls stay inside the executor. See [Messages](messages.md).
+Build these parts by hand only when the machine owns the loop, such as in a ReAct-style machine or when replaying a transcript. With a host-run tool loop, the intermediate calls stay inside the executor. See [Messages](messages.md).
 
 ## Presets and ejecting
 
-`createToolLoopMachine` from `@statelyai/agent/machines` is the same shape as the example above, prebuilt: one `answering` state, one request, `maxTurns` lowering to `metadata.maxSteps`.
+`createToolLoopMachine` from `@statelyai/agent/machines` is a prebuilt version of the machine above: one `answering` state and one tool-carrying request. See [Preset machines](machines-presets.md) for its options, including `maxSteps`.
 
-```ts no-check
-import { createToolLoopMachine } from "@statelyai/agent/machines";
+Eject from the preset when the tool loop needs machine states of its own:
 
-const machine = createToolLoopMachine({
-  model: "assistant",
-  instructions: "Answer using the tools.",
-  tools: { calculate },
-  maxTurns: 5,
-});
-```
+- To model approval as machine states, with approve, edit, and reject steps that persist and resume, eject to [examples/review-tool-calls](../examples/review-tool-calls/index.ts).
+- To model each think, act, and observe turn as its own transition, see [examples/react-agent](../examples/react-agent/index.ts).
 
-- `interruptOn: ['sendRefund']` lowers to `metadata.interruptOn`, read only by a host that implements gating. The preset stays a single state and never pauses.
-- For approval as real machine states (approve / edit / reject, persistable and resumable), eject to [examples/review-tool-calls](../examples/review-tool-calls/index.ts).
-- For each think/act/observe turn as its own transition, see [examples/react-agent](../examples/react-agent/index.ts).
-
-> **Not yet:** there is no built-in MCP client and no built-in tool-approval gate. MCP discovery, auth, and transport are your host's job; pass the discovered tool descriptors into `tools` like any other tool. See [Scope](scope.md).
+> **Note:** There is no built-in MCP client and no built-in tool-approval gate. MCP discovery, auth, and transport are the host's responsibility. Pass the discovered tool descriptors into `tools` like any other tool. See [Scope](scope.md).
 
 ## Related
 
-- [Text requests](text-requests.md): the request a tool attaches to, and structured/streaming output.
-- [Hosts](hosts.md): executors, model aliases, and writing your own adapter.
-- [Messages](messages.md): the message model tool parts live in.
-- [Preset machines](machines-presets.md): `createToolLoopMachine` and its siblings.
+- Read more about [Text requests](text-requests.md), the request a tool attaches to, including structured and streaming output.
+- Read more about [Hosts](hosts.md), including executors, model aliases, and writing your own adapter.
+- Read more about [Messages](messages.md), the message model that tool parts live in.
+- Read more about [Preset machines](machines-presets.md), including `createToolLoopMachine`.

--- a/docs/usage-and-budgets.md
+++ b/docs/usage-and-budgets.md
@@ -5,21 +5,26 @@ description: Read token usage off a run, cap runaway loops with maxModelCalls, a
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
+This page covers how to read token usage from a run and how to enforce budgets on it.
+
 ## Overview
 
-Three layers, coarsest first:
+Usage is available at three layers, listed from coarsest to finest.
 
-- **After the run**: `result.usage`, the aggregated model-call usage for that run.
-- **During the run, host side**: `onResult` and `onTrace` see each call's usage as it lands.
-- **During the run, machine side**: the reserved `@agent.usage` event delivers each call's tokens to the machine, so budgets live in `context` and are enforced by ordinary guards.
+- After the run, `result.usage` gives the aggregated model-call usage for that run.
+- During the run, on the host side, `onResult` and `onTrace` see each call's usage as it lands.
+- During the run, on the machine side, the reserved `@agent.usage` event delivers each call's tokens to the machine. Budgets then live in `context` and are enforced by ordinary guards.
 
-The first two are observational. Only the third can change what the agent does.
+The first two layers are observational. Only the third can change what the agent does.
+
+<!-- viz: usage flow: executor result -> runAgent aggregation into result.usage, -> onResult/onTrace on the host, -> @agent.usage event into machine context and guards -->
+
 
 ## The usage result
 
 <!-- AgentUsage from src/text-logic.ts; aggregation in src/run-agent.ts -->
 
-Every settled `RunAgentResult` carries `usage`, on all three variants (`done`, `idle`, `error`):
+Every settled `RunAgentResult` carries `usage`, on all three variants: `done`, `idle`, and `error`.
 
 ```ts
 const result = await runAgent(machine, { input, executors });
@@ -31,16 +36,25 @@ result.usage.totalTokens; // number | undefined (only calls that reported it)
 | Field                                                                                | Meaning                                                                                         |
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
 | `modelCalls`                                                                         | Model and decision calls this run made. Always a number. Each decision retry counts separately. |
-| `inputTokens`, `outputTokens`, `totalTokens`, `reasoningTokens`, `cachedInputTokens` | Partial sums, see below.                                                                        |
+| `inputTokens`, `outputTokens`, `totalTokens`, `reasoningTokens`, `cachedInputTokens` | Partial sums. See the notes below.                                                              |
 
-Caveats:
+Four things affect how you read these numbers.
 
-- **Partial sums.** Each token field sums only the calls that reported it, and is `undefined` only when _no_ call reported it. A run mixing a real SDK executor (reports usage) with a scripted mock (does not) yields a sum over the reporting subset. Do not read a token total as "the whole run" unless every executor reports.
-- **`modelCalls` is always there**, even when nothing reports tokens. It is the one number you can trust unconditionally.
-- **Per run, not per conversation.** A resumed run counts only its own calls, never the history behind `snapshot`/`events`. Add prior results' totals yourself for a conversation-wide figure.
-- **Usage comes from your executor.** `runAgent` reads `usage` off the raw executor result: our `{ output, usage }` envelope, a Vercel AI SDK result (same flat field names), or any custom executor following that shape. Non-finite values are dropped.
+- Token fields are partial sums. Each field sums only the calls that reported it, and is `undefined` only when no call reported it. A run that mixes a real SDK executor, which reports usage, with a scripted mock, which does not, yields a sum over the reporting subset only. Do not treat a token total as the whole run unless every executor reports usage.
+- `modelCalls` is always present, even when nothing reports tokens.
+- Usage is per run, not per conversation. A resumed run counts only its own calls, not the history behind `snapshot` or `events`. Add prior results' totals yourself for a conversation-wide figure.
+- Usage comes from your executor. `runAgent` reads `usage` from the raw executor result. That can be the `{ output, usage }` envelope, a Vercel AI SDK result, which uses the same flat field names, or any custom executor following that shape. Non-finite values are dropped.
 
-Summing across a resume chain is host code:
+### Billing
+
+`result.usage` is the authoritative record of what a run spent. Usage folds into the totals before the machine is involved, so a call counts even when its `@agent.usage` event is never delivered. A straggler that settles after the run resolved counts, and so does a call whose event no active state accepts. Only the machine event is dropped, and the drop is traced as `usage.dropped`. Counters in `context` are control flow, not billing: they only see the calls the machine reacted to.
+
+Two caveats apply.
+
+- `modelCalls` counts only calls admitted by the budget. A call rejected by `maxModelCalls` is not counted, because it was never made.
+- Usage covers this run only. A resumed run does not re-add the history behind `snapshot` or `events`.
+
+Summing across a resume chain is host code.
 
 ```ts
 function addUsage(a: AgentUsage, b: AgentUsage): AgentUsage {
@@ -59,10 +73,10 @@ function addUsage(a: AgentUsage, b: AgentUsage): AgentUsage {
 
 ## Per-call usage
 
-Two seams, both live and both read-only:
+Two callbacks report usage per call. Both are live and read-only.
 
 - `onResult(request, { output, raw })`: `raw` is your executor's verbatim result, so `raw.usage` is that call's usage in whatever shape the executor produced.
-- `onTrace` `request.end`: a normalized `usage?: AgentCallUsage`, present only when the executor reported one. See [Observability](observability.md#the-versioned-trace-stream).
+- `onTrace` on a `request.end` event: `usage?: AgentCallUsage` is normalized, and present only when the executor reported usage. See [Observability](observability.md#the-versioned-trace-stream).
 
 ```ts
 await runAgent(machine, {
@@ -82,11 +96,11 @@ await runAgent(machine, {
 });
 ```
 
-Use these for dashboards, per-tenant metering, and cost alerts. Neither can stop the run. To feed the machine, use `@agent.usage` below.
+Use these for dashboards, per-tenant metering, and cost alerts. Neither can stop the run. To deliver usage to the machine, use [`@agent.usage`](#the-agentusage-event).
 
-## `maxModelCalls`: the global backstop
+## The global backstop: `maxModelCalls`
 
-`maxModelCalls` caps the number of model and decision calls one run may make. Default `100`. Decision retries count separately.
+`maxModelCalls` caps the number of model and decision calls one run may make. The default is `100`. Decision retries count separately.
 
 ```ts
 const result = await runAgent(machine, { input, executors, maxModelCalls: 20 });
@@ -97,17 +111,30 @@ if (result.status === "error" && result.cause === "max-model-calls") {
 }
 ```
 
-- The overrun is thrown **into the invoke that would have made the call**. With nothing handling it, the run settles `{ status: 'error', cause: 'max-model-calls' }`, with `usage`, `snapshot`, and `events` intact.
-- An `onError` on that invoke **catches it like any other failure**. A machine whose invoke has `onError: { target: 'someState' }` can therefore settle `done` at the cap instead of `error`. Route `onError` deliberately, or leave it off where you want the cap to surface.
-- It counts calls, not tokens or dollars, and it is host-owned: the machine cannot read how much budget is left.
+- The overrun is thrown into the invoke that would have made the call, as an `AgentMaxModelCallsExceededError` with `code: 'max-model-calls'`. If nothing handles it, the run settles as `{ status: 'error', cause: 'max-model-calls' }`, with `usage`, `snapshot`, and `events` intact.
+- An `onError` on that invoke catches the overrun like any other failure. Branch on the code to route the budget breach separately from a model or tool failure.
+- A blanket `onError: { target: 'someState' }` also catches the overrun, so the run settles `done` at the cap instead of `error`. That is a valid choice, as long as it is deliberate.
+- `maxModelCalls` counts calls, not tokens or dollars. It is host-owned, so the machine cannot read how much budget is left.
 
-Treat it as the runaway-loop backstop. Anything the machine's own logic should react to belongs in a guard.
+```ts no-check
+onError: [
+  {
+    guard: ({ event }) => event.error?.code === "max-model-calls",
+    target: "budgetSpent",
+  },
+  { target: "failed" },
+];
+```
+
+Use `maxModelCalls` as a runaway-loop backstop. Put anything the machine's own logic should react to in a guard.
 
 ## Retries and executor budgets
 
-Transport-level retries (429s, timeouts, backoff) belong in the executor or the SDK it wraps, not the machine. The AI SDK's `maxRetries` (and the OpenAI/Anthropic client equivalents) handles them; a raw-`fetch` executor adds its own loop. The machine never sees a transient network failure. Machine-level retry is different: an authored `onError` transition re-entering a state after a _semantic_ failure (a validation rejection, an exhausted decision) is control flow you model explicitly.
+Transport-level retries, such as retries for 429 responses, timeouts, and backoff, belong in the executor or the SDK it wraps, not in the machine. The AI SDK's `maxRetries` handles them, as do the equivalent options on the OpenAI and Anthropic clients. `maxRetries` keeps AI SDK semantics: it is the number of retries made after the first attempt, so `maxRetries: 2` allows up to three attempts. A raw-`fetch` executor adds its own loop. The machine never sees a transient network failure.
 
-For finer budgets than `maxModelCalls` (a token cap, a per-request-`src` call count), wrap the executors. A child machine's requests inherit the parent's executors, so one wrapper counts the whole tree:
+Machine-level retry is different. An authored `onError` transition that re-enters a state after a semantic failure, such as a validation rejection or an exhausted decision, is control flow you model explicitly.
+
+For finer budgets than `maxModelCalls`, such as a token cap or a per-request-`src` call count, wrap the executors. A child machine's requests inherit the parent's executors, so one wrapper counts the whole tree.
 
 ```ts
 function withBudget(base: AgentRequestExecutors, maxCalls: number): AgentRequestExecutors {
@@ -127,11 +154,20 @@ function withBudget(base: AgentRequestExecutors, maxCalls: number): AgentRequest
 await runAgent(machine, { input, executors: withBudget(executors, 20) });
 ```
 
-A wrapper is still host-side: the machine cannot read the remaining budget or react to it. For that, use `@agent.usage` and a guard.
+A wrapper is still host-side. The machine cannot read the remaining budget or react to it. For that, use `@agent.usage` and a guard.
 
 ## The `@agent.usage` event
 
 <!-- AGENT_USAGE_EVENT_TYPE and AgentUsageEvent from src/effects.ts -->
+
+`@agent.usage` is a reserved event that carries one model call's tokens into the machine. Four rules govern it.
+
+- You declare nothing. `setupAgent` and `createAgentSchemas` register `'@agent.usage'` and its payload schema in every agent's events, so the handler is typed and `event.usage.totalTokens` narrows. Declaring it yourself is an error, because the `@agent.` namespace is reserved.
+- Delivery is opt-in. The event is delivered only when an active state declares a transition that matches it, either `'@agent.usage'` or the wildcard `'*'`. If no active state declares one, there is no transition, no trace event, and no event-log entry. Wildcard matching follows XState semantics, so a catch-all `on: { '*': … }` does receive `@agent.usage`. Narrow the handler on `event.type` when the catch-all is meant for other events.
+- Declare the handler at machine level. A root `on: { '@agent.usage': … }` catches every call regardless of which state made it. A state-scoped handler drops calls made in other states.
+- Delivery goes to the run's root machine, including usage from requests inside an invoked child machine. Attribute those calls with `id`, `src`, and `model`.
+
+The payload has this shape.
 
 ```ts no-check
 {
@@ -145,30 +181,26 @@ A wrapper is still host-side: the machine cannot read the remaining budget or re
 }
 ```
 
-### Rationale
+### Why the event exists
 
-Model-call results reach the machine stripped of usage:
+Model-call results reach the machine with usage stripped out.
 
-- A **text invoke's `onDone` output is the normalized output only**. The runner returns `{ output }` and drops the rest of the executor envelope (`src/run-agent.ts`).
-- A **decision delivers only the chosen event**. `resolveDecision` returns the validated event; the executor's `usage` is dropped (`src/decision.ts`).
+- A text invoke's `onDone` receives the normalized output only. The runner returns `{ output }` and drops the rest of the executor envelope (`src/run-agent.ts`).
+- A decision delivers only the chosen event. `resolveDecision` returns the validated event and drops the executor's `usage` (`src/decision.ts`).
 
-`@agent.usage` carries the tokens instead: after every settled model call that reported usage, `runAgent` delivers it to the machine, so `context` can fold it and guards can read it. Turn counters and token counters are therefore both free: increment turns in `onDone`, fold tokens in `@agent.usage`.
+`@agent.usage` carries the tokens instead. After every settled model call that reported usage, `runAgent` delivers the event to the machine, so `context` can fold it and guards can read it. You can then keep both counters in `context`: increment turns in `onDone`, and fold tokens in the `@agent.usage` handler.
 
 ### Rules
 
 | Area                 | Rule                                                                                                                                                                                                                                                                                                                           |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Declaration**      | `setupAgent`/`createAgentSchemas` register `'@agent.usage'` and its payload schema in every agent's events, so the handler is typed (`event.usage.totalTokens` narrows) with nothing to declare. Declaring it yourself is an error: the `@agent.` namespace is reserved.                                                       |
-| **Opt-in**           | Delivered only when an active state declares a `'@agent.usage'` transition **explicitly**. Declare none and nothing changes: no transition, no trace event, no event-log entry. A catch-all `on: { '*': … }` never receives it, so a wildcard machine is byte-identical to a run without the feature.                          |
-| **Placement**        | Declare it machine-level. A root `on: { '@agent.usage': … }` catches every call whatever state made it; a state-scoped handler silently drops calls made elsewhere.                                                                                                                                                            |
-| **Not model-facing** | The `@agent.*` namespace is excluded from `getAcceptedEvents` and `parseAgentEvent`, so it is never a decision candidate (not even under `allowedEvents: ['*']`) and cannot be forged from a wire message.                                                                                                                     |
-| **Durability**       | Journaled like any other external input, so events-only recovery (`runAgent({ events })`) replays the folded tokens without re-calling a model.                                                                                                                                                                                |
-| **Spend records**    | The cost already happened when the event is reported, so entries are append-only facts. Replay folds every one, and a call re-executed by crash recovery journals its own usage on top. A recovered total reflects true cumulative cost, including the call whose result the crash lost. You really did spend it.              |
-| **Stragglers**       | A call settling after the run's cycle resolved (idle settle, `done`/`error` settle, abort) still folds into `result.usage`, but its machine event is dropped, on both `runAgent` and `createAgentActor`, so a late arrival cannot re-open a returned idle result. Watch `usage.dropped` on `onTrace` if a counter looks short. |
-| **Scope**            | Delivered to the run's root machine, including usage from requests inside an invoked child machine. Attribute those with `id`/`src`/`model`.                                                                                                                                                                                   |
-| **Coverage**         | Only what your executor reports. No `usage` on the result means no event. [`simulateAgent`](verify.md) scripts return no usage, so a token counter stays `0` under simulation: test budgets with `runAgent` and a usage-reporting mock.                                                                                        |
+| **Not model-facing** | The `@agent.*` namespace is excluded from `getAcceptedEvents` and `parseAgentEvent`. The event is never a decision candidate, even under `allowedEvents: ['*']`, and cannot be forged from a wire message.                                                                                                                     |
+| **Durability**       | The event is journaled like any other external input, so events-only recovery with `runAgent({ events })` replays the folded tokens without calling a model again.                                                                                                                                                             |
+| **Spend records**    | The cost is already incurred when the event is reported, so entries are append-only facts. Replay folds every entry, and a call re-executed by crash recovery journals its own usage on top. A recovered total therefore reflects cumulative cost, including the call whose result the crash lost.                              |
+| **Stragglers**       | A call that settles after the run's cycle resolved, at an idle settle, a `done` or `error` settle, or an abort, still folds into `result.usage`, but its machine event is dropped. This applies to both `runAgent` and `createAgentActor`, so a late arrival cannot re-open a returned idle result. Watch `usage.dropped` on `onTrace` if a counter looks short. |
+| **Coverage**         | Only usage your executor reports is delivered. No `usage` on the result means no event. [`simulateAgent`](verify.md) scripts return no usage, so a token counter stays `0` under simulation. Test budgets with `runAgent` and a usage-reporting mock.                                                                          |
 
-Opt in with a transition:
+Opt in with a transition.
 
 ```ts no-check
 import { AGENT_USAGE_EVENT_TYPE, setupAgent } from "@statelyai/agent";
@@ -188,17 +220,20 @@ const machine = agentSetup.createMachine({
 
 ## Budgets as guards
 
-A budget is data, not a runtime feature:
+A budget is data in `context`, not a separate runtime feature.
 
-- **Limits enter via `input`** and land in `context` (`maxTurns`, `maxTokens`, `maxDollars`).
-- **Counters live in `context`**, folded in by the transitions that carry the data.
-- **Guards are ordinary transition functions**: over budget, return a transition into a final `outOfBudget` state, or return `undefined` so the expensive event is not takeable at all.
+- Limits enter through `input` and land in `context`, as fields such as `maxTurns`, `maxTokens`, and `maxDollars`.
+- Counters live in `context` and are folded in by the transitions that carry the data.
+- Guards are ordinary transition functions. When over budget, return a transition into a final `outOfBudget` state, or return `undefined` so the expensive event cannot be taken at all.
 
-Nothing here is agent-specific. It is the same [guard](machines.md#transitions) mechanism the rest of the machine uses, which is why it composes with decisions: a candidate event whose transition returns `undefined` is never offered to the model.
+None of this is agent-specific. It is the same [guard](machines.md#transitions) mechanism the rest of the machine uses, so it composes with decisions. A candidate event whose transition returns `undefined` is never offered to the model.
 
-### Recipe: turn and token budget
+### Turn and token budget
 
-A machine-level `@agent.usage` handler folds every call's tokens into `context`; an ordinary guard stops the loop when the budget is spent:
+A machine-level `@agent.usage` handler folds every call's tokens into `context`. An ordinary guard stops the loop when the budget is spent.
+
+<!-- viz: budget machine: researching -> checkingBudget -> researching loop, exiting to final outOfBudget when turns or tokens exceed their limits, with @agent.usage folding tokens at machine level -->
+
 
 ```ts
 import { z } from "zod";
@@ -247,7 +282,7 @@ const machine = agentSetup.createMachine({
     maxTurns: input.maxTurns,
     maxTokens: input.maxTokens,
   }),
-  // Machine-level, so every model call's tokens land wherever they were spent.
+  // Machine-level, so every model call's tokens are folded.
   on: {
     [AGENT_USAGE_EVENT_TYPE]: ({ context, event }) => ({
       context: { tokens: context.tokens + (event.usage.totalTokens ?? 0) },
@@ -260,17 +295,16 @@ const machine = agentSetup.createMachine({
         id: "research",
         src: "researchStep",
         input: ({ context }) => ({ topic: context.topic, turn: context.turns + 1 }),
-        // Only the turn counter here; the tokens already arrived on their own.
+        // Tokens arrive through `@agent.usage`, so only turns are folded here.
         onDone: ({ context, output }) => ({
           target: "checkingBudget",
           context: { notes: [...context.notes, output], turns: context.turns + 1 },
         }),
-        // No onError on purpose: an overrun of maxModelCalls surfaces as the
-        // run's error result instead of being swallowed here.
+        // No onError, so a maxModelCalls overrun surfaces as the run's error
+        // result instead of being handled here.
       },
     },
     checkingBudget: {
-      // The budget guard: an ordinary transition function reading context.
       always: ({ context }) =>
         context.turns >= context.maxTurns || context.tokens >= context.maxTokens
           ? { target: "outOfBudget" }
@@ -288,8 +322,7 @@ const machine = agentSetup.createMachine({
   },
 });
 
-// Scripted, keyless executor. `usage` on the result is all it takes: the same
-// field `result.usage` aggregates is the one `@agent.usage` carries.
+// Scripted, keyless executor. Returning `usage` is what feeds `@agent.usage`.
 let call = 0;
 const executors = {
   generateText: async () => ({
@@ -310,14 +343,14 @@ if (result.status === "done") {
 result.usage; // { totalTokens: 1560, modelCalls: 3 }
 ```
 
-Two things to note about the shape:
+Two details of this shape matter.
 
-- The loop goes `researching -> checkingBudget -> researching`. A transition targeting its own state does **not** re-enter it, so a self-targeting `onDone` would not re-run the invoke. Bounce through a check state.
-- The tokens land **between** the call settling and its `onDone`, so `checkingBudget` always reads a counter that includes the call it just made.
+- The loop runs `researching -> checkingBudget -> researching`. A transition targeting its own state does not re-enter it, so a self-targeting `onDone` would not re-run the invoke. Route through a check state instead.
+- The tokens land between the call settling and its `onDone`, so `checkingBudget` always reads a counter that includes the most recent call.
 
 ### Guarding a decision
 
-The same guard makes an over-budget choice **impossible**, not merely discouraged. An event whose transition returns `undefined` is not a legal candidate, so the model is never offered it:
+The same guard removes an over-budget choice from the decision entirely. An event whose transition returns `undefined` is not a legal candidate, so the model is never offered it.
 
 ```ts no-check
 deciding: {
@@ -343,7 +376,7 @@ deciding: {
 
 ### Uncontrolled: `provideExecutors` + `createActor`
 
-Delivery is built in, but it follows the binding boundary: `provideExecutors` does not descend into invoked child machines, so a child with its own agent invokes needs its own `provideExecutors(...)`; until it has one, its calls report no usage anywhere. `runAgent` rebinds children and reports their usage to the root. There is no run cycle on the [uncontrolled path](any-stack.md#controlled-and-uncontrolled), so there are no dropped stragglers either.
+Delivery is built in, but it follows the binding boundary. `provideExecutors` does not descend into invoked child machines, so a child with its own agent invokes needs its own `provideExecutors(...)` call. Until it has one, its calls report no usage anywhere. `runAgent` rebinds children and reports their usage to the root. There is no run cycle on the [uncontrolled path](any-stack.md#controlled-and-uncontrolled), so no stragglers are dropped either.
 
 ```ts no-check
 import { createActor, toPromise } from "xstate";
@@ -360,11 +393,11 @@ const output = await toPromise(actor); // stoppedBy: 'tokens'
 
 ### Step path: an ordinary event
 
-On [the step path](steps.md#token-usage-on-this-path) the host holds the raw executor result, so it normalizes it with `getCallUsage(raw)` and appends the event itself. Because the entry is journaled, `replay` reproduces the folded counter exactly.
+On [the step path](steps.md#token-usage-on-this-path) the host holds the raw executor result. Normalize it with `getCallUsage(raw)` and append the event yourself. The entry is journaled, so `replay` reproduces the folded counter exactly.
 
 ### Plain XState: manual send
 
-In a hand-rolled loop over `actor.send`, the event is just an event:
+In a hand-rolled loop over `actor.send`, `@agent.usage` is an ordinary event.
 
 ```ts
 const result = await generateText(request);
@@ -373,7 +406,7 @@ if (result.usage) {
 }
 ```
 
-A `setupAgent` machine already declares `'@agent.usage'` in its event union. A machine built with a plain `setup()` declares it itself:
+A `setupAgent` machine already declares `'@agent.usage'` in its event union. A machine built with a plain `setup()` must declare it.
 
 ```ts
 import { z } from "zod";
@@ -401,7 +434,7 @@ const machine = setup({
 
 ## Cost estimation
 
-The library ships no price data and never estimates cost. Keep a price table in host code:
+The library ships no price data and never estimates cost. Keep a price table in host code.
 
 ```ts
 // USD per 1M tokens. Fill in from your provider's pricing page.
@@ -422,7 +455,7 @@ function estimateCost(model: string, usage: AgentUsage | AgentCallUsage): number
 estimateCost("openai/gpt-5.4-mini", result.usage);
 ```
 
-`result.usage` is aggregated across every model the run used, so a per-model figure needs per-call attribution:
+`result.usage` is aggregated across every model the run used, so a per-model figure needs per-call attribution.
 
 ```ts no-check
 let spentUsd = 0;
@@ -442,15 +475,15 @@ await runAgent(machine, {
 });
 ```
 
-`@agent.usage` carries the same `model` attribution, so the machine can keep a per-model spend counter in `context` and guard on it, rather than only reporting one from the host.
+`@agent.usage` carries the same `model` attribution, so the machine can keep a per-model spend counter in `context` and guard on it, instead of only reporting one from the host.
 
-Cached input tokens are usually billed at a discount rather than free; subtracting them as above is a floor, not an exact invoice. Reconcile against your provider's billing and treat these numbers as budget signals.
+Cached input tokens are usually billed at a discount rather than free. Subtracting them as shown above gives a floor, not an exact invoice. Reconcile against your provider's billing and treat these numbers as budget signals.
 
 ## Legacy: usage in the request output
 
-Before `@agent.usage`, tokens reached `context` by declaring a `usage` field on a request's own output schema and having the executor fill it. Prefer `@agent.usage`.
+Before `@agent.usage` existed, tokens reached `context` by declaring a `usage` field on a request's own output schema and having the executor fill it. Prefer `@agent.usage`.
 
-The old form still has two narrow uses: the tokens arrive inside `onDone`, in the same transition as the output, and they survive `simulateAgent` because a script can return them. It only works for output shapes you own, so a shared request, a third-party executor, and a decision are all out of reach.
+The older form still has two uses. The tokens arrive inside `onDone`, in the same transition as the output, and they survive `simulateAgent` because a script can return them. It only works for output shapes you own, so it cannot cover a shared request, a third-party executor, or a decision.
 
 ## Related
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -5,19 +5,19 @@ description: Statically lint, simulate, and explore agent machines without any A
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-Three APIs check an agent machine before it runs, with no API key or model call:
+This page covers the APIs that check an agent machine before it runs. None of them need an API key or a model call.
 
-- `lintAgentMachine` catches dead states, undeliverable decisions, and output-contract gaps statically.
-- `simulateAgent` drives a scripted playthrough to a known outcome deterministically.
-- `explorePaths` / `canReach` enumerate every decision branch and prove a target state is reachable.
+- `lintAgentMachine` statically catches dead states, undeliverable decisions, and output-contract gaps. Pass `{ throw: true }` for the throwing form.
+- `simulateAgent` drives a deterministic scripted playthrough to a known outcome.
+- `explorePaths` and `canReach` enumerate decision branches and check that a target state is reachable.
 
-Use them to prove an LLM-generated machine is legal before you run it ([authoring from scratch](quickstart.md)), or to pin that a refactor preserved behavior, so a machine converted [from a loop](from-a-loop.md) is safe to ship.
+Use these APIs to check that an LLM-generated machine is legal before you run it. See [authoring from scratch](quickstart.md). You can also use them to confirm that a refactor preserved behavior, so a machine converted [from a loop](from-a-loop.md) is safe to ship.
 
-> **Note:** Everything on this page runs on `machine.config` and the pure step path: no provider, no network, no keys. It is deterministic, so these are ordinary unit tests in any test runner (vitest, jest) and CI checks.
+> **Note:** Everything on this page runs on `machine.config` and the pure step path, with no provider, no network, and no keys. It is deterministic, so these checks work as ordinary unit tests in any test runner, such as vitest or jest, and as CI checks.
 
 ## Machine linting
 
-The `lintAgentMachine(machine, options?)` function runs static structural checks over a built machine, for TS-authored (`setupAgent(...).createMachine(...)`) and `setupAgent.fromConfig(...)`-compiled machines alike. It returns `AgentLintDiagnostic[]` (`{ code, severity, path, message }`), empty when clean.
+`lintAgentMachine(machine, options?)` runs static structural checks over a built machine. It accepts machines authored in TypeScript with `setupAgent(...).createMachine(...)` and machines compiled with `setupAgent.fromConfig(...)`. It returns `AgentLintDiagnostic[]`, where each diagnostic is `{ code, severity, path, message }`. The array is empty when the machine is clean.
 
 ```ts
 import { lintAgentMachine } from "@statelyai/agent";
@@ -28,33 +28,37 @@ if (errors.length) {
 }
 ```
 
-For a one-liner that throws instead of returning findings, use `assertAgentMachine(machine, options?)`: silent when clean, throws `AgentLintError` (findings on `.diagnostics`) on any error-severity finding. `warnings: true` fails warnings too; `disable` skips checks, same as `lintAgentMachine`.
+To throw instead of returning findings, pass `{ throw: true }`. The call is silent when the machine is clean, and throws `AgentLintError` on any error-severity finding, with the findings on `.diagnostics`. Add `warnings: true` to fail on warnings too. Pass `disable` to skip checks by code.
+
+```ts no-check
+lintAgentMachine(machine, { throw: true, warnings: true });
+```
 
 | Code                       | Severity | Fires when                                                                                                                                                                                                                                                                         |
 | -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `unreachable-state`        | error    | A state no transition/`always`/`choice`/`onDone`/`onError` can reach from the initial state. Conservative: dynamic (function) transitions over-approximate, so it never false-flags. Exact for `fromConfig` machines, whose declared targets the lowering retains.                 |
+| `unreachable-state`        | error    | A state that no transition, `always`, `choice`, `onDone`, or `onError` can reach from the initial state. The check is conservative. Dynamic function transitions over-approximate, so it never reports a false positive. It is exact for `fromConfig` machines, because the lowering retains their declared targets.                 |
 | `decide-without-events`    | error    | A state invokes `agent.decide` but neither it nor any ancestor handles any event, so the chosen event can never be delivered.                                                                                                                                                      |
-| `unserializable-context`   | warning  | The context schema exposes no JSON schema (e.g. a `z.custom` messages array), so its fields can't be statically checked for JSON persist/resume.                                                                                                                                   |
-| `direct-object-src`        | warning  | An invoke `src` is a direct object/machine value that can't be rebound by `runAgent`, so it inherits no host executors.                                                                                                                                                            |
+| `unserializable-context`   | warning  | The context schema exposes no JSON schema, for example a `z.custom` messages array, so its fields cannot be checked statically for JSON persist and resume.                                                                                                                                   |
+| `direct-object-src`        | warning  | An invoke `src` is a direct object or machine value that `runAgent` cannot rebind, so it inherits no host executors.                                                                                                                                                            |
 | `final-without-output`     | error    | The machine declares an output schema but a top-level final state has no `output`.                                                                                                                                                                                                 |
-| `final-output-reads-event` | warning  | A top-level final state's `output` function reads the entering `event`. Final `output` fns are evaluated more than once with different events, so `event` is unreliable. Read `context` only, capturing what you need into context in the transition that targets the final state. |
-| `undeclared-event`         | warning  | A state handles an event in `on:` that isn't declared in `schemas.events` and isn't a builtin/wildcard pattern. Its payload stays unvalidated; usually a typo. Skipped entirely when the machine declares no events.                                                               |
-| `missing-final`            | warning  | No reachable final state; the machine can only idle/loop (legal, but flagged).                                                                                                                                                                                                     |
+| `final-output-reads-event` | warning  | A top-level final state's `output` function reads the entering `event`. Final `output` functions are evaluated more than once with different events, so `event` is unreliable. Read `context` only, and capture what you need into context in the transition that targets the final state. |
+| `undeclared-event`         | warning  | A state handles an event in `on:` that is not declared in `schemas.events` and is not a builtin or wildcard pattern. Its payload stays unvalidated. This is usually a typo. The check is skipped when the machine declares no events.                                                               |
+| `missing-final`            | warning  | The machine has no reachable final state, so it can only idle or loop. This is legal, but flagged.                                                                                                                                                                                                     |
 
 ## Test assertions
 
-Every check is a plain function, so assert structural soundness, reachability, and scripted playthroughs directly in vitest/jest:
+Every check is a plain function, so you can assert structural soundness, reachability, and scripted playthroughs directly in vitest or jest.
 
 ```ts no-check
-import { assertAgentMachine, canReach, simulateAgent } from "@statelyai/agent";
+import { canReach, lintAgentMachine, simulateAgent } from "@statelyai/agent";
 import { supportMachine } from "./support-machine";
 
 test("machine is structurally sound", () => {
-  assertAgentMachine(supportMachine); // throws AgentLintError with findings
+  lintAgentMachine(supportMachine, { throw: true });
 });
 
 test("escalation is reachable", async () => {
-  const { canReach: reachable } = await canReach(supportMachine, "escalated", {
+  const { reachable } = await canReach(supportMachine, "escalated", {
     input: { question: "refund?" },
   });
   expect(reachable).toBe(true);
@@ -69,11 +73,11 @@ test("happy path settles done", async () => {
 });
 ```
 
-Guards stay in force throughout: `canReach` and `simulateAgent` walk the same step path `runAgent` uses, so a graph path that is guard-illegal never counts as reachable. These tests pin the shape as prompts and models change.
+Guards stay in force throughout. `canReach` and `simulateAgent` walk the same step path that `runAgent` uses, so a graph path that a guard rejects never counts as reachable. These tests pin the machine's shape as prompts and models change.
 
 ## Deterministic executors
 
-Executors are plain functions, so a test supplies scripted ones and never touches the network. Bind them onto a logic with `.withExecutor(...)`:
+Executors are plain functions, so a test can supply scripted executors and never touch the network. Bind them onto a logic with `.withExecutor(...)`.
 
 ```ts no-check
 const machine = emailDrafter.provide({
@@ -85,17 +89,18 @@ const machine = emailDrafter.provide({
 });
 ```
 
-[examples/email-drafter/agent-logic.ts](../examples/email-drafter/agent-logic.ts) drives a full run this way: fixed values, deterministic, no model called.
+[examples/email-drafter/agent-logic.ts](../examples/email-drafter/agent-logic.ts) drives a full run this way, with fixed values and no model call.
 
-Use this when the test should exercise the real `runAgent` path with canned model output; use `simulateAgent` below when a scripted playthrough on the pure step path is enough.
+Use deterministic executors when the test should exercise the real `runAgent` path with canned model output. Use [`simulateAgent`](#scripted-playthroughs) when a scripted playthrough on the pure step path is enough.
 
 ## Scripted playthroughs
 
-The `simulateAgent(machine, { input, script, maxSteps? })` call runs a deterministic, model-free playthrough on the pure step path. The `script` supplies responses by invoke `src` (FIFO queues), so runs are reproducible:
+`simulateAgent(machine, { input, script, maxSteps? })` runs a deterministic, model-free playthrough on the pure step path. The `script` supplies responses as FIFO queues, so runs are reproducible.
 
-- `decisions`: the `ChosenEvent` to apply per decision (keyed by decision src, usually `agent.decide`);
-- `text`: output values for text requests (keyed by request src);
-- `invokes`: answers for `agent.userInput` invokes.
+- `decisions` holds the `ChosenEvent` to apply per decision, keyed by decision src, usually `agent.decide`.
+- `text` holds output values for text requests, keyed by request src.
+- `invokes` holds answers for scripted invokes, keyed by invoke src.
+- `userInput` is one flat queue of answers for `agent.userInput` invokes.
 
 ```ts
 import { simulateAgent } from "@statelyai/agent";
@@ -104,7 +109,7 @@ const { status, snapshot, trail } = await simulateAgent(machine, {
   input: { questionsRemaining: 20 },
   script: {
     decisions: { "agent.decide": [{ type: "GUESS", guess: "a cat" }] },
-    invokes: { "agent.userInput": ["yes", "no"] },
+    userInput: ["yes", "no"],
     text: {
       classifyGuessFeedback: [{ correct: true, reasoning: "matched" }],
       classifyPlayAgain: [{ playAgain: false, reasoning: "stop" }],
@@ -114,7 +119,13 @@ const { status, snapshot, trail } = await simulateAgent(machine, {
 // status: 'done' | 'idle' | 'exhausted'
 ```
 
-It returns `{ status, snapshot, trail }`. For a `'done'` run the output lives on `snapshot.output`, typed as the generic `AnyMachineSnapshot`, so it needs a cast to your output type:
+`simulateAgent` returns `{ status, snapshot, trail }`. The status is one of three values:
+
+- `'done'`: the machine reached a final state.
+- `'idle'`: the machine came to rest waiting on an external event that the script does not supply.
+- `'exhausted'`: the playthrough hit the `maxSteps` bound, which defaults to 100, before reaching either of the above. Raise `maxSteps` or shorten the script.
+
+For a `'done'` run, the output is on `snapshot.output`. The snapshot is typed as the generic `AnyMachineSnapshot`, so the output needs a cast to your output type.
 
 ```ts
 if (result.status === "done") {
@@ -122,15 +133,20 @@ if (result.status === "done") {
 }
 ```
 
-> **Note:** When the script runs dry mid-request, `simulateAgent` throws a descriptive error naming the pending request's kind, src, and id, so a missing response is obvious.
+> **Note:** When a script queue runs dry mid-request, `simulateAgent` throws a descriptive error naming the pending request's kind, src, and id.
 
 ## Branch exploration
 
-The `explorePaths(machine, { input, maxDepth?, textOutputs? })` call enumerates decision and external-event branches, model-free, and reports coverage.
+`explorePaths(machine, { input, maxDepth?, maxPaths?, text?, invokes?, userInput? })` enumerates decision and external-event branches without a model, and reports coverage.
 
-- At each decision it forks one branch per candidate event. Guard-rejected candidates count in `prunedByGuard` and are not explored.
-- At an idle wait it forks per externally-accepted event.
-- Text/`userInput` invokes resolve from `textOutputs` (a by-src canned-output map); a missing src halts that branch with a `needs-output` terminal instead of throwing.
+- At each decision, it forks one branch per candidate event. Guard-rejected candidates count in `prunedByGuard` and are not explored.
+- At an idle wait, it forks one branch per externally accepted event.
+- `text` is a map of canned outputs for text requests, keyed by src. One value per src is reused every time that src is reached.
+- `invokes` is the same map for scripted invokes, and `userInput` is the shorthand for `invokes['agent.userInput']`.
+- A src with no canned output halts that branch with a `needs-output` terminal instead of throwing. The terminal's `missingSrc` names it.
+
+<!-- viz: branch exploration tree for the refund machine: deciding -> AUTO_APPROVE (pruned by guard) / NEEDS_REVIEW -> awaitingHuman -> refunded, denied -->
+
 
 ```ts
 import { explorePaths } from "@statelyai/agent";
@@ -143,34 +159,36 @@ const report = await explorePaths(refundMachine, {
 // report.reachedStates → ['deciding', 'awaitingHuman', 'refunded', 'denied']
 ```
 
-Exploration is bounded by `maxDepth` (default 8) and `maxPaths` (default 200; `report.hitPathCap` flags a partial report).
+Exploration is bounded by `maxDepth`, which defaults to 8, and `maxPaths`, which defaults to 200. `report.hitPathCap` is true when the report is partial.
 
 ## Reachability checks
 
-The `canReach(machine, statePath, opts)` call wraps `explorePaths` to answer "can this state be reached?" with a witness path (async).
+`canReach(machine, statePath, opts)` wraps `explorePaths` to report whether a state is reachable, along with a witness path. It is async.
 
 ```ts
 import { canReach } from "@statelyai/agent";
 
-const { canReach: ok, witness } = await canReach(refundMachine, "denied", {
+const { reachable, witness } = await canReach(refundMachine, "denied", {
   input: { request: "x", amount: 5000 },
 });
-// ok → true; witness → [{ type: 'NEEDS_REVIEW' }, { type: 'DENY' }]
+// reachable → true; witness → [{ type: 'NEEDS_REVIEW' }, { type: 'DENY' }]
 ```
+
+`witness` is the sequence of chosen and applied events that reaches the state, which is the proof that it is reachable. It is absent when `reachable` is `false`.
 
 ## CI checks
 
-Everything on this page runs without an API key, so a small script is enough for CI or a generation loop:
+Everything on this page runs without an API key, so a small script is enough for CI or a generation loop.
 
 ```ts no-check
 // check.ts (run with: npx tsx check.ts)
-import { assertAgentMachine } from "@statelyai/agent";
+import { lintAgentMachine } from "@statelyai/agent";
 import { machine } from "./machine";
 
-assertAgentMachine(machine); // throws AgentLintError on error-severity findings
+lintAgentMachine(machine, { throw: true }); // throws AgentLintError on error-severity findings
 ```
 
-For machines authored as data (see [Machines as data](machines-as-data.md)), compile the config first: `assertAgentMachine(setupAgent.fromConfig(config, { compileSchema }).machine)`. Every check applies, reachability included: the lowering keeps the config's transition targets, so `unreachable-state` reads the real graph even where the JSON layer folds a target into a resolver function.
+For machines authored as data, validate the config with `validateAgentConfig(config)` from `@statelyai/agent/validate` first, then compile it and lint the machine: `lintAgentMachine(setupAgent.fromConfig(config, { compileSchema }).machine, { throw: true })`. See [Machines as data](machines-as-data.md). Every check applies, including reachability. The lowering keeps the config's transition targets, so `unreachable-state` reads the real graph even where the JSON layer folds a target into a resolver function.
 
 ## Related
 

--- a/examples/ai-sdk-game-host/index.ts
+++ b/examples/ai-sdk-game-host/index.ts
@@ -70,7 +70,7 @@ async function resolveEffect(
     if (!executors.decide) {
       throw new Error(`decision effect '${effect.request.id}' needs a 'decide' executor.`);
     }
-    return resolveDecision(effect.request, executors.decide, {
+    return resolveDecision(effect.request, executors, {
       canTake: (event) => snapshot.can(event as never),
     });
   }

--- a/examples/ai-sdk-sub-agents/index.ts
+++ b/examples/ai-sdk-sub-agents/index.ts
@@ -103,7 +103,7 @@ function createAiSdkSubAgentWorkflow(subAgents: SubAgents) {
         },
         // Bound the host-side tool loop so the supervisor can call both
         // sub-agents across steps (the AI SDK adapter reads this).
-        metadata: { maxSteps: 8 },
+        maxSteps: 8,
       },
     },
   });

--- a/examples/braintrust-evals/index.ts
+++ b/examples/braintrust-evals/index.ts
@@ -44,7 +44,7 @@ type DrafterSnapshot = SnapshotFrom<typeof emailDrafter>;
  */
 const WAITING_STATES = new Set(["prompting", "needsMoreInfo", "reviewing", "sent"]);
 
-const isSuspended = (snapshot: AnyMachineSnapshot) =>
+const isIdle = (snapshot: AnyMachineSnapshot) =>
   typeof snapshot.value === "string" && WAITING_STATES.has(snapshot.value);
 
 /** One dataset row's input: the request, plus how the simulated user behaves. */
@@ -159,7 +159,7 @@ export async function runDrafterCase(
       ...(snapshot ? { snapshot, event } : { event }),
       events: log,
       executors,
-      isSuspended,
+      isIdle,
       onTransition: (next) => statePath.push(String(next.value)),
     });
 

--- a/examples/braintrust-evals/seams.ts
+++ b/examples/braintrust-evals/seams.ts
@@ -122,8 +122,7 @@ export async function runSeamCase(
     seam: input.seam,
     ...(candidate ? { candidate } : {}),
     respond: respondFor(input),
-    isSuspended: (snapshot) =>
-      typeof snapshot.value === "string" && WAITING_STATES.has(snapshot.value),
+    isIdle: (snapshot) => typeof snapshot.value === "string" && WAITING_STATES.has(snapshot.value),
   });
 
   return {
@@ -256,7 +255,7 @@ export const clarifySeam: SeamRow[] = [
         promptEvaluator: [VAGUE_ASSESSMENT, COMPLETE_ASSESSMENT],
         emailDrafter: [DRAFT],
       },
-      seam: { model: "promptEvaluator", occurrence: 0 },
+      seam: { request: "evaluatePrompt", occurrence: 0 },
     },
     expected: {
       // A prompt with no recipient must send the machine to `needsMoreInfo`.
@@ -276,7 +275,7 @@ export const clarifySeam: SeamRow[] = [
         promptEvaluator: [COMPLETE_ASSESSMENT],
         emailDrafter: [DRAFT],
       },
-      seam: { model: "promptEvaluator", occurrence: 0 },
+      seam: { request: "evaluatePrompt", occurrence: 0 },
     },
     expected: {
       // Straight to drafting: no clarification round.
@@ -299,7 +298,7 @@ export const draftSeam: SeamRow[] = [
         promptEvaluator: [COMPLETE_ASSESSMENT],
         emailDrafter: [DRAFT],
       },
-      seam: { model: "emailDrafter", occurrence: 0 },
+      seam: { request: "draftEmail", occurrence: 0 },
     },
     expected: {
       statePath: ["reviewing", "sending", "sent"],
@@ -318,7 +317,7 @@ export const draftSeam: SeamRow[] = [
         promptEvaluator: [VAGUE_ASSESSMENT, COMPLETE_ASSESSMENT],
         emailDrafter: [DRAFT],
       },
-      seam: { model: "emailDrafter", occurrence: 0 },
+      seam: { request: "draftEmail", occurrence: 0 },
     },
     expected: {
       statePath: ["reviewing", "sending", "sent"],
@@ -341,7 +340,7 @@ export const reviseSeam: SeamRow[] = [
         promptEvaluator: [COMPLETE_ASSESSMENT],
         emailDrafter: [DRAFT, REVISED_DRAFT],
       },
-      seam: { model: "emailDrafter", occurrence: 1 },
+      seam: { request: "draftEmail", occurrence: 1 },
     },
     expected: {
       statePath: ["reviewing", "sending", "sent"],

--- a/examples/chat-with-pdf/index.ts
+++ b/examples/chat-with-pdf/index.ts
@@ -317,7 +317,7 @@ const agentSetup = setupAgent({
   models,
   // Deterministic idle detection: the states waiting on the human are exactly
   // the ones tagged `waiting`.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
   actors: {
     // Plain typed actor — no model in the retrieval path.
     retrieve: createAsyncLogic<Chunk[], QueryPdfInput>({

--- a/examples/cloudflare-workers-ai-host/index.ts
+++ b/examples/cloudflare-workers-ai-host/index.ts
@@ -159,43 +159,45 @@ async function runWorkersAiTextRequest(env: Env, request: AgentTextRequest) {
 async function runWorkersAiDecision(env: Env, request: AgentDecisionRequest): Promise<ChosenEvent> {
   return resolveDecision(
     request,
-    async (attemptRequest) => {
-      const legalEvents = attemptRequest.events.map((event) => `- ${event.type}`).join("\n");
-      const attemptFeedback = renderDecisionAttempts(attemptRequest)
-        .map((m) => m.content)
-        .join("\n");
+    {
+      decide: async (attemptRequest) => {
+        const legalEvents = attemptRequest.events.map((event) => `- ${event.type}`).join("\n");
+        const attemptFeedback = renderDecisionAttempts(attemptRequest)
+          .map((m) => m.content)
+          .join("\n");
 
-      const prompt = [
-        attemptRequest.prompt ?? "",
-        attemptFeedback,
-        "",
-        "Choose exactly one legal event.",
-        "Legal events:",
-        legalEvents,
-        "",
-        "Reply with ONLY a JSON object and no other text, no explanation, no prose.",
-        'Example reply: {"type":"ATTACK","target":"goblin"}',
-      ]
-        .filter(Boolean)
-        .join("\n");
+        const prompt = [
+          attemptRequest.prompt ?? "",
+          attemptFeedback,
+          "",
+          "Choose exactly one legal event.",
+          "Legal events:",
+          legalEvents,
+          "",
+          "Reply with ONLY a JSON object and no other text, no explanation, no prose.",
+          'Example reply: {"type":"ATTACK","target":"goblin"}',
+        ]
+          .filter(Boolean)
+          .join("\n");
 
-      const text = await runWorkersAiPrompt(env, {
-        model: attemptRequest.model,
-        system: attemptRequest.system,
-        prompt,
-        temperature: attemptRequest.temperature,
-        maxOutputTokens: attemptRequest.maxOutputTokens,
-      });
+        const text = await runWorkersAiPrompt(env, {
+          model: attemptRequest.model,
+          system: attemptRequest.system,
+          prompt,
+          temperature: attemptRequest.temperature,
+          maxOutputTokens: attemptRequest.maxOutputTokens,
+        });
 
-      try {
-        return { event: parseJsonFromText(text) as ChosenEvent };
-      } catch (error) {
-        // Not JSON at all. Hand back an event type that cannot match, so
-        // `resolveDecision` records an `unknown-event` attempt and re-asks with
-        // that feedback in `request.attempts` — rather than throwing out of the
-        // whole turn on one malformed response.
-        return { event: { type: `<unparsed response: ${String(error)}>` } };
-      }
+        try {
+          return { event: parseJsonFromText(text) as ChosenEvent };
+        } catch (error) {
+          // Not JSON at all. Hand back an event type that cannot match, so
+          // `resolveDecision` records an `unknown-event` attempt and re-asks with
+          // that feedback in `request.attempts` — rather than throwing out of the
+          // whole turn on one malformed response.
+          return { event: { type: `<unparsed response: ${String(error)}>` } };
+        }
+      },
     },
     { maxRetries: 2 },
   );

--- a/examples/context-compaction/index.ts
+++ b/examples/context-compaction/index.ts
@@ -127,7 +127,7 @@ const agentSetup = setupAgent({
   models,
   // Deterministic idle detection: the run settles whenever the machine is
   // parked in the tagged waiting-for-a-human state.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
   requests: {
     // Chat reply. Rendered as: [summary-as-system?] + recent messages.
     respond: {

--- a/examples/customer-support/index.ts
+++ b/examples/customer-support/index.ts
@@ -17,7 +17,7 @@
  *
  *   - Non-sensitive Q&A: ONE `answer` request carries real `tools`
  *     (`lookupBooking`, `searchPolicies` over a small sample table) and the host
- *     runs the tool loop, bounded by `metadata.maxSteps`. The machine never sees
+ *     runs the tool loop, bounded by the request's `maxSteps`. The machine never sees
  *     the intermediate tool calls — same as LangGraph's safe-tools path, minus
  *     the extra node. (See examples/tool-calling.)
  *   - Intent routing: a structured-output `classify` request returns a
@@ -28,7 +28,7 @@
  *     `['awaiting-approval']`, a static `meta.interaction` label, and the pending
  *     action in `context.pendingAction`. `runAgent` settles `{ status: 'idle',
  *     snapshot }` deterministically (the machine declares its own wait signal via
- *     `isSuspended`), so pausing is a first-class machine state, not a host-side
+ *     `isIdle`), so pausing is a first-class machine state, not a host-side
  *     `snapshot.next` check. The host persists the snapshot and resumes with an
  *     APPROVE or DENY event in a *second* `runAgent` call. (See
  *     examples/human-in-the-loop.)
@@ -47,7 +47,6 @@ import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
 import {
   getAcceptedEvents,
   getStateMeta,
-  persistSnapshot,
   runAgent,
   setupAgent,
   type AgentRequestExecutors,
@@ -158,7 +157,7 @@ const agentSetup = setupAgent({
   // The machine's own wait signal: the `confirming` tag. `runAgent` settles idle
   // deterministically whenever a resting snapshot carries it — no timing
   // heuristic, no host-side `snapshot.next` check.
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-approval"),
   actors: {
     // Applies the approved sensitive action. Reads the real booking table and
     // returns a confirmation message. (A production host would persist the
@@ -223,7 +222,7 @@ const agentSetup = setupAgent({
         }),
       },
       // Bound the host-side tool loop (the AI SDK adapter reads this).
-      metadata: { maxSteps: 5 },
+      maxSteps: 5,
     },
   },
   // `confirming` and `executing` are reached only after classify set a sensitive
@@ -427,7 +426,7 @@ export async function runCustomerSupportExample(
     ? ({ type: "APPROVE" } as const)
     : ({ type: "DENY", reason: denyReason } as const);
   const second = await runAgent(customerSupportMachine, {
-    snapshot: persistSnapshot(first.snapshot),
+    snapshot: first.persistedSnapshot,
     event,
     ...executors,
     onTransition: track,
@@ -490,7 +489,7 @@ if (import.meta.url === new URL(process.argv[1]!, "file:").href) {
       console.log(interaction?.label ?? "");
       console.log("Legal events:", legalEvents.join(", "));
 
-      const persisted = persistSnapshot(snapshot);
+      const persisted = result.persistedSnapshot;
       const answer = (await promptLine("approve / deny? ")).toLowerCase();
       const event = answer.startsWith("a")
         ? ({ type: "APPROVE" } as const)

--- a/examples/described-workflow/index.ts
+++ b/examples/described-workflow/index.ts
@@ -33,6 +33,7 @@ import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
 import {
   createTextLogic,
   getAgentMessages,
+  getSnapshotNodes,
   runAgent,
   type AgentMessage,
   type AgentRequestExecutors,
@@ -156,9 +157,10 @@ export const describedWorkflowMachine = setup({ actors: { write } }).createMachi
  * idle, so this hook never sees them.
  */
 export const getRequests = (snapshot: AnyMachineSnapshot): AgentStateRequest[] => {
-  const rootDescription = snapshot._nodes.find((node) => !node.parent)?.description;
-  return snapshot._nodes
-    .filter((node) => node.parent && node.description && !node.tags.includes("waiting"))
+  const [root, ...descendants] = getSnapshotNodes(snapshot);
+  const rootDescription = root?.description;
+  return descendants
+    .filter((node) => node.description && !node.tags.includes("waiting"))
     .map((node) => ({
       model: "writer",
       prompt: node.description!,

--- a/examples/email-drafter/agent-logic.ts
+++ b/examples/email-drafter/agent-logic.ts
@@ -137,6 +137,7 @@ export const evaluatePrompt = createTextLogic({
     input: z.object({ prompt: z.string() }),
     output: promptAssessmentSchema,
   },
+  name: "evaluatePrompt",
   model: "promptEvaluator",
   system:
     "Evaluate an email drafting request. Require recipient, subject, and body details. Return missing fields and one question per gap.",
@@ -151,6 +152,7 @@ export const draftEmail = createTextLogic({
     }),
     output: emailDraftSchema,
   },
+  name: "draftEmail",
   model: "emailDrafter",
   system:
     "Draft a polished email from the request. Use the provided details without inventing missing essentials unless the user explicitly asked to draft anyway.",
@@ -180,7 +182,7 @@ const agentSetup = setupAgent({
   models,
   // The machine's own wait signal: the `awaiting-user` tag. Every state that
   // needs the human carries it, so `runAgent` settles idle deterministically.
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-user"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-user"),
   actors: emailDrafterActors,
 });
 

--- a/examples/eve-host/bridge.ts
+++ b/examples/eve-host/bridge.ts
@@ -24,7 +24,6 @@ import type { EventFromLogic, Snapshot } from "xstate";
 import { createAiSdkExecutors } from "@statelyai/agent/ai-sdk";
 import {
   getStateMeta,
-  persistSnapshot,
   runAgent,
   type AgentTextRequest,
   type RunAgentOptions,
@@ -153,7 +152,7 @@ function toToolResult(result: RunAgentResult<typeof emailDrafter>, handle: strin
 
   const meta = getStateMeta<typeof result.snapshot, z.infer<typeof metaSchema>>(result.snapshot);
   const interaction = meta.interaction ?? null;
-  runs.set(handle, { snapshot: persistSnapshot(result.snapshot), interaction });
+  runs.set(handle, { snapshot: result.persistedSnapshot, interaction });
 
   return {
     status: "pending",

--- a/examples/express-host/index.ts
+++ b/examples/express-host/index.ts
@@ -26,7 +26,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   getAcceptedEvents,
   getStateMeta,
-  persistSnapshot,
   runAgent,
   setupAgent,
   type AgentRequestExecutors,
@@ -50,7 +49,7 @@ const agentSetup = setupAgent({
   meta: z.object({ interaction: z.object({ label: z.string() }).optional() }),
   events: { APPROVE: z.object({}), REJECT: z.object({ reason: z.string() }) },
   // The machine's own wait signal — runAgent settles idle deterministically on it.
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-review"),
   requests: {
     writeDraft: {
       schemas: { input: z.object({ topic: z.string() }), output: z.string() },
@@ -121,7 +120,7 @@ export function createApp(executors: Partial<AgentRequestExecutors> = resolveExe
 
     if (result.status === "idle") {
       const id = crypto.randomUUID();
-      snapshots.set(id, persistSnapshot(result.snapshot));
+      snapshots.set(id, result.persistedSnapshot);
       const { interaction } = getStateMeta(result.snapshot);
       return res.status(202).json({
         id,
@@ -147,7 +146,7 @@ export function createApp(executors: Partial<AgentRequestExecutors> = resolveExe
       return res.json({ status: "done", output: result.output });
     }
     if (result.status === "idle") {
-      snapshots.set(id, persistSnapshot(result.snapshot));
+      snapshots.set(id, result.persistedSnapshot);
       return res.status(202).json({ status: "idle", draft: result.snapshot.context.draft });
     }
     return res.status(500).json({ status: result.status });

--- a/examples/fan-out/index.test.ts
+++ b/examples/fan-out/index.test.ts
@@ -1,7 +1,7 @@
 import { test } from "vitest";
 import assert from "node:assert/strict";
 import type { AnyMachineSnapshot, Snapshot } from "xstate";
-import { persistSnapshot, runAgent, type AgentTextRequest } from "@statelyai/agent";
+import { runAgent, type AgentTextRequest } from "@statelyai/agent";
 import { fanOutMachine, runFanOutExample } from "./index.js";
 
 test("fan-out plans subtopics, spawns one branch per subtopic, and reduces all summaries", async () => {
@@ -73,7 +73,7 @@ test("fan-out plans subtopics, spawns one branch per subtopic, and reduces all s
 });
 
 // FINDING (2026-07): resuming a snapshot persisted while branches are still in
-// flight does NOT re-run those spawned children. `persistSnapshot` captures the
+// flight does NOT re-run those spawned children. A persisted snapshot captures the
 // live children with no resumable state (status undefined, no output); on
 // restore xstate drops them (`children: {}`), so `collecting` has nothing left
 // to await and `runAgent` settles `{ status: 'idle' }` in `collecting` with
@@ -104,7 +104,7 @@ test.skip("resumes a mid-flight snapshot and completes with all summaries", asyn
     onTransition: (snapshot) => {
       if (JSON.stringify(snapshot.value) !== '"collecting"') return;
       if (!captured && Object.keys(snapshot.context.summaries).length < subtopics.length) {
-        captured = persistSnapshot(snapshot);
+        captured = fanOutMachine.getPersistedSnapshot(snapshot);
       }
     },
   });

--- a/examples/file-snapshot-store/index.ts
+++ b/examples/file-snapshot-store/index.ts
@@ -65,7 +65,7 @@ const agentSetup = setupAgent({
   },
   // The machine's own wait signal: the `awaiting-review` tag. `runAgent` settles
   // idle deterministically whenever a resting snapshot carries it.
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-review"),
   requests: {
     writeDraft: {
       schemas: { input: z.object({ topic: z.string() }), output: z.string() },

--- a/examples/flue-host/machine-owned.ts
+++ b/examples/flue-host/machine-owned.ts
@@ -37,7 +37,6 @@ import type { EventFromLogic, Snapshot } from "xstate";
 import { createAiSdkExecutors } from "@statelyai/agent/ai-sdk";
 import {
   getStateMeta,
-  persistSnapshot,
   runAgent,
   type AgentTextRequest,
   type RunAgentOptions,
@@ -185,7 +184,7 @@ function toToolResult(result: RunAgentResult<typeof emailDrafter>, handle: strin
 
   const meta = getStateMeta<typeof result.snapshot, z.infer<typeof metaSchema>>(result.snapshot);
   const interaction = meta.interaction ?? null;
-  runs.set(handle, { snapshot: persistSnapshot(result.snapshot), interaction });
+  runs.set(handle, { snapshot: result.persistedSnapshot, interaction });
 
   return {
     status: "pending",

--- a/examples/game-agent/index.ts
+++ b/examples/game-agent/index.ts
@@ -465,7 +465,7 @@ const rpsSetup = setupAgent({
   models: rpsModels,
   // Deterministic idle detection: the run settles as soon as the machine is in
   // the tagged waiting-for-you state, no timing heuristic involved.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
   states: {
     awaitingHumanThrow: {},
     choosingThrow: {},

--- a/examples/game-loop-agent/index.ts
+++ b/examples/game-loop-agent/index.ts
@@ -182,7 +182,7 @@ const gameSetup = setupAgent({
   // `runAgent` settles idle deterministically whenever a resting snapshot
   // carries it — the invoked `player` child (with its accumulated
   // observations) round-trips through the idle `persistedSnapshot`.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
   context: z.object({
     seed: z.number(),
     target: z.number(),

--- a/examples/go-fish/index.ts
+++ b/examples/go-fish/index.ts
@@ -299,7 +299,7 @@ export const goFishMachine = setupAgent({
   models,
   // Deterministic idle detection: the run settles whenever it is waiting on the
   // human, instead of falling back to the timing heuristic.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
 }).createMachine({
   id: "go-fish",
   context: ({ input }) => deal(input.deck ?? shuffledDeck(input.seed), input.maxTurns),

--- a/examples/hono-host/index.ts
+++ b/examples/hono-host/index.ts
@@ -23,7 +23,6 @@ import { openai } from "@ai-sdk/openai";
 import {
   getAcceptedEvents,
   getStateMeta,
-  persistSnapshot,
   runAgent,
   setupAgent,
   type AgentRequestExecutors,
@@ -46,7 +45,7 @@ const reviewSetup = setupAgent({
   output: z.object({ published: z.boolean(), draft: z.string() }),
   meta: z.object({ interaction: z.object({ label: z.string() }).optional() }),
   events: { APPROVE: z.object({}), REJECT: z.object({ reason: z.string() }) },
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-review"),
   requests: {
     writeDraft: {
       schemas: { input: z.object({ topic: z.string() }), output: z.string() },
@@ -152,7 +151,7 @@ export function createApp(executors: Partial<AgentRequestExecutors> = resolveExe
 
     if (result.status === "idle") {
       const id = crypto.randomUUID();
-      snapshots.set(id, persistSnapshot(result.snapshot));
+      snapshots.set(id, result.persistedSnapshot);
       const { interaction } = getStateMeta(result.snapshot);
       return c.json(
         {
@@ -181,7 +180,7 @@ export function createApp(executors: Partial<AgentRequestExecutors> = resolveExe
       return c.json({ status: "done", output: result.output });
     }
     if (result.status === "idle") {
-      snapshots.set(id, persistSnapshot(result.snapshot));
+      snapshots.set(id, result.persistedSnapshot);
       return c.json({ status: "idle", draft: result.snapshot.context.draft }, 202);
     }
     return c.json({ status: result.status }, 500);

--- a/examples/human-in-the-loop/index.ts
+++ b/examples/human-in-the-loop/index.ts
@@ -10,7 +10,7 @@
  *     are inferred from the idle snapshot with `getAcceptedEvents(...)`.
  *   - REJECT-with-reason redraft loop: rejecting feeds the reason back into the
  *     next draft; APPROVE publishes.
- *   - Snapshot persistence: each idle snapshot survives `persistSnapshot(...)`
+ *   - Snapshot persistence: each idle settle hands back a `persistedSnapshot`
  *     (a JSON round-trip) and resumes in the *next* `runAgent` call.
  *
  * Two entry points:
@@ -29,7 +29,6 @@ import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
 import {
   getAcceptedEvents,
   getStateMeta,
-  persistSnapshot,
   runAgent,
   setupAgent,
   type AgentRequestExecutors,
@@ -75,8 +74,8 @@ const agentSetup = setupAgent({
   },
   // This machine declares its own wait signal: a tag it chose. runAgent settles
   // idle deterministically whenever a resting snapshot carries it (no timing
-  // heuristic). A host could override this per-run via runAgent({ isSuspended }).
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
+  // heuristic). A host could override this per-run via runAgent({ isIdle }).
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-review"),
   requests: {
     writeDraft: {
       schemas: {
@@ -185,7 +184,7 @@ export async function runHumanInTheLoopExample(
   // Phase 2: ...later, new process, human approved. Same machine, one event,
   // resumed from the persisted (JSON-round-tripped) snapshot.
   const second = await runAgent(humanInTheLoopMachine, {
-    snapshot: persistSnapshot(first.snapshot),
+    snapshot: first.persistedSnapshot,
     event: { type: "APPROVE" },
     ...executors,
   });
@@ -240,7 +239,7 @@ if (import.meta.url === new URL(process.argv[1]!, "file:").href) {
       console.log("\n" + (interaction?.label ?? ""));
       console.log("Legal events:", legalEvents.join(", "));
 
-      const persisted = persistSnapshot(snapshot);
+      const persisted = result.persistedSnapshot;
       const answer = (await promptLine("approve / reject? ")).toLowerCase();
 
       if (answer.startsWith("a")) {

--- a/examples/json-agent/index.ts
+++ b/examples/json-agent/index.ts
@@ -14,9 +14,9 @@
  *   - `draftReply` (drafting): a plain text request, same as any
  *     `setupAgent({ requests: {...} })` request.
  *   - `awaitingApproval`: an idle state — no invoke, nothing left to do
- *     until a human sends APPROVE/REJECT. The config's `suspendedTags:
+ *     until a human sends APPROVE/REJECT. The config's `idleTags:
  *     ["awaiting-approval"]` (matching the state's `tags`) is the declarative
- *     form of `setupAgent({ isSuspended })` — `fromConfig` lowers it to a
+ *     form of `setupAgent({ isIdle })` — `fromConfig` lowers it to a
  *     `hasTag` predicate, so `runAgent` settles `{ status: 'idle', snapshot }`
  *     deterministically (no timing heuristic, no warning); the host persists
  *     that snapshot and resumes with `runAgent(machine, { snapshot, event,

--- a/examples/json-agent/workflow.json
+++ b/examples/json-agent/workflow.json
@@ -98,7 +98,7 @@
     }
   },
   "initial": "triaging",
-  "suspendedTags": ["awaiting-approval"],
+  "idleTags": ["awaiting-approval"],
   "states": {
     "triaging": {
       "invoke": {

--- a/examples/langchain-host/bridge.ts
+++ b/examples/langchain-host/bridge.ts
@@ -26,7 +26,6 @@ import type { BaseChatModel } from "@langchain/core/language_models/chat_models"
 import { createAgent } from "langchain";
 import {
   getStateMeta,
-  persistSnapshot,
   runAgent,
   type RunAgentOptions,
   type RunAgentResult,
@@ -147,7 +146,7 @@ function toToolResult(result: RunAgentResult<typeof emailDrafter>, handle: strin
 
   const meta = getStateMeta<typeof result.snapshot, z.infer<typeof metaSchema>>(result.snapshot);
   const interaction = meta.interaction ?? null;
-  runs.set(handle, { snapshot: persistSnapshot(result.snapshot), interaction });
+  runs.set(handle, { snapshot: result.persistedSnapshot, interaction });
 
   return {
     status: "pending",

--- a/examples/long-running-onboarding/index.ts
+++ b/examples/long-running-onboarding/index.ts
@@ -27,7 +27,6 @@ import { createAsyncLogic } from "xstate";
 import {
   getAcceptedEvents,
   getStateMeta,
-  persistSnapshot,
   runAgent,
   setupAgent,
   type AgentRequestExecutors,
@@ -122,7 +121,7 @@ const coordinatorSetup = setupAgent({
   // state with `meta.interaction` (what the host should show), so it reuses that
   // as its suspension signal instead of a separate tag. runAgent settles idle
   // deterministically at any resting state carrying an interaction.
-  isSuspended: (snapshot) => getStateMeta(snapshot).interaction !== undefined,
+  isIdle: (snapshot) => getStateMeta(snapshot).interaction !== undefined,
   actors: {
     sendWelcomePacket: createAsyncLogic({
       schemas: {
@@ -335,7 +334,7 @@ export async function runLongRunningOnboardingExample(
   idlePrompts.push(getStateMeta(first.snapshot).interaction?.label ?? "");
   idleEventTypes.push(getAcceptedEvents(first.snapshot).map((event) => event.type));
 
-  const persistedAfterWelcome = persistSnapshot(first.snapshot);
+  const persistedAfterWelcome = first.persistedSnapshot;
   const second = await runAgent(longRunningOnboardingMachine, {
     snapshot: persistedAfterWelcome,
     event: { type: "DOCS_SIGNED", signedAt: "2026-07-20" },
@@ -351,7 +350,7 @@ export async function runLongRunningOnboardingExample(
   idlePrompts.push(getStateMeta(second.snapshot).interaction?.label ?? "");
   idleEventTypes.push(getAcceptedEvents(second.snapshot).map((event) => event.type));
 
-  const persistedAfterProvisioning = persistSnapshot(second.snapshot);
+  const persistedAfterProvisioning = second.persistedSnapshot;
   const third = await runAgent(longRunningOnboardingMachine, {
     snapshot: persistedAfterProvisioning,
     event: { type: "HARDWARE_DELIVERED", deliveredAt: "2026-07-28" },

--- a/examples/machine-as-tool/index.ts
+++ b/examples/machine-as-tool/index.ts
@@ -82,7 +82,7 @@ const agentSetup = setupAgent({
   },
   // The machine's own wait signal: the `awaiting-approval` tag. `runAgent`
   // settles idle deterministically whenever a resting snapshot carries it.
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-approval"),
   requests: {
     // Stands in for a real validation model call (fraud check, policy, …).
     validateRefund: {

--- a/examples/mastra-host/index.ts
+++ b/examples/mastra-host/index.ts
@@ -37,7 +37,6 @@ import {
 import { createAiSdkExecutors } from "@statelyai/agent/ai-sdk";
 import {
   getStateMeta,
-  persistSnapshot,
   runAgent,
   type AgentTextRequest,
   type RunAgentOptions,
@@ -165,7 +164,7 @@ function toToolResult(result: RunAgentResult<typeof emailDrafter>, handle: strin
 
   const meta = getStateMeta<typeof result.snapshot, z.infer<typeof metaSchema>>(result.snapshot);
   const interaction = meta.interaction ?? null;
-  runs.set(handle, { snapshot: persistSnapshot(result.snapshot), interaction });
+  runs.set(handle, { snapshot: result.persistedSnapshot, interaction });
 
   return {
     status: "pending",

--- a/examples/next-host/app/api/agent/[id]/resume/route.ts
+++ b/examples/next-host/app/api/agent/[id]/resume/route.ts
@@ -8,7 +8,7 @@
  * async in the App Router as of Next 15. This example is typed against the real
  * `next` package, so that is enforced rather than assumed.
  */
-import { persistSnapshot, runAgent } from "@statelyai/agent";
+import { runAgent } from "@statelyai/agent";
 import { NextResponse, type NextRequest } from "next/server";
 import { announceMachine, snapshots } from "../../route";
 import { resolveExecutors, maybeCreateRunInspection } from "../../../../../agent-runtime";
@@ -39,7 +39,7 @@ export async function POST(
     // A REJECT loops back through `drafting` and settles at `reviewing` again,
     // so the stored snapshot has to be replaced or the next resume would run
     // against the pre-rejection draft.
-    snapshots.set(id, persistSnapshot(result.snapshot));
+    snapshots.set(id, result.persistedSnapshot);
     return NextResponse.json(
       { status: "idle", id, draft: result.snapshot.context.draft },
       { status: 202 },

--- a/examples/next-host/app/api/agent/route.ts
+++ b/examples/next-host/app/api/agent/route.ts
@@ -20,13 +20,7 @@
  * DB row, a KV namespace — keyed by run id. See ../file-snapshot-store.
  */
 import { z } from "zod";
-import {
-  getAcceptedEvents,
-  getStateMeta,
-  persistSnapshot,
-  runAgent,
-  setupAgent,
-} from "@statelyai/agent";
+import { getAcceptedEvents, getStateMeta, runAgent, setupAgent } from "@statelyai/agent";
 import type { Snapshot } from "xstate";
 import { NextResponse, type NextRequest } from "next/server";
 import { models, resolveExecutors, maybeCreateRunInspection } from "../../../agent-runtime";
@@ -42,7 +36,7 @@ const agentSetup = setupAgent({
   output: z.object({ published: z.boolean(), draft: z.string() }),
   meta: z.object({ interaction: z.object({ label: z.string() }).optional() }),
   events: { APPROVE: z.object({}), REJECT: z.object({ reason: z.string() }) },
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-review"),
   requests: {
     writeDraft: {
       schemas: { input: z.object({ topic: z.string() }), output: z.string() },
@@ -102,7 +96,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   if (result.status === "idle") {
     const id = crypto.randomUUID();
-    snapshots.set(id, persistSnapshot(result.snapshot));
+    snapshots.set(id, result.persistedSnapshot);
     const { interaction } = getStateMeta(result.snapshot);
     return NextResponse.json(
       {

--- a/examples/plain-xstate/index.ts
+++ b/examples/plain-xstate/index.ts
@@ -185,7 +185,7 @@ export const plainWriterMachine = setup({
     // Nothing here knows the events will be chosen by a model.
     judging: {
       // Plain XState tags mark the human-wait state; hosts that want
-      // deterministic idle pass runAgent({ isSuspended: (s) => s.hasTag("waiting") }).
+      // deterministic idle pass runAgent({ isIdle: (s) => s.hasTag("waiting") }).
       tags: ["waiting"],
       on: {
         APPROVE: { target: "approved" },
@@ -271,7 +271,7 @@ export async function runPlainXstateExample(
         events,
         attempts: [],
       },
-      decide,
+      { decide },
       // The guard, not the model, is the source of truth: a REVISE past the
       // budget is rejected here and the decision retries (converging to APPROVE).
       { canTake: (event) => snapshot.can(event) },

--- a/examples/react-agent/index.ts
+++ b/examples/react-agent/index.ts
@@ -3,7 +3,7 @@
  *
  * This is the escalation, not the default. For plain tool use, keep the loop
  * inside one request and let your SDK run it — that's examples/tool-calling
- * (one state, `tools` on the request, `metadata.maxSteps` bounding the loop).
+ * (one state, `tools` on the request, `maxSteps` bounding the loop).
  * Unroll to this shape when individual turns need what a state gives you: an
  * approval gate before a dangerous tool, a spend guard, a snapshot you can
  * persist and resume mid-loop.

--- a/examples/retrofit/README.md
+++ b/examples/retrofit/README.md
@@ -25,15 +25,15 @@ Each step compiles, runs, and preserves the observable behavior.
 
 ## Your code → where it went
 
-| In `before.ts` (the loop)           | In the machine                           |
-| ----------------------------------- | ---------------------------------------- |
-| `while (true)`                      | `runAgent` owns the loop                 |
-| `phase` string + boolean flags      | explicit states                          |
-| nested `if/else` tool dispatch      | `agent.decide` + typed events            |
-| `if (amount > 100)` refund limit    | a guard on the REFUND transition         |
-| retry/backoff wrapper               | a custom `generateText` executor         |
-| `{ pending }` sentinel + `resume()` | an idle state + `persistSnapshot`/resume |
-| duplicated transcript bookkeeping   | context, written once per transition     |
+| In `before.ts` (the loop)           | In the machine                             |
+| ----------------------------------- | ------------------------------------------ |
+| `while (true)`                      | `runAgent` owns the loop                   |
+| `phase` string + boolean flags      | explicit states                            |
+| nested `if/else` tool dispatch      | `agent.decide` + typed events              |
+| `if (amount > 100)` refund limit    | a guard on the REFUND transition           |
+| retry/backoff wrapper               | a custom `generateText` executor           |
+| `{ pending }` sentinel + `resume()` | an idle state + `persistedSnapshot`/resume |
+| duplicated transcript bookkeeping   | context, written once per transition       |
 
 ## Run
 

--- a/examples/retrofit/index.test.ts
+++ b/examples/retrofit/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import {
-  assertAgentMachine,
+  lintAgentMachine,
   simulateAgent,
   type AgentRequestExecutors,
   type ChosenEvent,
@@ -12,7 +12,7 @@ const TRIAGE = { category: "refund", sentiment: "neutral", summary: "Damaged ite
 // ─── (a) the final machine is structurally sound ───
 
 test("final machine lints clean", () => {
-  assertAgentMachine(supportMachine);
+  lintAgentMachine(supportMachine, { throw: true });
 });
 
 // ─── (b) simulateAgent proves the refactor preserved before.ts behavior ───

--- a/examples/retrofit/index.ts
+++ b/examples/retrofit/index.ts
@@ -22,7 +22,6 @@ import {
   createAgentSchemas,
   getAcceptedEvents,
   getStateMeta,
-  persistSnapshot,
   runAgent,
   setupAgent,
   type AgentRequestExecutors,
@@ -98,7 +97,7 @@ const agentSetup = setupAgent({
   models,
   // The machine's own wait signal — `runAgent` settles idle whenever a resting
   // snapshot carries this tag (the `{ pending }` sentinel, now first-class).
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-approval"),
   actors: {
     // The `lookupOrder` tool, now a typed actor. Reads the sample table.
     lookupOrder: createAsyncLogic<string, { orderId: string }>({
@@ -332,7 +331,7 @@ export async function runRetrofitExample(
     ? ({ type: "APPROVE" } as const)
     : ({ type: "DENY", reason: denyReason } as const);
   const second = await runAgent(supportMachine, {
-    snapshot: persistSnapshot(first.snapshot),
+    snapshot: first.persistedSnapshot,
     event,
     executors,
     onTransition: track,

--- a/examples/retrofit/step3.ts
+++ b/examples/retrofit/step3.ts
@@ -2,7 +2,7 @@
  * STEP 3 — the `{ pending }` sentinel becomes an idle state.
  *
  * Moved: `needsApproval` (a final state whose output the runner reshaped) becomes
- * a real idle `awaitingApproval` state — no invoke, an `isSuspended` tag, and
+ * a real idle `awaitingApproval` state — no invoke, an `isIdle` tag, and
  * APPROVE/DENY handlers. `runAgent` now settles `{ status: 'idle', snapshot }`
  * there; the runner persists that snapshot (plain JSON) and resumes with an event
  * in a second `runAgent` call. No closure, no lost state, resumable across
@@ -14,7 +14,6 @@ import { openai } from "@ai-sdk/openai";
 import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
 import {
   createAgentSchemas,
-  persistSnapshot,
   runAgent,
   setupAgent,
   type AgentRequestExecutors,
@@ -49,7 +48,7 @@ const schemas = createAgentSchemas({
 const agentSetup = setupAgent({
   schemas,
   models,
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-approval"),
   states: { awaitingApproval: { context: { pendingRefund: z.number() } } },
 });
 
@@ -168,7 +167,7 @@ export async function runSupportStep3(
   if (first.status !== "idle") throw new Error(`unexpected status ${first.status}`);
 
   const second = await runAgent(supportMachineStep3, {
-    snapshot: persistSnapshot(first.snapshot),
+    snapshot: first.persistedSnapshot,
     event: approve ? { type: "APPROVE" } : { type: "DENY", reason: "Outside policy." },
     executors,
   });

--- a/examples/review-tool-calls/index.ts
+++ b/examples/review-tool-calls/index.ts
@@ -43,7 +43,6 @@ import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
 import {
   getAcceptedEvents,
   getStateMeta,
-  persistSnapshot,
   runAgent,
   setupAgent,
   type AgentRequestExecutors,
@@ -115,7 +114,7 @@ const agentSetup = setupAgent({
   },
   // The machine's own wait signal: the `awaiting-review` tag. `runAgent` settles
   // idle deterministically whenever a resting snapshot carries it.
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-review"),
   actors: {
     // The consequential tool: applies the approved/edited refund. A real host
     // would call a payments API here; this fake records it and returns a receipt.
@@ -302,7 +301,7 @@ export async function runReviewToolCallsExample(
     const event = events[i] ?? events[events.length - 1];
     i++;
     result = await runAgent(reviewToolCallsMachine, {
-      snapshot: persistSnapshot(result.snapshot),
+      snapshot: result.persistedSnapshot,
       event,
       ...executors,
       onTransition: track,
@@ -356,7 +355,7 @@ if (import.meta.url === new URL(process.argv[1]!, "file:").href) {
       console.log(interaction?.label ?? "");
       console.log("Legal events:", legalEvents.join(", "));
 
-      const persisted = persistSnapshot(snapshot);
+      const persisted = result.persistedSnapshot;
       const answer = (await promptLine("approve / edit / reject? ")).toLowerCase();
 
       let event:

--- a/examples/session-actor/index.ts
+++ b/examples/session-actor/index.ts
@@ -66,7 +66,7 @@ const sessionQuizSetup = setupAgent({
     QUIT: {},
   },
   // Deterministic idle detection: settle exactly when the machine is waiting.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
   requests: {
     gradeAnswer: {
       schemas: {

--- a/examples/sql-agent/index.ts
+++ b/examples/sql-agent/index.ts
@@ -22,13 +22,7 @@
 import { z } from "zod";
 import { openai } from "@ai-sdk/openai";
 import { createAsyncLogic, type SnapshotFrom } from "xstate";
-import {
-  getStateMeta,
-  persistSnapshot,
-  runAgent,
-  setupAgent,
-  type RunAgentOptions,
-} from "@statelyai/agent";
+import { getStateMeta, runAgent, setupAgent, type RunAgentOptions } from "@statelyai/agent";
 import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
 
 // ─── In-memory sample table (the whole "database") ───
@@ -109,7 +103,7 @@ const agentSetup = setupAgent({
   },
   // The machine's own wait signal: the `awaiting-approval` tag. `runAgent`
   // settles idle deterministically whenever a resting snapshot carries it.
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-approval"),
   actors: {
     runQuery: createAsyncLogic<number, { plan: QueryPlan }>({
       run: async ({ input }) => executeQuery(input.plan),
@@ -269,7 +263,7 @@ export async function runSqlAgentExample(
   const interaction = readInteraction(first.snapshot);
 
   const second = await runAgent(sqlAgentMachine, {
-    snapshot: persistSnapshot(first.snapshot),
+    snapshot: first.persistedSnapshot,
     event: { type: approval },
     onTransition: observe,
     ...resolved,

--- a/examples/suspension.test.ts
+++ b/examples/suspension.test.ts
@@ -7,7 +7,7 @@
  * has to decide the run is idle; without a declared predicate it falls back to
  * a timing heuristic and logs a warning. The fix is one line on `setupAgent`:
  *
- *     isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval")
+ *     isIdle: (snapshot) => snapshot.hasTag("awaiting-approval")
  *
  * plus the matching `tags: [...]` on the waiting state. This test fails when a
  * new example forgets it.
@@ -17,7 +17,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import type { AnyStateMachine, StateNode } from "xstate";
-import { getMachineSuspensionPredicate } from "../src/internal/registry.js";
+import { getMachineIdlePredicate } from "../src/internal/registry.js";
 
 const examplesDir = fileURLToPath(new URL(".", import.meta.url));
 
@@ -88,7 +88,7 @@ describe("example suspension predicates", () => {
         if (!isMachine(value)) continue;
         const key = `${id}#${exportName}`;
         if (!humanWaitStates(value).length || key in EXCLUDED) continue;
-        (getMachineSuspensionPredicate(value) ? declared : undeclared).push(key);
+        (getMachineIdlePredicate(value) ? declared : undeclared).push(key);
       }
     }
 
@@ -110,7 +110,7 @@ describe("example suspension predicates", () => {
       // Still a human-waiting machine, still undeclared — drop the exclusion
       // once either stops being true.
       expect(humanWaitStates(machine as AnyStateMachine).length).toBeGreaterThan(0);
-      expect(getMachineSuspensionPredicate(machine as AnyStateMachine)).toBeUndefined();
+      expect(getMachineIdlePredicate(machine as AnyStateMachine)).toBeUndefined();
     }
   }, 60_000);
 });

--- a/examples/swarm-handoff/index.ts
+++ b/examples/swarm-handoff/index.ts
@@ -16,14 +16,9 @@
  * Run: OPENAI_API_KEY=... npx tsx examples/swarm-handoff/index.ts
  */
 import { z } from "zod";
+import type { Snapshot as PersistedSnapshot } from "xstate";
 import { openai } from "@ai-sdk/openai";
-import {
-  persistSnapshot,
-  runAgent,
-  setupAgent,
-  type RunAgentOptions,
-  type RunAgentResult,
-} from "@statelyai/agent";
+import { runAgent, setupAgent, type RunAgentOptions, type RunAgentResult } from "@statelyai/agent";
 import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
 
 const agentName = z.enum(["travel", "food"]);
@@ -74,7 +69,7 @@ const agentSetup = setupAgent({
   },
   // The machine's own wait signal: the `waiting` tag. `runAgent` settles idle
   // deterministically at the turn boundary whenever a snapshot carries it.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
   requests: {
     travelReply: {
       schemas: {
@@ -179,7 +174,7 @@ export async function runSwarmHandoffExample(
 
   // Persist the snapshot (host's choice of store) — JSON round-trip it to
   // prove `activeAgent` survives a real persistence layer.
-  const persisted = persistSnapshot(first.snapshot);
+  const persisted = first.persistedSnapshot;
 
   // ...later, new process: hand off to the food agent for the next turn.
   const second = await runAgent(swarmHandoffMachine, {
@@ -222,10 +217,10 @@ async function runInteractive() {
 
   // Turn 1 seeds the conversation from a fresh run; later turns resume the
   // persisted snapshot with a HANDOFF event.
-  type Snapshot = ReturnType<typeof swarmHandoffMachine.resolveState>;
-  let snapshot: Snapshot | null = null;
+  type LiveSnapshot = ReturnType<typeof swarmHandoffMachine.resolveState>;
+  let snapshot: PersistedSnapshot<unknown> | null = null;
 
-  const onTransition = (snap: Snapshot) => {
+  const onTransition = (snap: LiveSnapshot) => {
     // Surface the turn's routing (which agent's turn state runs).
     if (snap.value === "travelTurn" || snap.value === "foodTurn") {
       console.log(`  [state] ${snap.value}`);
@@ -275,7 +270,7 @@ async function runInteractive() {
         break;
       }
       active = result.snapshot.context.activeAgent;
-      snapshot = persistSnapshot(result.snapshot);
+      snapshot = result.persistedSnapshot;
       console.log(`[${active}] ${result.snapshot.context.reply ?? ""}\n`);
     }
   });

--- a/examples/tanstack-start-host/index.test.ts
+++ b/examples/tanstack-start-host/index.test.ts
@@ -9,7 +9,7 @@
  * The HTTP half is covered by booting the app (`pnpm --dir examples/tanstack-start-host dev`).
  */
 import { describe, expect, it } from "vitest";
-import { createScriptedExecutors, persistSnapshot, runAgent } from "@statelyai/agent";
+import { createScriptedExecutors, runAgent } from "@statelyai/agent";
 import { announceEventSchema, announceMachine } from "./index.js";
 
 const drafts = (...texts: string[]) => createScriptedExecutors({ text: texts });
@@ -50,7 +50,7 @@ describe("announceMachine", () => {
     if (idle.status !== "idle") return;
 
     const done = await runAgent(announceMachine, {
-      snapshot: persistSnapshot(idle.snapshot),
+      snapshot: idle.persistedSnapshot,
       event: { type: "APPROVE" },
       executors: drafts(),
     });
@@ -69,7 +69,7 @@ describe("announceMachine", () => {
 
     let seenPrompt = "";
     const rejected = await runAgent(announceMachine, {
-      snapshot: persistSnapshot(idle.snapshot),
+      snapshot: idle.persistedSnapshot,
       event: { type: "REJECT", reason: "name the speedup" },
       executors: createScriptedExecutors({
         text: [

--- a/examples/tanstack-start-host/index.ts
+++ b/examples/tanstack-start-host/index.ts
@@ -22,7 +22,6 @@ import {
   createScriptedExecutors,
   getAcceptedEvents,
   getStateMeta,
-  persistSnapshot,
   runAgent,
   setupAgent,
   type AgentRequestExecutors,
@@ -70,7 +69,7 @@ const agentSetup = setupAgent({
   output: z.object({ published: z.boolean(), draft: z.string() }),
   meta: z.object({ interaction: z.object({ label: z.string() }).optional() }),
   events: eventSchemas,
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-review"),
   requests: {
     writeDraft: {
       schemas: { input: z.object({ topic: z.string() }), output: z.string() },
@@ -164,7 +163,7 @@ type Settled =
  */
 function settle(result: Awaited<ReturnType<typeof runAgent<typeof announceMachine>>>, id: string) {
   if (result.status === "idle") {
-    snapshots.set(id, persistSnapshot(result.snapshot));
+    snapshots.set(id, result.persistedSnapshot);
     const { interaction } = getStateMeta(result.snapshot);
     return {
       id,

--- a/examples/time-travel/index.ts
+++ b/examples/time-travel/index.ts
@@ -5,8 +5,8 @@
  * LangGraph exposes `graph.get_state_history(config)` (a list of checkpoints) and
  * lets you resume from any past checkpoint's `config` to rewind and fork an
  * alternative branch. Here the equivalent is dead simple: every `runAgent` settle
- * (`idle` or `done`) hands back a `snapshot`, and `persistSnapshot(...)` is a plain
- * JSON round-trip. Keep those persisted snapshots in a list and you have the
+ * (`idle` or `done`) hands back a `snapshot`, and `machine.getPersistedSnapshot(...)`
+ * turns it into plain JSON. Keep those persisted snapshots in a list and you have the
  * history; feed any one of them back into a fresh `runAgent` and you have a rewind.
  *
  * Because a persisted snapshot is immutable JSON, resuming from the SAME
@@ -37,13 +37,8 @@
 import { z } from "zod";
 import { openai } from "@ai-sdk/openai";
 import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
-import {
-  persistSnapshot,
-  runAgent,
-  setupAgent,
-  type AgentRequestExecutors,
-} from "@statelyai/agent";
-import type { SnapshotFrom } from "xstate";
+import { runAgent, setupAgent, type AgentRequestExecutors } from "@statelyai/agent";
+import type { Snapshot, SnapshotFrom } from "xstate";
 
 export const models = defineModels({
   writer: openai("gpt-5.4-mini"),
@@ -92,7 +87,7 @@ const agentSetup = setupAgent({
   },
   // The machine's own wait signal: `runAgent` settles idle deterministically
   // whenever a resting snapshot carries this tag (see human-in-the-loop.md).
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-review"),
   requests: {
     writeDraft: {
       schemas: {
@@ -179,11 +174,11 @@ export const timeTravelMachine = agentSetup.createMachine({
 // ─── In-example checkpoint history (NOT a library API) ───
 //
 // A list of `{ label, snapshot }`, one per settle. Each snapshot is captured via
-// `persistSnapshot` (a JSON round-trip), so entries are immutable and independent
+// `machine.getPersistedSnapshot(...)` (plain JSON), so entries are immutable and independent
 // of the live run — the same guarantee a real persistence layer gives you.
 export interface Checkpoint {
   label: string;
-  snapshot: SnapshotFrom<typeof timeTravelMachine>;
+  snapshot: Snapshot<unknown>;
 }
 
 export class CheckpointHistory {
@@ -191,7 +186,7 @@ export class CheckpointHistory {
 
   /** Capture a settle's snapshot as an immutable, persisted checkpoint. */
   record(label: string, snapshot: SnapshotFrom<typeof timeTravelMachine>): void {
-    this.entries.push({ label, snapshot: persistSnapshot(snapshot) });
+    this.entries.push({ label, snapshot: timeTravelMachine.getPersistedSnapshot(snapshot) });
   }
 
   /** The checkpoint at `index` — the point you rewind/fork from. */
@@ -254,7 +249,7 @@ export async function runTimeTravelExample(
 
   // 2. Resume with REVISE, redraft, settle idle again. Checkpoint the revised draft.
   const second = await runAgent(timeTravelMachine, {
-    snapshot: persistSnapshot(first.snapshot),
+    snapshot: first.persistedSnapshot,
     event: { type: "REVISE", feedback },
     ...executors,
   });
@@ -263,7 +258,7 @@ export async function runTimeTravelExample(
 
   // 3. Approve the revised draft → the MAIN branch's final answer.
   const mainDone = await runAgent(timeTravelMachine, {
-    snapshot: persistSnapshot(second.snapshot),
+    snapshot: second.persistedSnapshot,
     event: { type: "APPROVE" },
     ...executors,
   });
@@ -275,7 +270,7 @@ export async function runTimeTravelExample(
   //    above is untouched — this is a new lineage that approves the ORIGINAL draft.
   const rewindTo = history.at(0);
   const forkedDone = await runAgent(timeTravelMachine, {
-    snapshot: persistSnapshot(rewindTo.snapshot),
+    snapshot: rewindTo.snapshot,
     event: { type: "APPROVE" },
     ...executors,
   });

--- a/examples/todo-nl/index.ts
+++ b/examples/todo-nl/index.ts
@@ -16,7 +16,7 @@
  *     `textEvent: "COMMAND"`, so a host routes free chat text into the machine
  *     and resumes with `runAgent(machine, { snapshot: persistedSnapshot,
  *     event })`. Nothing needs to answer a prompt callback. The state is
- *     tagged `waiting` and `setupAgent({ isSuspended })` reads that tag, so
+ *     tagged `waiting` and `setupAgent({ isIdle })` reads that tag, so
  *     idle detection is deterministic rather than heuristic.
  *   - Context-interpolated prompts: the label is
  *     "What should I do with your list? ({todosSummary})", and `{todosSummary}`
@@ -153,7 +153,7 @@ const agentSetup = setupAgent({
   models,
   // Deterministic idle detection: the only state that waits on a human is
   // tagged `waiting`, so hosts never rely on the timing heuristic.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
 });
 
 export const todoMachine = agentSetup.createMachine({

--- a/examples/tool-calling/index.test.ts
+++ b/examples/tool-calling/index.test.ts
@@ -66,12 +66,12 @@ test("sample-data rate lookup reads the fixed table", async () => {
   expect(result.validated).toBe(true);
 });
 
-test("the request carries maxSteps metadata for the host tool loop", async () => {
+test("the request carries a typed maxSteps for the host tool loop", async () => {
   let seenMaxSteps: unknown;
   const result = await runToolCallingExample({
     query: "What is 1 plus 1?",
     generateText: async (request) => {
-      seenMaxSteps = request.metadata?.maxSteps;
+      seenMaxSteps = request.maxSteps;
       const sum = (await executeTool(request.tools?.calculate, {
         operation: "add",
         a: 1,

--- a/examples/tool-calling/index.ts
+++ b/examples/tool-calling/index.ts
@@ -11,7 +11,7 @@
  *
  * One text request carries `tools` (a calculator, a unit converter, and a
  * sample-data currency lookup) and the host runs the tool loop — the AI SDK
- * adapter reads `metadata.maxSteps` to bound it. Selecting and executing tools
+ * adapter reads the request's typed `maxSteps` to bound it. Selecting and executing tools
  * is the model + host's business, not explicit workflow steps.
  *
  * What the MACHINE owns is the contract on the way out. The request returns a
@@ -31,7 +31,7 @@
  *     denied by the tools themselves (divide by zero, unknown currency pair).
  *   - A typed output contract the machine enforces, with a bounded retry that
  *     feeds the validation message back to the model.
- *   - `metadata.maxSteps` bounding the host-side tool loop (adapter behavior).
+ *   - `maxSteps` bounding the host-side tool loop (adapter behavior).
  *   - Progress and the validation trail surfaced host-side via `onTransition`.
  *
  * Want the tool loop as visible, persistable machine states instead (each
@@ -160,7 +160,7 @@ const agentSetup = setupAgent({
         }),
       },
       // Bound the host-side tool loop (the AI SDK adapter reads this).
-      metadata: { maxSteps: 5 },
+      maxSteps: 5,
     },
   },
 });

--- a/examples/triage/index.test.ts
+++ b/examples/triage/index.test.ts
@@ -65,7 +65,7 @@ describe("ticket-triage", () => {
       executors: { generateText },
     });
 
-    // The `waiting` tag + isSuspended settles this deterministically.
+    // The `waiting` tag + isIdle settles this deterministically.
     expect(first.status).toBe("idle");
     if (first.status !== "idle") throw new Error("expected idle");
     expect(first.snapshot.value).toBe("escalating");

--- a/examples/triage/index.ts
+++ b/examples/triage/index.ts
@@ -14,7 +14,7 @@
  *     threshold the run does NOT reply on its own — it settles idle in
  *     `escalating` and waits for a person to confirm the category or type the
  *     right one. `meta.interaction` tells a host how to render that, and the
- *     `waiting` tag plus `isSuspended` make the idle settle deterministic.
+ *     `waiting` tag plus `isIdle` make the idle settle deterministic.
  *   - One retry on reply generation. A failed draft is not an exception: it
  *     routes through `replyFailed`, retries once, then degrades to a `failed`
  *     outcome carrying a fallback reply rather than throwing.
@@ -119,7 +119,7 @@ const triageAgentSetup = setupAgent({
   models,
   // Deterministic idle detection: the run settles whenever a person owes it a
   // decision, instead of falling back to the timing heuristic.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
   requests: {
     classifyTicket: {
       schemas: {

--- a/examples/twenty-questions/index.ts
+++ b/examples/twenty-questions/index.ts
@@ -153,7 +153,7 @@ const agentSetup = setupAgent({
   // Deterministic idle detection: the states waiting on the player are exactly
   // the ones tagged `waiting`, so runAgent does not fall back to its timing
   // heuristic.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
   requests: {
     classifyAnswer: {
       schemas: {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,16 @@
         "default": "./dist/otel.cjs"
       }
     },
+    "./validate": {
+      "import": {
+        "types": "./dist/validate.d.mts",
+        "default": "./dist/validate.mjs"
+      },
+      "require": {
+        "types": "./dist/validate.d.cts",
+        "default": "./dist/validate.cjs"
+      }
+    },
     "./sqlite": {
       "import": {
         "types": "./dist/sqlite.d.mts",
@@ -151,6 +161,7 @@
   "peerDependencies": {
     "@opentelemetry/api": "^1",
     "ai": "^6.0.67",
+    "ajv": "^8.20.0",
     "xstate": ">=6.0.0-alpha.25 <6.0.0"
   },
   "peerDependenciesMeta": {
@@ -158,6 +169,9 @@
       "optional": true
     },
     "ai": {
+      "optional": true
+    },
+    "ajv": {
       "optional": true
     }
   },

--- a/schemas/agent-workflow.json
+++ b/schemas/agent-workflow.json
@@ -71,8 +71,8 @@
         "$ref": "#/$defs/State"
       }
     },
-    "suspendedTags": {
-      "description": "State tags that mark an intentional wait for an external event (a human approval, an inbound webhook, ...). Lowered by setupAgent.fromConfig(...) into a snapshot.hasTag(...) suspension predicate so runAgent settles those states idle deterministically. Every listed tag must appear in some state's 'tags'.",
+    "idleTags": {
+      "description": "State tags that mark an intentional wait for an external event (a human approval, an inbound webhook, ...). Lowered by setupAgent.fromConfig(...) into a snapshot.hasTag(...) idle predicate so runAgent settles those states idle deterministically. Every listed tag must appear in some state's 'tags'.",
       "type": "array",
       "items": {
         "type": "string",

--- a/skills/generate-machine/SKILL.md
+++ b/skills/generate-machine/SKILL.md
@@ -8,7 +8,7 @@ description: Author a @statelyai/agent workflow as JSON and check it before it r
 An agent machine is data. You author a JSON `AgentWorkflowConfig`, then run it through gates that all work with no API key: Ajv → `fromConfig` → lint → simulate. Do not hand back a config that has not passed all four.
 
 ```
-author → validate (Ajv 2020) → lower (fromConfig) → lint (assertAgentMachine) → simulate → hand back
+author → validate (validateAgentConfig) → lower (fromConfig) → lint (lintAgentMachine) → simulate → hand back
 ```
 
 ## 1. Read the schema
@@ -132,28 +132,26 @@ Reference config — decision, text request, idle human step, one final state:
 }
 ```
 
-## 3. Validate with Ajv 2020
+## 3. Validate with `validateAgentConfig`
 
-The workflow schema is draft 2020-12, so it needs Ajv's 2020 build. Run this before anything else touches the config.
+`validateAgentConfig` from `@statelyai/agent/validate` checks a candidate against the shipped workflow schema with Ajv 2020 built in. It needs `ajv` installed (an optional peer of the package). Run it before anything else touches the config.
 
 ```ts
-import Ajv2020 from "ajv/dist/2020.js";
-import workflowSchema from "@statelyai/agent/agent-workflow.json";
+import { validateAgentConfig } from "@statelyai/agent/validate";
 import type { AgentWorkflowConfig } from "@statelyai/agent";
 
-const validateWorkflow = new Ajv2020({ strict: false }).compile(workflowSchema);
-
 function validateGeneratedConfig(candidate: unknown): AgentWorkflowConfig {
-  if (validateWorkflow(candidate)) return candidate as AgentWorkflowConfig;
+  const result = validateAgentConfig(candidate);
+  if (result.valid) return candidate as AgentWorkflowConfig;
   throw new Error(
-    (validateWorkflow.errors ?? [])
-      .map((error) => `${error.instancePath || "(root)"} ${error.message}`)
+    result.errors
+      .map((error) => `${error.path || "(root)"} ${error.message}`)
       .join("\n"),
   );
 }
 ```
 
-Ajv errors carry `instancePath`, so a repair prompt can name the exact bad field.
+Each error carries a JSON Pointer `path`, so a repair prompt can name the exact bad field.
 
 ## 4. Lower with `fromConfig`
 
@@ -193,10 +191,10 @@ Lowering is itself a gate: it throws on an unresolved named guard/action and on 
 ## 5. Lint
 
 ```ts
-import { assertAgentMachine, lintAgentMachine } from "@statelyai/agent";
+import { lintAgentMachine } from "@statelyai/agent";
 
 const diagnostics = lintAgentMachine(machine);
-assertAgentMachine(machine); // throws AgentLintError on error-severity findings
+lintAgentMachine(machine, { throw: true }); // throws AgentLintError on error-severity findings
 ```
 
 Every check applies to config-built machines, reachability included — the lowering keeps the config's transition targets, so `unreachable-state` and `missing-final` read the real graph. Do not disable checks.
@@ -224,7 +222,7 @@ Derive the script from the config rather than guessing: take the first entry of 
 
 - `'exhausted'` → the machine loops. Reject it.
 - `'idle'` → it stopped at a human step. Expected when the config has one.
-- To cover every branch instead of one path, use `explorePaths` / `canReach`.
+- To cover every branch instead of one path, use `explorePaths` / `canReach` (its result is `{ reachable, witness }`).
 
 ## 7. Repair loop
 

--- a/src/agent-usage-event.test.ts
+++ b/src/agent-usage-event.test.ts
@@ -339,7 +339,7 @@ describe("@agent.usage (reserved per-call usage event)", () => {
     });
   });
 
-  test("a wildcard-only machine never receives it: an `on: { '*' }` handler is not an opt-in", async () => {
+  test("a wildcard-only machine DOES receive it: `on: { '*' }` matches, per plain XState semantics", async () => {
     const wildcardSchemas = createAgentSchemas({
       context: z.object({ note: z.string(), wildcards: z.array(z.string()) }),
       output: z.object({ note: z.string(), wildcards: z.array(z.string()) }),
@@ -376,9 +376,9 @@ describe("@agent.usage (reserved per-call usage event)", () => {
     });
 
     expect(result.status).toBe("done");
-    expect(seen).not.toContain(AGENT_USAGE_EVENT_TYPE);
-    expect(usageEntries(result.events)).toHaveLength(0);
-    expect(result.snapshot.context.wildcards).not.toContain(AGENT_USAGE_EVENT_TYPE);
+    expect(seen).toContain(AGENT_USAGE_EVENT_TYPE);
+    expect(usageEntries(result.events)).toHaveLength(1);
+    expect(result.snapshot.context.wildcards).toContain(AGENT_USAGE_EVENT_TYPE);
   });
 
   test("a machine declaring BOTH a wildcard and an explicit handler still receives it", async () => {

--- a/src/ai-sdk/index.test.ts
+++ b/src/ai-sdk/index.test.ts
@@ -483,7 +483,7 @@ describe("onResult metadata enrichment", () => {
   });
 });
 
-describe("metadata.maxSteps (multi-step tool loops)", () => {
+describe("maxSteps (multi-step tool loops)", () => {
   const streamUsage = {
     inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
     outputTokens: { total: 1, text: 1, reasoning: 0 },
@@ -513,7 +513,7 @@ describe("metadata.maxSteps (multi-step tool loops)", () => {
     },
   };
 
-  test("streamText honors metadata.maxSteps (loops the tool call, matching generateText)", async () => {
+  test("streamText honors the typed maxSteps (loops the tool call, matching generateText)", async () => {
     let calls = 0;
     const model = new MockLanguageModelV3({
       doStream: async () => {
@@ -530,7 +530,7 @@ describe("metadata.maxSteps (multi-step tool loops)", () => {
     const result = await streamText({
       model: "m",
       prompt: "hi",
-      metadata: { maxSteps: 5 },
+      maxSteps: 5,
       tools: pingTool,
     });
 
@@ -752,7 +752,7 @@ describe("metadata.maxSteps (multi-step tool loops)", () => {
     expect(JSON.stringify(sentResponseFormat)).not.toContain("reasoning");
   });
 
-  test("generateText honors metadata.maxSteps (symmetry check)", async () => {
+  test("generateText honors the typed maxSteps (symmetry check)", async () => {
     let calls = 0;
     const model = new MockLanguageModelV3({
       doGenerate: async () => {
@@ -790,7 +790,59 @@ describe("metadata.maxSteps (multi-step tool loops)", () => {
     const result = await generateText({
       model: "m",
       prompt: "hi",
+      maxSteps: 5,
+      tools: pingTool,
+    });
+
+    expect(calls).toBe(3);
+    expect(result.output).toBe("done");
+  });
+
+  test("metadata.maxSteps still works as a fallback for pre-typed-field requests", async () => {
+    let calls = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        calls++;
+        return {
+          stream: simulateReadableStream({
+            chunks: calls < 2 ? toolCallStreamChunks(`call-${calls}`) : finalTextStreamChunks,
+          }),
+        };
+      },
+    });
+    const { streamText } = createAiSdkExecutors({ models: { m: model } });
+
+    const result = await streamText({
+      model: "m",
+      prompt: "hi",
       metadata: { maxSteps: 5 },
+      tools: pingTool,
+    });
+
+    expect(calls).toBe(2);
+    expect(result.output).toBe("done");
+  });
+
+  test("the typed maxSteps wins over metadata.maxSteps", async () => {
+    let calls = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        calls++;
+        return {
+          stream: simulateReadableStream({
+            chunks: calls < 3 ? toolCallStreamChunks(`call-${calls}`) : finalTextStreamChunks,
+          }),
+        };
+      },
+    });
+    const { streamText } = createAiSdkExecutors({ models: { m: model } });
+
+    // The typed field allows the loop; the stale metadata value (1) is ignored.
+    const result = await streamText({
+      model: "m",
+      prompt: "hi",
+      maxSteps: 5,
+      metadata: { maxSteps: 1 },
       tools: pingTool,
     });
 

--- a/src/ai-sdk/index.ts
+++ b/src/ai-sdk/index.ts
@@ -30,14 +30,14 @@ import {
   toDecisionMessages,
 } from "./mappers.js";
 
-// Multi-step tool loops: `metadata` is the host-owned per-call channel (see
-// AgentTextRequest.metadata). `metadata.maxSteps` bounds the AI SDK tool-call
-// loop for a request; default stays single-step. Shared by generateText and
-// streamText so both honor it symmetrically.
+// Multi-step tool loops: the request's typed `maxSteps` bounds the AI SDK
+// tool-call loop; default stays single-step. `metadata.maxSteps` is still read
+// as a fallback for requests written before `maxSteps` was a typed field.
+// Shared by generateText and streamText so both honor it symmetrically.
 function maxStepsSetting(request: AgentTextRequest): { stopWhen?: ReturnType<typeof stepCountIs> } {
-  return typeof request.metadata?.maxSteps === "number"
-    ? { stopWhen: stepCountIs(request.metadata.maxSteps) }
-    : {};
+  const maxSteps =
+    typeof request.maxSteps === "number" ? request.maxSteps : request.metadata?.maxSteps;
+  return typeof maxSteps === "number" ? { stopWhen: stepCountIs(maxSteps) } : {};
 }
 
 // ─── createAiSdkExecutors ───

--- a/src/decision.ts
+++ b/src/decision.ts
@@ -12,6 +12,8 @@ import {
   DECIDE_ACTOR,
   resolveTextLogicValue,
   type AgentCallUsage,
+  type AgentRequestExecutorInfo,
+  type AgentRequestExecutors,
   type ResolveTextLogicValue,
 } from "./text-logic.js";
 import { isEventPattern, sanitizeEventToolName, type AgentEventDescriptor } from "./events.js";
@@ -109,10 +111,14 @@ function decideActorWithExecutor(
         );
       }
 
-      return resolveDecision(decideRequestFromInput(input), execute, {
-        maxRetries: input.maxRetries ?? 2,
-        signal,
-      });
+      return resolveDecision(
+        decideRequestFromInput(input),
+        { decide: execute },
+        {
+          maxRetries: input.maxRetries ?? 2,
+          signal,
+        },
+      );
     },
   });
 
@@ -304,7 +310,7 @@ export function createDecisionLogic<
         );
       }
 
-      return resolveDecision(request(input), execute, { maxRetries, signal });
+      return resolveDecision(request(input), { decide: execute }, { maxRetries, signal });
     },
   });
 
@@ -450,14 +456,20 @@ export function renderDecisionAttempts(
  * `generateText`/`streamText` — how the model is coerced into choosing
  * (tool-per-event + forced tool choice, structured output, …) is entirely
  * adapter business; core only validates and retries the returned choice (see
- * {@link resolveDecision}). The optional `reason` is carried through to
+ * {@link resolveDecision}). It takes the same `(request, info)` pair as
+ * `generateText`/`streamText` — `info` carries the host seams (`signal`,
+ * `runId`, `requestId`); `onChunk` is never set for a decision.
+ * The optional `reason` is carried through to
  * `onResult`/event-sourcing but never affects validation. Like text
  * executors' `{ output, ...extras }` envelope, any extra keys (finish reason,
  * …) flow untouched to `onResult`'s `raw`; `usage` is the one core reads —
  * report this attempt's tokens there and `runAgent` folds them into the run's
  * aggregated {@link AgentUsage}.
  */
-export type AgentDecisionExecutor = (request: AgentDecisionRequest) => PromiseLike<{
+export type AgentDecisionExecutor = (
+  request: AgentDecisionRequest,
+  info?: AgentRequestExecutorInfo,
+) => PromiseLike<{
   event: ChosenEvent;
   reason?: string;
   /** This attempt's token usage, aggregated into the run result's {@link AgentUsage}. */
@@ -491,7 +503,7 @@ export interface ResolveDecisionOptions<TEvent extends ChosenEvent = ChosenEvent
 
 /**
  * Validation + retry core for decisions. No provider mechanics — the
- * `executor` is responsible for making the model choose an event; this
+ * `executors.decide` is responsible for making the model choose an event; this
  * function only validates the choice and retries on failure, up to
  * `options.maxRetries` (default 2, i.e. up to 3 attempts total).
  *
@@ -509,29 +521,45 @@ export interface ResolveDecisionOptions<TEvent extends ChosenEvent = ChosenEvent
  *
  * @example
  * ```ts
- * const event = await resolveDecision(request, decide, {
+ * const event = await resolveDecision(request, executors, {
  *   canTake: (e) => snapshot.can(e),
  * });
  * ```
  */
 export async function resolveDecision<TEvent extends ChosenEvent = ChosenEvent>(
   request: AgentDecisionRequest,
-  executor: AgentDecisionExecutor,
+  executors: Pick<Partial<AgentRequestExecutors>, "decide">,
   options: ResolveDecisionOptions<TEvent> = {},
 ): Promise<TEvent> {
+  const executor = executors?.decide;
+  if (typeof executor !== "function") {
+    throw new AgentError(
+      "missing-decide-executor",
+      "resolveDecision(request, executors, ...) takes the EXECUTOR SET (the same object " +
+        "executeAgentRequest takes), and this one has no 'decide' function. Build one with " +
+        "createAiSdkExecutors({ models }), or pass { decide }.",
+    );
+  }
   const maxRetries = options.maxRetries ?? 2;
   const attempts: DecisionAttempt[] = [];
   const eventsByType = new Map(request.events.map((event) => [event.type, event]));
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     options.signal?.throwIfAborted();
-    const result = await executor({
-      ...request,
-      attempts: [...attempts],
-      // Thread the run's abort signal onto the request so the executor can
-      // cancel its in-flight model call (adapters read `request.signal`).
-      signal: options.signal,
-    });
+    const result = await executor(
+      {
+        ...request,
+        attempts: [...attempts],
+        // Thread the run's abort signal onto the request so the executor can
+        // cancel its in-flight model call (adapters read `request.signal`).
+        signal: options.signal,
+      },
+      // The same `info` second argument generateText/streamText receive.
+      {
+        ...(options.signal !== undefined ? { signal: options.signal } : {}),
+        ...(request.id ? { requestId: request.id } : {}),
+      },
+    );
 
     // Fail fast (and descriptively) on the common executor mistake of
     // returning a bare event (`{ type: 'SAFE' }`) instead of the required

--- a/src/effects.test.ts
+++ b/src/effects.test.ts
@@ -16,7 +16,6 @@ import {
   initEntry,
   replay,
   AgentReplayDivergenceError,
-  verifyReplay,
   type AgentEffect,
 } from "./effects.js";
 import type { AgentLogEntry } from "./event-log-store.js";
@@ -434,7 +433,9 @@ describe("replay — envelope verification", () => {
       verification: { stateHash: expect.any(String), effectsHash: expect.any(String) },
     });
     const roundTripped = JSON.parse(JSON.stringify(entries)) as AgentLogEntry[];
-    expect(verifyReplay(machine, roundTripped).snapshot.context).toEqual({ count: 1 });
+    expect(replay(machine, roundTripped, { verify: "strict" }).snapshot.context).toEqual({
+      count: 1,
+    });
   });
 
   test("pins strict divergence to the first mismatched entry", () => {
@@ -445,9 +446,11 @@ describe("replay — envelope verification", () => {
       verification: { ...entries[1]!.verification!, stateHash: "deadbeef" },
     };
 
-    expect(() => verifyReplay(machine, entries)).toThrow(AgentReplayDivergenceError);
+    expect(() => replay(machine, entries, { verify: "strict" })).toThrow(
+      AgentReplayDivergenceError,
+    );
     try {
-      verifyReplay(machine, entries);
+      replay(machine, entries, { verify: "strict" });
     } catch (error) {
       expect(error).toMatchObject({ eventId: "evt_00000001", index: 1, kind: "state" });
     }

--- a/src/effects.test.ts
+++ b/src/effects.test.ts
@@ -8,7 +8,12 @@ import {
   type AnyMachineSnapshot,
   type EventObject,
 } from "xstate";
-import { createAgentSchemas, createTextLogic, setupAgent } from "./index.js";
+import {
+  createAgentSchemas,
+  createTextLogic,
+  getMachineStructuralHash,
+  setupAgent,
+} from "./index.js";
 import {
   createReplayEntry,
   diffEventLogs,
@@ -468,5 +473,27 @@ describe("replay — envelope verification", () => {
     expect(diff.stateChanges).toEqual(
       expect.arrayContaining([expect.objectContaining({ path: "/status" })]),
     );
+  });
+});
+
+describe("machine version resolution", () => {
+  const build = (version?: string) =>
+    createMachine({
+      id: "versioned",
+      ...(version !== undefined ? { version } : {}),
+      initial: "a",
+      states: { a: { on: { GO: "b" } }, b: { type: "final" } },
+    } as never);
+
+  test("a declared createMachine({ version }) is the default machineVersion for log entries", () => {
+    const machine = build("7");
+    const init = initEntry(machine);
+    expect(init.machineVersion).toBe("7");
+    expect(createReplayEntry(machine, [init], { type: "GO" }).machineVersion).toBe("7");
+  });
+
+  test("an unversioned machine falls back to the structural hash", () => {
+    const machine = build();
+    expect(initEntry(machine).machineVersion).toBe(getMachineStructuralHash(machine));
   });
 });

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -43,7 +43,7 @@ import {
   type AgentLogVerification,
   type JsonValue,
 } from "./event-log-store.js";
-import { djb2Hex, getMachineStructuralHash } from "./utils.js";
+import { djb2Hex, resolveMachineVersion } from "./utils.js";
 import { AgentError } from "./errors.js";
 import {
   getRegisteredAgentExecutionOptions,
@@ -181,7 +181,7 @@ export function createReplayEntry<TMachine extends AnyStateMachine>(
 ): AgentLogEntry {
   const index = entries.length;
   const machineId = (machine.config as { id?: string }).id ?? machine.id ?? "(machine)";
-  const machineVersion = options.machineVersion ?? getMachineStructuralHash(machine);
+  const machineVersion = options.machineVersion ?? resolveMachineVersion(machine);
   const entry: AgentLogEntry = {
     schemaVersion: AGENT_EVENT_SCHEMA_VERSION,
     id: options.id ?? `evt_${String(index).padStart(8, "0")}`,
@@ -710,7 +710,7 @@ export function replay<TMachine extends AnyStateMachine>(
   options: ReplayOptions = {},
 ): ReplayResult<TMachine> {
   const machineId = (machine.config as { id?: string }).id ?? machine.id ?? "(machine)";
-  const machineVersion = options.machineVersion ?? getMachineStructuralHash(machine);
+  const machineVersion = options.machineVersion ?? resolveMachineVersion(machine);
   validateReplayEntries(entries, { machineId, machineVersion }, "Replay entries");
   const events = toEvents(entries);
 

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -746,15 +746,6 @@ export function replay<TMachine extends AnyStateMachine>(
   return { snapshot: snapshot as SnapshotFrom<TMachine>, effects };
 }
 
-/** Requires and checks every entry's recorded state/effect hashes. */
-export function verifyReplay<TMachine extends AnyStateMachine>(
-  machine: TMachine,
-  entries: readonly AgentLogEntry[],
-  options: Omit<ReplayOptions, "verify"> = {},
-): ReplayResult<TMachine> {
-  return replay(machine, entries, { ...options, verify: "strict" });
-}
-
 /** Structural event-tail, logical-state, and owed-effect comparison. */
 export function diffEventLogs<TMachine extends AnyStateMachine>(
   machine: TMachine,

--- a/src/event-log-store-conformance.ts
+++ b/src/event-log-store-conformance.ts
@@ -123,8 +123,8 @@ export async function assertEventLogStoreConformance(create: CreateStore): Promi
     if (!(caught instanceof AgentEventLogConflictError)) {
       fail("a stale expectedIndex must throw AgentEventLogConflictError");
     }
-    if (caught.threadId !== "t" || caught.expectedIndex !== 0 || caught.actualLength !== 1) {
-      fail("conflict error must carry threadId, expectedIndex, and the actual length");
+    if (caught.threadId !== "t" || caught.expectedIndex !== 0 || caught.actualIndex !== 1) {
+      fail("conflict error must carry threadId, expectedIndex, and the actual index");
     }
   }
 
@@ -257,12 +257,12 @@ export async function assertEventLogStoreConformance(create: CreateStore): Promi
       "fork with upToIndex 1 must copy only entry 0",
     );
 
-    // Inclusive event-id cutoff.
-    await store.fork({ threadId: "src", newThreadId: "fork-id", atEventId: "evt_1" });
+    // upToIndex is exclusive.
+    await store.fork({ threadId: "src", newThreadId: "fork-2", upToIndex: 2 });
     assertJsonEqual(
-      (await store.read("fork-id")).map((e) => e.id),
+      (await store.read("fork-2")).map((e) => e.id),
       ["evt_0", "evt_1"],
-      "fork with atEventId must include the named entry",
+      "fork with upToIndex 2 must copy entries 0 and 1 only",
     );
 
     // The fork appends independently from its copied length; the source is untouched.
@@ -299,6 +299,17 @@ export async function assertEventLogStoreConformance(create: CreateStore): Promi
     }
     if (!(caughtUnknown instanceof Error) || caughtUnknown instanceof AgentEventLogConflictError) {
       fail("forking an unknown source thread must reject with a plain Error");
+    }
+
+    // An out-of-range upToIndex rejects.
+    let caughtRange: unknown;
+    try {
+      await store.fork({ threadId: "src", newThreadId: "fork-range", upToIndex: 99 });
+    } catch (error) {
+      caughtRange = error;
+    }
+    if (!(caughtRange instanceof Error) || caughtRange instanceof AgentEventLogConflictError) {
+      fail("forking past the source length must reject with a plain Error");
     }
   }
 }

--- a/src/event-log-store.test.ts
+++ b/src/event-log-store.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
 import { createActor, setup, type EventFromLogic } from "xstate";
-import { persistSnapshot } from "./utils.js";
 import { createReplayEntry, initEntry, replay } from "./effects.js";
 import {
   AgentEventLogConflictError,
@@ -33,7 +32,7 @@ describe("createInMemoryEventLogStore conformance", () => {
 });
 
 describe("AgentEventLogConflictError", () => {
-  test("carries threadId, expectedIndex, and actualLength", async () => {
+  test("carries threadId, expectedIndex, and actualIndex", async () => {
     const store = createInMemoryEventLogStore();
     await store.append({
       threadId: "t",
@@ -56,7 +55,7 @@ describe("AgentEventLogConflictError", () => {
     const conflict = caught as AgentEventLogConflictError;
     expect(conflict.threadId).toBe("t");
     expect(conflict.expectedIndex).toBe(0);
-    expect(conflict.actualLength).toBe(1);
+    expect(conflict.actualIndex).toBe(1);
     expect(conflict.name).toBe("AgentEventLogConflictError");
   });
 });
@@ -181,7 +180,8 @@ describe("deterministic replay from the log", () => {
     const { snapshot } = replay(counterMachine, journal);
 
     // The deterministic-replay property the whole durability model rests on.
-    expect(persistSnapshot(snapshot)).toEqual(persistSnapshot(liveSnapshot));
+    const toJson = (value: unknown) => JSON.parse(JSON.stringify(value)) as unknown;
+    expect(toJson(snapshot)).toEqual(toJson(liveSnapshot));
     expect(snapshot.context).toEqual({ total: 17, ops: 3 });
     expect(snapshot.status).toBe("done");
   });

--- a/src/event-log-store.ts
+++ b/src/event-log-store.ts
@@ -259,42 +259,41 @@ export interface AgentEventLogStore {
   /** The thread's current log length (0 for an unknown thread) — the next `expectedIndex`. */
   length(threadId: string): Promise<number>;
   /**
-   * Copy a prefix onto a fresh, empty `newThreadId` — either `[0, upToIndex)`
-   * or through the inclusive `atEventId`. With neither cutoff the full source
-   * is copied. The fork then appends independently. Rejects (plain `Error`) if
-   * `newThreadId` already has entries, the source/id is unknown, or both cutoff
-   * forms are supplied. Implementations may copy-on-write or physically copy;
-   * observable behavior must match a full copy.
+   * Copy the prefix `[0, upToIndex)` onto a fresh, empty `newThreadId`.
+   * Without `upToIndex` the full source is copied. The fork then appends
+   * independently. Rejects (plain `Error`) if `newThreadId` already has
+   * entries, the source is unknown, or `upToIndex` is out of range.
+   * Implementations may copy-on-write or physically copy; observable behavior
+   * must match a full copy.
    */
   fork(input: {
     threadId: string;
     newThreadId: string;
+    /** Exclusive index cutoff. */
     upToIndex?: number;
-    /** Inclusive event-id cutoff. Mutually exclusive with `upToIndex`. */
-    atEventId?: string;
   }): Promise<void>;
 }
 
 /**
  * Rejection from {@link AgentEventLogStore.append} when the thread's stored
  * length is not the `expectedIndex` the writer held — a concurrent writer
- * appended first. `actualLength` is the length core found.
+ * appended first. `actualIndex` is the next index the store would accept.
  */
 export class AgentEventLogConflictError extends AgentError {
   readonly threadId: string;
   readonly expectedIndex: number;
-  readonly actualLength: number;
+  readonly actualIndex: number;
 
-  constructor(threadId: string, expectedIndex: number, actualLength: number) {
+  constructor(threadId: string, expectedIndex: number, actualIndex: number) {
     super(
       "event-log-conflict",
-      `AgentEventLogStore.append: length conflict on thread "${threadId}": ` +
-        `expected length ${expectedIndex} but found ${actualLength} — a concurrent writer won.`,
+      `AgentEventLogStore.append: index conflict on thread "${threadId}": ` +
+        `expected index ${expectedIndex} but found ${actualIndex} — a concurrent writer won.`,
     );
     this.name = "AgentEventLogConflictError";
     this.threadId = threadId;
     this.expectedIndex = expectedIndex;
-    this.actualLength = actualLength;
+    this.actualIndex = actualIndex;
   }
 }
 
@@ -359,7 +358,7 @@ export function createInMemoryEventLogStore(): AgentEventLogStore {
       return threads.get(threadId)?.length ?? 0;
     },
 
-    async fork({ threadId, newThreadId, upToIndex, atEventId }) {
+    async fork({ threadId, newThreadId, upToIndex }) {
       if ((threads.get(newThreadId)?.length ?? 0) > 0) {
         throw new Error(
           `AgentEventLogStore.fork: newThreadId "${newThreadId}" already has entries.`,
@@ -369,17 +368,7 @@ export function createInMemoryEventLogStore(): AgentEventLogStore {
       if (!source) {
         throw new Error(`AgentEventLogStore.fork: unknown source thread "${threadId}".`);
       }
-      if (upToIndex !== undefined && atEventId !== undefined) {
-        throw new Error("AgentEventLogStore.fork: pass either upToIndex or atEventId, not both.");
-      }
-      const eventIndex =
-        atEventId === undefined ? undefined : source.findIndex((entry) => entry.id === atEventId);
-      if (atEventId !== undefined && eventIndex === -1) {
-        throw new Error(
-          `AgentEventLogStore.fork: thread "${threadId}" has no event id "${atEventId}".`,
-        );
-      }
-      const upTo = eventIndex === undefined ? (upToIndex ?? source.length) : eventIndex + 1;
+      const upTo = upToIndex ?? source.length;
       if (upTo < 0 || upTo > source.length) {
         throw new Error(
           `AgentEventLogStore.fork: thread "${threadId}" (length ${source.length}) ` +

--- a/src/examples.test.ts
+++ b/src/examples.test.ts
@@ -145,9 +145,9 @@ describe("curated XState setup examples", () => {
     }
     expect(chooseMove.events.map((event) => event.type)).toEqual(["ATTACK", "DEFEND", "FLEE"]);
 
-    const attackEvent = await resolveDecision(chooseMove, async () => ({
-      event: { type: "ATTACK", target: "goblin" },
-    }));
+    const attackEvent = await resolveDecision(chooseMove, {
+      decide: async () => ({ event: { type: "ATTACK", target: "goblin" } }),
+    });
 
     const attackStep = transitionAgentStep(gameMachine, snapshot, attackEvent as never);
 

--- a/src/get-requests.test.ts
+++ b/src/get-requests.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
-import { createMachine } from "xstate";
+import { createActor, createMachine, type AnyMachineSnapshot } from "xstate";
 import {
   getAgentMessages,
-  persistSnapshot,
   runAgent,
   userMessage,
   type AgentDecisionRequest,
@@ -14,6 +13,8 @@ import {
   type AgentTools,
 } from "./index.js";
 import { getMachineStructuralHash } from "./index.js";
+// TODO: re-export from ./index.js (see the export list in the handoff report).
+import { getSnapshotNodes, getSnapshotRequests } from "./run-agent.js";
 
 // ─── State interpretation (runAgent's `getRequests` option) ───
 //
@@ -137,7 +138,9 @@ describe("runAgent getRequests (state interpretation)", () => {
     // typed accessor — it works on the live and JSON-persisted snapshot alike.
     // `onMessage` observed the same log live, message by message.
     const messages = getAgentMessages(result.snapshot);
-    expect(getAgentMessages(persistSnapshot(result.snapshot))).toEqual(messages);
+    expect(getAgentMessages(taglineMachine.getPersistedSnapshot(result.snapshot) as never)).toEqual(
+      messages,
+    );
     expect(live).toEqual(messages);
 
     // The live info arg carries the run's identity, one per message, all
@@ -465,7 +468,7 @@ describe("runAgent getRequests (state interpretation)", () => {
   });
 
   test(
-    "advances through isSuspended-positive states instead of stalling",
+    "advances through isIdle-positive states instead of stalling",
     { timeout: 3000 },
     async () => {
       const machine = createMachine({
@@ -481,7 +484,7 @@ describe("runAgent getRequests (state interpretation)", () => {
       const result = await runAgent(machine, {
         // Every snapshot reads as an intentional wait — interpretation must
         // still retrigger after each pass (P1 regression).
-        isSuspended: () => true,
+        isIdle: () => true,
         getRequests: (snapshot) =>
           snapshot._nodes
             .filter((node) => node.description)
@@ -521,3 +524,95 @@ describe("runAgent getRequests (state interpretation)", () => {
     expect(result.status === "error" ? result.cause : undefined).toBe("max-model-calls");
   });
 });
+
+// ─── getSnapshotRequests / getSnapshotNodes (the recipe, without `_nodes`) ───
+
+describe("getSnapshotRequests", () => {
+  test("drives the same described machine with no `_nodes` access in host code", async () => {
+    const textCalls: AgentTextRequest[] = [];
+    const decideCalls: AgentDecisionRequest[] = [];
+
+    const result = await runAgent(taglineMachine, {
+      getRequests: (snapshot) => getSnapshotRequests(snapshot, { model: "test-model" }),
+      executors: {
+        generateText: async (request) => {
+          textCalls.push(request);
+          return { output: "a line" };
+        },
+        decide: async (request) => {
+          decideCalls.push(request);
+          return { event: { type: "APPROVE" } };
+        },
+      },
+    });
+
+    expect(result.status).toBe("done");
+    // brainstorming + drafting are text steps; judging (tagged `decision`) is not.
+    expect(textCalls).toHaveLength(2);
+    expect(textCalls[1]?.system).toBe("Senior copywriter");
+    expect(decideCalls).toHaveLength(1);
+    // Candidate events are scoped to the node's own events.
+    expect(decideCalls[0]?.events.map((event) => event.type).sort()).toEqual(["APPROVE", "REVISE"]);
+  });
+
+  test("single-outcome states advance deterministically; `filter`/`map` override the defaults", () => {
+    const machine = createMachine({
+      id: "two",
+      initial: "writing",
+      states: {
+        writing: {
+          description: "Write it.",
+          on: { NEXT: { target: "waiting" } },
+        },
+        waiting: {
+          description: "Wait for a human.",
+          tags: ["waiting"],
+          on: { APPROVE: { target: "done" }, REJECT: { target: "writing" } },
+        },
+        done: { type: "final" },
+      },
+    });
+
+    const snapshot = runAgentSnapshot(machine);
+    const requests = getSnapshotRequests(snapshot, { model: "m" });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      model: "m",
+      prompt: "Write it.",
+      kind: "text",
+      onDone: { type: "NEXT" },
+      allowedEvents: ["NEXT"],
+    });
+
+    // `map` reshapes; returning undefined drops.
+    expect(
+      getSnapshotRequests(snapshot, {
+        model: "m",
+        map: (request) => ({ ...request, system: "Be brief." }),
+      })[0]?.system,
+    ).toBe("Be brief.");
+    expect(getSnapshotRequests(snapshot, { model: "m", map: () => undefined })).toEqual([]);
+    // `filter` overrides the default described-and-not-waiting rule.
+    expect(getSnapshotRequests(snapshot, { model: "m", filter: () => false })).toEqual([]);
+  });
+
+  test("getSnapshotNodes exposes the active nodes as plain descriptors", () => {
+    const snapshot = runAgentSnapshot(taglineMachine);
+    const nodes = getSnapshotNodes(snapshot);
+
+    expect(nodes.some((node) => node.id.endsWith("brainstorming"))).toBe(true);
+    const leaf = nodes.find((node) => node.key === "brainstorming");
+    expect(leaf?.description).toBe("Brainstorm three tagline ideas for the product.");
+    expect(leaf?.ownEvents).toEqual(["IDEAS_READY"]);
+    expect(leaf?.leaf).toBe(true);
+  });
+});
+
+// The initial snapshot of a machine, as a live actor would see it.
+function runAgentSnapshot(machine: Parameters<typeof createActor>[0]) {
+  const actor = createActor(machine);
+  actor.start();
+  const snapshot = actor.getSnapshot() as AnyMachineSnapshot;
+  actor.stop();
+  return snapshot;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,9 @@ export {
   AGENT_TRACE_SCHEMA_VERSION,
   AgentIdleError,
   AgentIllegalResumeEventError,
+  AgentMaxModelCallsExceededError,
+  getSnapshotNodes,
+  getSnapshotRequests,
   inspectTransitions,
   runAgent,
   createAgentActor,
@@ -80,7 +83,9 @@ export type {
   AgentInputFrom,
   AgentMessageInfo,
   AgentRunMeta,
+  AgentSnapshotNode,
   AgentStateRequest,
+  GetSnapshotRequestsOptions,
   AgentTraceEvent,
   AgentUserInputExecutor,
   InspectedActorRef,
@@ -97,7 +102,6 @@ export { provideExecutors } from "./provide-executors.js";
 export type { ProvideExecutorsOptions } from "./provide-executors.js";
 export {
   AgentLintError,
-  assertAgentMachine,
   canReach,
   explorePaths,
   lintAgentMachine,
@@ -108,7 +112,6 @@ export type {
   AgentLintSeverity,
   AgentPathReport,
   AgentPathTerminal,
-  AssertAgentMachineOptions,
   CanReachResult,
   ExplorePathsOptions,
   LintAgentMachineOptions,
@@ -131,8 +134,10 @@ export { createScriptedExecutors } from "./scripted-executors.js";
 export type {
   ScriptedDecisionEntry,
   ScriptedDecisionValue,
+  ScriptedExecutors,
   ScriptedExecutorsScript,
   ScriptedTextEntry,
+  ScriptedUserInputEntry,
 } from "./scripted-executors.js";
 export {
   assistantMessage,
@@ -142,7 +147,6 @@ export {
   getMachineStructuralHash,
   getStateMeta,
   isStandardSchema,
-  persistSnapshot,
   systemMessage,
   toolMessage,
   userMessage,
@@ -172,7 +176,6 @@ export {
   getAgentEffects,
   initEntry,
   replay,
-  verifyReplay,
 } from "./effects.js";
 export type {
   AgentEffectDiff,

--- a/src/internal/registry.ts
+++ b/src/internal/registry.ts
@@ -17,22 +17,22 @@ export const agentExecutionOptions = new WeakMap<object, AgentExecutionOptions>(
  * object. `config` is shared by reference across `machine.provide(...)` (unlike
  * the machine object itself), so a predicate registered here travels with the
  * machine through `.provide` — which is why it is keyed on `config`, not the
- * machine. Set by `setupAgent({ isSuspended })` in `createMachine` and by
- * `setupAgent.fromConfig` (its `isSuspended` option or the config's
- * `suspendedTags`), read by `runAgent` (below the host `options.isSuspended`
+ * machine. Set by `setupAgent({ isIdle })` in `createMachine` and by
+ * `setupAgent.fromConfig` (its `isIdle` option or the config's
+ * `idleTags`), read by `runAgent` (below the host `options.isIdle`
  * override, above the timing heuristic).
  */
-export const machineSuspensionPredicates = new WeakMap<
+export const machineIdlePredicates = new WeakMap<
   object,
   (snapshot: AnyMachineSnapshot) => boolean
 >();
 
-/** Reads the {@link machineSuspensionPredicates} predicate carried by `machine` (via its root `config`), if any. */
-export function getMachineSuspensionPredicate(
+/** Reads the {@link machineIdlePredicates} predicate carried by `machine` (via its root `config`), if any. */
+export function getMachineIdlePredicate(
   machine: AnyStateMachine,
 ): ((snapshot: AnyMachineSnapshot) => boolean) | undefined {
   const config = (machine as { config?: object }).config;
-  return config ? machineSuspensionPredicates.get(config) : undefined;
+  return config ? machineIdlePredicates.get(config) : undefined;
 }
 
 /**
@@ -45,7 +45,7 @@ export function getMachineSuspensionPredicate(
  * context patch into an opaque resolver function, erasing its target from
  * `machine.config` — so `lintAgentMachine`'s reachability walk reads the
  * targets from here instead. Keyed on the machine's root `config` object (like
- * {@link machineSuspensionPredicates}) so it survives `machine.provide(...)`.
+ * {@link machineIdlePredicates}) so it survives `machine.provide(...)`.
  */
 export const machineStaticTransitionTargets = new WeakMap<object, Record<string, string[]>>();
 

--- a/src/internal/state-request-pass.ts
+++ b/src/internal/state-request-pass.ts
@@ -282,10 +282,14 @@ async function runAdvancePhase(
     events,
     attempts: [],
   };
-  const chosen = await resolveDecision(decisionRequest, deps.decide, {
-    signal: deps.signal,
-    canTake: (event) => deps.getSnapshot().can(event),
-  });
+  const chosen = await resolveDecision(
+    decisionRequest,
+    { decide: deps.decide },
+    {
+      signal: deps.signal,
+      canTake: (event) => deps.getSnapshot().can(event),
+    },
+  );
   // Re-check after the await: a run that settled while the decision was in
   // flight gets no further appends (no stray post-settle onMessage) or sends.
   if (deps.isSettled()) {

--- a/src/machines/handoff.ts
+++ b/src/machines/handoff.ts
@@ -91,7 +91,7 @@ export function createHandoffMachine(config: CreateHandoffMachineConfig): AnySta
     actors: machineActors(agents),
     // A turn ends in `waiting`, which is an intentional wait for the next
     // message — not a stall.
-    isSuspended: (snapshot) => snapshot.matches("waiting"),
+    isIdle: (snapshot) => snapshot.matches("waiting"),
   });
 
   const turnState = (name: string) => `${name}Turn`;

--- a/src/machines/internal.ts
+++ b/src/machines/internal.ts
@@ -58,8 +58,8 @@ export interface PresetRequestEntry {
   outputSchema?: StandardSchemaV1;
   /** Tools the host runs inside this one request. */
   tools?: AgentTools;
-  /** Bounds the host-side tool loop (lowered to `metadata.maxSteps`). */
-  maxTurns?: number;
+  /** Bounds the host-side tool loop (lowered to the request's typed `maxSteps`). */
+  maxSteps?: number;
 }
 
 /** One delegated unit of work, lowered to an invoked child machine. */
@@ -129,7 +129,7 @@ export function requestInput(
     prompt,
     ...(entry.tools ? { tools: entry.tools } : {}),
     ...(entry.outputSchema ? { outputSchema: entry.outputSchema } : {}),
-    ...(entry.maxTurns !== undefined ? { metadata: { maxSteps: entry.maxTurns } } : {}),
+    ...(entry.maxSteps !== undefined ? { maxSteps: entry.maxSteps } : {}),
   };
 }
 

--- a/src/machines/loop.ts
+++ b/src/machines/loop.ts
@@ -36,8 +36,8 @@ export interface CreateLoopMachineConfig {
   };
   /** Stop condition, checked after each iteration. */
   until: (state: LoopState) => boolean;
-  /** Hard upper bound on iterations, enforced by a guard. */
-  maxIterations: number;
+  /** Hard upper bound on machine turns (iterations), enforced by a guard. */
+  maxTurns: number;
 }
 
 /** Context of a {@link createLoopMachine} machine. */
@@ -60,7 +60,7 @@ const outputSchema = objectSchema<{ iterations: number; results: unknown[]; last
 
 /**
  * A bounded repeat: run the body, check `until` over the accumulated state,
- * and either stop or go again. `maxIterations` is a guard, so the loop cannot
+ * and either stop or go again. `maxTurns` is a guard, so the loop cannot
  * run away even if `until` never returns `true`.
  *
  * States: `running` → `checking` → (`running` | `done`).
@@ -70,14 +70,14 @@ const outputSchema = objectSchema<{ iterations: number; results: unknown[]; last
  *   model: "quick",
  *   body: { instructions: "Improve the draft. Return only the draft." },
  *   until: ({ last }) => String(last).length > 500,
- *   maxIterations: 4,
+ *   maxTurns: 4,
  * });
  * ```
  */
 export function createLoopMachine(config: CreateLoopMachineConfig): AnyStateMachine {
-  const { model, body, until, maxIterations } = config;
-  if (!Number.isInteger(maxIterations) || maxIterations < 1) {
-    throw new Error("createLoopMachine: maxIterations must be an integer >= 1.");
+  const { model, body, until, maxTurns } = config;
+  if (!Number.isInteger(maxTurns) || maxTurns < 1) {
+    throw new Error("createLoopMachine: maxTurns must be an integer >= 1.");
   }
 
   const agentSetup = setupAgent({
@@ -133,7 +133,7 @@ export function createLoopMachine(config: CreateLoopMachineConfig): AnyStateMach
       checking: {
         type: "choice",
         choice: ({ context }: { context: LoopContext }) =>
-          context.iterations >= maxIterations || until(loopState(context))
+          context.iterations >= maxTurns || until(loopState(context))
             ? { target: "done" }
             : { target: "running" },
       },

--- a/src/machines/machines.test.ts
+++ b/src/machines/machines.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { lintAgentMachine, persistSnapshot, runAgent } from "../index.js";
+import { lintAgentMachine, runAgent } from "../index.js";
 import type { AgentRequestExecutors, AgentTextRequest } from "../text-logic.js";
 import type { AgentDecisionExecutor, AgentDecisionRequest } from "../decision.js";
 import {
@@ -43,7 +43,7 @@ describe("createToolLoopMachine", () => {
     model: "quick",
     instructions: "Answer using the tools.",
     tools: { calculate: { description: "math", execute: async () => 714 } },
-    maxTurns: 5,
+    maxSteps: 5,
   });
 
   test("runs one request and finishes with its output", async () => {
@@ -62,16 +62,16 @@ describe("createToolLoopMachine", () => {
     expect(Object.keys(requests[0]?.tools ?? {})).toEqual(["calculate"]);
   });
 
-  test("maxTurns lowers to metadata.maxSteps, interruptOn to metadata.interruptOn", async () => {
+  test("maxSteps lowers to the typed request field", async () => {
     const gated = createToolLoopMachine({
       model: "quick",
-      maxTurns: 3,
-      interruptOn: ["sendRefund"],
+      maxSteps: 3,
     });
     const { generateText, requests } = mockGenerateText();
     await runAgent(gated, { input: { prompt: "hi" }, executors: { generateText } });
 
-    expect(requests[0]?.metadata).toEqual({ maxSteps: 3, interruptOn: ["sendRefund"] });
+    expect(requests[0]?.maxSteps).toBe(3);
+    expect(requests[0]?.metadata).toBeUndefined();
   });
 
   test("carries version '1' and lints clean", () => {
@@ -95,16 +95,15 @@ describe("createToolLoopMachine", () => {
     expect((result.snapshot as { agentMeta?: { version?: string } }).agentMeta?.version).toBe("1");
   });
 
-  test("an explicit machineVersion option still overrides the machine-carried version", async () => {
+  test("the machine's own version is the single source (no machineVersion option)", async () => {
     const { generateText } = mockGenerateText();
     const events: string[] = [];
     await runAgent(machine, {
       input: { prompt: "hi" },
-      machineVersion: "my-pinned-version",
       executors: { generateText },
       onTrace: (event) => events.push(event.machineVersion),
     });
-    expect(new Set(events)).toEqual(new Set(["my-pinned-version"]));
+    expect(new Set(events)).toEqual(new Set(["1"]));
   });
 });
 
@@ -296,7 +295,7 @@ describe("createLoopMachine", () => {
       model: "quick",
       body: { instructions: "Improve it." },
       until: ({ iterations }) => iterations >= 2,
-      maxIterations: 10,
+      maxTurns: 10,
     });
     const { generateText } = mockGenerateText(() => "draft");
     const result = await runAgent(machine, {
@@ -312,12 +311,12 @@ describe("createLoopMachine", () => {
     });
   });
 
-  test("maxIterations bounds a predicate that never fires", async () => {
+  test("maxTurns bounds a predicate that never fires", async () => {
     const machine = createLoopMachine({
       model: "quick",
       body: { instructions: "Improve it.", prompt: ({ iterations }) => `round ${iterations}` },
       until: () => false,
-      maxIterations: 3,
+      maxTurns: 3,
     });
     const { generateText, requests } = mockGenerateText(() => "draft");
     const result = await runAgent(machine, {
@@ -332,10 +331,10 @@ describe("createLoopMachine", () => {
     expect(lintErrors(machine)).toEqual([]);
   });
 
-  test("rejects a non-positive maxIterations", () => {
+  test("rejects a non-positive maxTurns", () => {
     expect(() =>
-      createLoopMachine({ model: "quick", body: {}, until: () => true, maxIterations: 0 }),
-    ).toThrow(/maxIterations/);
+      createLoopMachine({ model: "quick", body: {}, until: () => true, maxTurns: 0 }),
+    ).toThrow(/maxTurns/);
   });
 });
 
@@ -430,7 +429,7 @@ describe("createHandoffMachine", () => {
     expect(first.snapshot.context.reply).toBe("travel says hi");
 
     const second = await runAgent(machine, {
-      snapshot: persistSnapshot(first.snapshot),
+      snapshot: first.persistedSnapshot,
       event: { type: "transfer_to_food", message: "What should I eat?" },
       executors: { generateText },
     });

--- a/src/machines/sequential.ts
+++ b/src/machines/sequential.ts
@@ -35,8 +35,8 @@ export interface SequentialStep {
   model?: string;
   /** Tools the host runs inside this step's request. */
   tools?: AgentTools;
-  /** Bounds this step's host-side tool loop (`metadata.maxSteps`). */
-  maxTurns?: number;
+  /** Bounds this step's host-side tool loop (the request's typed `maxSteps`). */
+  maxSteps?: number;
 }
 
 /** Config for {@link createSequentialMachine}. */
@@ -111,7 +111,7 @@ export function createSequentialMachine(config: CreateSequentialMachineConfig): 
               model: step.model,
               outputSchema: step.outputSchema,
               tools: step.tools,
-              maxTurns: step.maxTurns,
+              maxSteps: step.maxSteps,
             },
             model,
             step.prompt

--- a/src/machines/tool-loop.ts
+++ b/src/machines/tool-loop.ts
@@ -13,15 +13,12 @@ export interface CreateToolLoopMachineConfig {
   tools?: AgentTools;
   /** Structured output schema. Omitted means the output is plain text. */
   outputSchema?: StandardSchemaV1;
-  /** Bounds the host-side tool loop — lowered to `metadata.maxSteps`. */
-  maxTurns?: number;
   /**
-   * Tool names the host should gate before executing. Lowered to
-   * `metadata.interruptOn`, which only a host that implements gating reads —
-   * the preset itself stays a single state and never pauses. For a real
-   * approval gate as machine states, eject to `examples/review-tool-calls`.
+   * Bounds the host-side tool loop — lowered to the request's typed
+   * {@link AgentTextRequest.maxSteps}. It bounds MODEL STEPS inside one
+   * request, not machine turns, hence the name.
    */
-  interruptOn?: readonly string[];
+  maxSteps?: number;
 }
 
 /** Context of a {@link createToolLoopMachine} machine. */
@@ -38,7 +35,7 @@ const outputSchema = objectSchema<{ result: unknown }>({ result: jsonAny }, ["re
 
 /**
  * The single-state tool loop: one text request carries the `tools`, and the
- * host runs the tool loop inside it (`maxTurns` bounds it). Selecting and
+ * host runs the tool loop inside it (`maxSteps` bounds it). Selecting and
  * executing tools is the model + host's business, not machine states.
  *
  * States: `answering` → `done`.
@@ -48,7 +45,7 @@ const outputSchema = objectSchema<{ result: unknown }>({ result: jsonAny }, ["re
  *   model: "quick",
  *   instructions: "Answer using the tools.",
  *   tools: { calculate },
- *   maxTurns: 5,
+ *   maxSteps: 5,
  * });
  *
  * const result = await runAgent(machine, {
@@ -59,12 +56,7 @@ const outputSchema = objectSchema<{ result: unknown }>({ result: jsonAny }, ["re
  * ```
  */
 export function createToolLoopMachine(config: CreateToolLoopMachineConfig): AnyStateMachine {
-  const { model, instructions, tools, outputSchema: resultSchema, maxTurns, interruptOn } = config;
-
-  const metadata = {
-    ...(maxTurns !== undefined ? { maxSteps: maxTurns } : {}),
-    ...(interruptOn && interruptOn.length > 0 ? { interruptOn: [...interruptOn] } : {}),
-  };
+  const { model, instructions, tools, outputSchema: resultSchema, maxSteps } = config;
 
   const agentSetup = setupAgent({
     context: contextSchema,
@@ -92,7 +84,7 @@ export function createToolLoopMachine(config: CreateToolLoopMachineConfig): AnyS
             prompt: context.prompt,
             ...(tools ? { tools } : {}),
             ...(resultSchema ? { outputSchema: resultSchema } : {}),
-            ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+            ...(maxSteps !== undefined ? { maxSteps } : {}),
           }),
           onDone: ({ output }) => ({ target: "done", context: { result: output } }),
         },

--- a/src/provide-executors.test.ts
+++ b/src/provide-executors.test.ts
@@ -437,7 +437,7 @@ describe("provideExecutors + '@agent.usage'", () => {
     ]);
   });
 
-  test("a wildcard-only machine never receives it (same opt-in gate as runAgent)", async () => {
+  test("a wildcard-only machine DOES receive it (plain XState wildcard semantics, as in runAgent)", async () => {
     const wildcardSchemas = createAgentSchemas({
       context: z.object({ tokens: z.number(), seen: z.array(z.string()) }),
       output: z.object({ tokens: z.number(), seen: z.array(z.string()) }),
@@ -469,7 +469,8 @@ describe("provideExecutors + '@agent.usage'", () => {
     actor.start();
     const output = await toPromise(actor);
 
-    expect(output.seen).not.toContain(AGENT_USAGE_EVENT_TYPE);
+    expect(output.seen).toContain(AGENT_USAGE_EVENT_TYPE);
+    // The wildcard handler only records event types, so tokens stay 0.
     expect(output.tokens).toBe(0);
   });
 
@@ -514,5 +515,140 @@ describe("provideExecutors + '@agent.usage'", () => {
     actor.start();
 
     expect(await toPromise(actor)).toEqual({ tokens: 77, kinds: ["decision:choose"] });
+  });
+});
+
+// ─── Recursive executor inheritance (parity with runAgent) ───
+
+describe("provideExecutors recursive child binding", () => {
+  const childText = createTextLogic({
+    schemas: { input: z.object({ topic: z.string() }), output: z.string() },
+    model: "child-model",
+    prompt: ({ input }) => input.topic,
+  });
+
+  const buildGrandchild = () => {
+    const schemas = createAgentSchemas({
+      context: z.object({ line: z.string().nullable() }),
+      input: z.object({ topic: z.string() }),
+      output: z.object({ line: z.string() }),
+    });
+    return setupAgent({ schemas, actors: { childText } }).createMachine({
+      context: { line: null },
+      initial: "writing",
+      states: {
+        writing: {
+          invoke: {
+            id: "write",
+            src: "childText",
+            input: ({ context }: { context: { line: string | null } }) => {
+              void context;
+              return { topic: "grandchild topic" };
+            },
+            onDone: ({ output }: { output: unknown }) => ({
+              target: "done",
+              context: { line: output as string },
+            }),
+          },
+        },
+        done: {
+          type: "final",
+          output: ({ context }: { context: { line: string | null } }) => ({ line: context.line }),
+        },
+      },
+    } as never);
+  };
+
+  const buildParent = () => {
+    const grandchild = buildGrandchild();
+    const childSchemas = createAgentSchemas({
+      context: z.object({ line: z.string().nullable() }),
+      input: z.object({ topic: z.string() }),
+      output: z.object({ line: z.string() }),
+    });
+    const child = setupAgent({
+      schemas: childSchemas,
+      actors: { grandchild },
+    }).createMachine({
+      context: { line: null },
+      initial: "delegating",
+      states: {
+        delegating: {
+          invoke: {
+            id: "grandchild",
+            src: "grandchild",
+            input: { topic: "t" },
+            onDone: ({ output }: { output: unknown }) => ({
+              target: "done",
+              context: { line: (output as { line: string }).line },
+            }),
+          },
+        },
+        done: {
+          type: "final",
+          output: ({ context }: { context: { line: string | null } }) => ({ line: context.line }),
+        },
+      },
+    } as never);
+
+    const parentSchemas = createAgentSchemas({
+      context: z.object({ line: z.string().nullable() }),
+      input: z.object({}),
+      output: z.object({ line: z.string() }),
+    });
+    return setupAgent({ schemas: parentSchemas, actors: { child } }).createMachine({
+      context: { line: null },
+      initial: "delegating",
+      states: {
+        delegating: {
+          invoke: {
+            id: "child",
+            src: "child",
+            input: { topic: "t" },
+            onDone: ({ output }: { output: unknown }) => ({
+              target: "done",
+              context: { line: (output as { line: string }).line },
+            }),
+          },
+        },
+        done: {
+          type: "final",
+          output: ({ context }: { context: { line: string | null } }) => ({ line: context.line }),
+        },
+      },
+    } as never);
+  };
+
+  test("a request inside a nested child machine inherits the host executors", async () => {
+    const models: string[] = [];
+    const bound = provideExecutors(buildParent(), {
+      generateText: async (request: { model: string }) => {
+        models.push(request.model);
+        return { output: "written by the grandchild" };
+      },
+    } as never);
+
+    const actor = createActor(bound, { input: {} } as never);
+    actor.start();
+    const output = (await toPromise(actor)) as { line: string };
+
+    expect(output).toEqual({ line: "written by the grandchild" });
+    // Two levels down, and it still reached the host executor.
+    expect(models).toEqual(["child-model"]);
+  });
+
+  test("child requests reach the same onTrace stream as parent ones", async () => {
+    const traced: string[] = [];
+    const bound = provideExecutors(
+      buildParent(),
+      { generateText: async () => ({ output: "ok" }) } as never,
+      { onTrace: (event) => traced.push(event.type) },
+    );
+
+    const actor = createActor(bound, { input: {} } as never);
+    actor.start();
+    await toPromise(actor);
+
+    expect(traced).toEqual(["request.start", "request.end"]);
   });
 });

--- a/src/provide-executors.test.ts
+++ b/src/provide-executors.test.ts
@@ -330,6 +330,51 @@ describe("provideExecutors onTrace / traceTransitions", () => {
     }
   });
 
+  test("a declared createMachine({ version }) is stamped on uncontrolled trace envelopes", async () => {
+    const draftText = createTextLogic({
+      schemas: { input: z.object({ topic: z.string() }), output: z.string() },
+      model: "test-model",
+      prompt: ({ input }) => input.topic,
+    });
+    const schemas = createAgentSchemas({
+      context: z.object({ topic: z.string() }),
+      input: z.object({ topic: z.string() }),
+    });
+    const machine = setupAgent({ schemas, actors: { draftText } }).createMachine({
+      version: "7",
+      context: ({ input }: { input: { topic: string } }) => ({ topic: input.topic }),
+      initial: "drafting",
+      states: {
+        drafting: {
+          invoke: {
+            src: "draftText",
+            input: ({ context }: { context: { topic: string } }) => ({ topic: context.topic }),
+            onDone: { target: "done" },
+          },
+        },
+        done: { type: "final" },
+      },
+    } as never);
+
+    const trace: AgentTraceEvent[] = [];
+    const push = (event: AgentTraceEvent) => trace.push(event);
+    const bound = provideExecutors(
+      machine,
+      {
+        generateText: async () => ({ output: "ok" }),
+      } as never,
+      { onTrace: push },
+    );
+    const actor = createActor(bound, { inspect: traceTransitions(push), input: { topic: "cats" } });
+    actor.start();
+    await toPromise(actor);
+
+    expect(trace.length).toBeGreaterThan(0);
+    for (const event of trace) {
+      expect(event.machineVersion).toBe("7");
+    }
+  });
+
   test("two concurrent actors from one bound machine get distinct runIds and independent seq", async () => {
     const trace: AgentTraceEvent[] = [];
     const bound = provideExecutors(buildStreamMachine(), streamExecutors(), {
@@ -650,5 +695,75 @@ describe("provideExecutors recursive child binding", () => {
     await toPromise(actor);
 
     expect(traced).toEqual(["request.start", "request.end"]);
+  });
+
+  test("a nested child's missing executor throws at bind time, before any actor starts", () => {
+    expect(() => provideExecutors(buildParent(), {} as never)).toThrow(
+      /provideExecutors: actor source 'child > grandchild > childText' is a text source but no 'generateText' executor/,
+    );
+  });
+
+  test("a child machine's stream request with no streamText throws at bind time", () => {
+    const streamLogic = createTextLogic({
+      schemas: { input: z.object({ topic: z.string() }), output: z.string() },
+      model: "child-model",
+      mode: "stream",
+      prompt: ({ input }) => input.topic,
+    });
+    const childSchemas = createAgentSchemas({
+      context: z.object({ line: z.string().nullable() }),
+      input: z.object({ topic: z.string() }),
+      output: z.object({ line: z.string() }),
+    });
+    const child = setupAgent({ schemas: childSchemas, actors: { streamLogic } }).createMachine({
+      context: { line: null },
+      initial: "writing",
+      states: {
+        writing: {
+          invoke: {
+            src: "streamLogic",
+            input: { topic: "t" },
+            onDone: ({ output }: { output: unknown }) => ({
+              target: "done",
+              context: { line: output as string },
+            }),
+          },
+        },
+        done: {
+          type: "final",
+          output: ({ context }: { context: { line: string | null } }) => ({ line: context.line }),
+        },
+      },
+    } as never);
+
+    const parentSchemas = createAgentSchemas({
+      context: z.object({ line: z.string().nullable() }),
+      input: z.object({}),
+      output: z.object({ line: z.string() }),
+    });
+    const parent = setupAgent({ schemas: parentSchemas, actors: { child } }).createMachine({
+      context: { line: null },
+      initial: "delegating",
+      states: {
+        delegating: {
+          invoke: {
+            src: "child",
+            input: { topic: "t" },
+            onDone: { target: "done" },
+          },
+        },
+        done: {
+          type: "final",
+          output: ({ context }: { context: { line: string | null } }) => ({ line: context.line }),
+        },
+      },
+    } as never);
+
+    // Passing generateText is not enough: the child needs streamText.
+    expect(() =>
+      provideExecutors(parent, { generateText: async () => ({ output: "x" }) } as never),
+    ).toThrow(
+      /provideExecutors: actor source 'child > streamLogic' is a streaming text source but no 'streamText' executor/,
+    );
   });
 });

--- a/src/provide-executors.ts
+++ b/src/provide-executors.ts
@@ -2,9 +2,11 @@ import type { AnyActorLogic, AnyStateMachine } from "xstate";
 import { isTextLogic, USER_INPUT_ACTOR, type AgentRequestExecutors } from "./text-logic.js";
 import { isDecisionLogic } from "./decision.js";
 import {
+  bindChildMachineForProvide,
   bindDecisionForProvide,
   bindTextForProvide,
   getConfiguredInvokeSrcs,
+  isStateMachineLogic,
   type AgentTraceEvent,
 } from "./run-agent.js";
 import { executorBoundLogics } from "./internal/registry.js";
@@ -68,9 +70,12 @@ export interface ProvideExecutorsOptions<TMachine extends AnyStateMachine = AnyS
  * Throws at bind time if a source needs an executor kind that `executors` does
  * not provide.
  *
- * `provideExecutors` does not descend into invoked child state machines: a string-keyed child
- * machine source is left untouched, so a child with its own agent invokes needs
- * its own `provideExecutors(...)` (or `runAgent`, which does rebind children).
+ * Executor inheritance is RECURSIVE, exactly as in `runAgent`: a string-keyed
+ * invoked child machine is rebound too, so its own text/decision requests — at
+ * any depth — reach the same host executors. A direct-object invoke `src`
+ * cannot be swapped via `.provide`, so nothing under one inherits; bind those
+ * with `.withExecutor(...)` or register the child as a string-keyed source. A
+ * source that already carries its own executor is never overwritten.
  */
 export function provideExecutors<TMachine extends AnyStateMachine>(
   machine: TMachine,
@@ -101,6 +106,21 @@ export function provideExecutors<TMachine extends AnyStateMachine>(
       continue;
     }
 
+    // An invoked child machine: recursively bind ITS agent sources with the
+    // same executors (same semantics as runAgent's rebindChildMachine).
+    if (isStateMachineLogic(logic)) {
+      const rebound = bindChildMachineForProvide(
+        logic,
+        executors,
+        bindOptions,
+        new Set([provided as AnyStateMachine]),
+      );
+      if (rebound !== logic) {
+        wrappedSources[key] = rebound;
+      }
+      continue;
+    }
+
     let binding: MissingExecutorBinding | undefined;
     if (isDecisionLogic(logic)) {
       binding = {
@@ -116,7 +136,7 @@ export function provideExecutors<TMachine extends AnyStateMachine>(
         bind: () => bindTextForProvide(provided, logic, executors, bindOptions),
       };
     }
-    // Invoked child state machines and non-agent actors pass through untouched.
+    // Non-agent actors pass through untouched.
     if (!binding) {
       continue;
     }

--- a/src/provide-executors.ts
+++ b/src/provide-executors.ts
@@ -109,6 +109,12 @@ export function provideExecutors<TMachine extends AnyStateMachine>(
     // An invoked child machine: recursively bind ITS agent sources with the
     // same executors (same semantics as runAgent's rebindChildMachine).
     if (isStateMachineLogic(logic)) {
+      // Assert BEFORE binding: a child's own invoked text/decision sources
+      // need the same executors, and a missing one must fail here rather than
+      // when the child actor eventually starts.
+      if (invokedSrcs.has(key)) {
+        assertChildBindable(logic, executors, key, new Set([provided as AnyStateMachine]));
+      }
       const rebound = bindChildMachineForProvide(
         logic,
         executors,
@@ -121,25 +127,18 @@ export function provideExecutors<TMachine extends AnyStateMachine>(
       continue;
     }
 
-    let binding: MissingExecutorBinding | undefined;
-    if (isDecisionLogic(logic)) {
-      binding = {
-        executorKey: "decide",
-        kind: "decision",
-        bind: () => bindDecisionForProvide(provided, logic, executors, bindOptions),
-      };
-    } else if (isTextLogic(logic)) {
-      const streaming = logic.mode === "stream";
-      binding = {
-        executorKey: streaming ? "streamText" : "generateText",
-        kind: streaming ? "streaming text" : "text",
-        bind: () => bindTextForProvide(provided, logic, executors, bindOptions),
-      };
-    }
     // Non-agent actors pass through untouched.
-    if (!binding) {
+    const requirement = executorRequirementOf(logic);
+    if (!requirement) {
       continue;
     }
+    const binding: MissingExecutorBinding = {
+      ...requirement,
+      bind: () =>
+        isDecisionLogic(logic)
+          ? bindDecisionForProvide(provided, logic, executors, bindOptions)
+          : bindTextForProvide(provided, logic as never, executors, bindOptions),
+    };
     // A source that already carries its own executor (`.withExecutor(...)`) runs itself.
     if (executorBoundLogics.has(logic)) {
       continue;
@@ -154,6 +153,63 @@ export function provideExecutors<TMachine extends AnyStateMachine>(
   }
 
   return withActors(provided, wrappedSources);
+}
+
+/** The executor slot + label an agent logic needs, or `undefined` for a non-agent actor. */
+function executorRequirementOf(logic: AnyActorLogic):
+  | {
+      executorKey: "generateText" | "streamText" | "decide";
+      kind: "text" | "streaming text" | "decision";
+    }
+  | undefined {
+  if (isDecisionLogic(logic)) {
+    return { executorKey: "decide", kind: "decision" };
+  }
+  if (isTextLogic(logic)) {
+    return logic.mode === "stream"
+      ? { executorKey: "streamText", kind: "streaming text" }
+      : { executorKey: "generateText", kind: "text" };
+  }
+  return undefined;
+}
+
+/**
+ * Walks an invoked child machine's own invoked sources (recursively, at any
+ * depth) and throws the same missing-executor error `provideExecutors` throws
+ * for the top-level machine — before any actor starts. Mirrors runAgent's
+ * `assertBindable` for the uncontrolled path. Cycle-safe via `visited`.
+ */
+function assertChildBindable(
+  childMachine: AnyStateMachine,
+  executors: AgentRequestExecutors,
+  path: string,
+  visited: Set<AnyStateMachine>,
+): void {
+  if (visited.has(childMachine)) {
+    return;
+  }
+  const nextVisited = new Set([...visited, childMachine]);
+  const sources = childMachine.sources.actors as Record<string, AnyActorLogic>;
+  for (const src of getConfiguredInvokeSrcs(childMachine)) {
+    if (src === USER_INPUT_ACTOR) {
+      continue;
+    }
+    const logic = sources[src];
+    if (!logic) {
+      continue;
+    }
+    if (isStateMachineLogic(logic)) {
+      assertChildBindable(logic, executors, `${path} > ${src}`, nextVisited);
+      continue;
+    }
+    const requirement = executorRequirementOf(logic);
+    if (!requirement || executorBoundLogics.has(logic)) {
+      continue;
+    }
+    if (!executors[requirement.executorKey]) {
+      throw missingExecutorError(`${path} > ${src}`, requirement.kind, requirement.executorKey);
+    }
+  }
 }
 
 /** What one agent source needs: the executor slot, its label, and how to bind it. */

--- a/src/run-agent.test.ts
+++ b/src/run-agent.test.ts
@@ -481,6 +481,67 @@ describe("runAgent", () => {
     expect(result.status === "error" ? result.cause : undefined).toBe("max-model-calls");
   });
 
+  test("maxModelCalls: the overrun is a typed AgentError an invoke's onError can branch on", async () => {
+    const schemas = createAgentSchemas({
+      context: z.object({ calls: z.number(), budgetSpent: z.boolean() }),
+      input: z.object({}),
+      output: z.object({ calls: z.number(), budgetSpent: z.boolean() }),
+    });
+
+    const step = createTextLogic({
+      schemas: { input: z.object({}), output: z.number() },
+      model: "test-model",
+    });
+
+    const agent = setupAgent({ schemas, actors: { step } });
+    const machine = agent.createMachine({
+      context: { calls: 0, budgetSpent: false },
+      initial: "looping",
+      states: {
+        looping: {
+          invoke: {
+            id: "step",
+            src: "step",
+            input: {},
+            onDone: ({ context }) => ({
+              target: "looping",
+              reenter: true,
+              context: { calls: context.calls + 1 },
+            }),
+            // The budget breach is branchable: a typed AgentError whose `code`
+            // is the same string the settled result's `cause` uses.
+            onError: ({ event }) =>
+              (event.error as { code?: string })?.code === "max-model-calls"
+                ? { target: "budgetSpent", context: { budgetSpent: true } }
+                : { target: "failed" },
+          },
+        },
+        budgetSpent: {
+          type: "final",
+          output: ({ context }) => context,
+        },
+        failed: { type: "final", output: ({ context }) => context },
+      },
+    });
+
+    let calls = 0;
+    const result = await runAgent(machine, {
+      input: {},
+      maxModelCalls: 2,
+      executors: {
+        generateText: async () => {
+          calls += 1;
+          return { output: calls };
+        },
+      },
+    });
+
+    // Handled: the run completes normally instead of settling an error.
+    expect(result.status).toBe("done");
+    expect(result.status === "done" && result.output).toEqual({ calls: 2, budgetSpent: true });
+    expect(calls).toBe(2);
+  });
+
   test("abort: a pre-aborted signal settles an aborted error", async () => {
     const schemas = createAgentSchemas({
       context: z.object({}),
@@ -1818,21 +1879,26 @@ describe("emitted events (runAgent `on`)", () => {
     expect(new Set(trace.map((event) => event.runId)).size).toBe(1);
   });
 
-  test("machineVersion option overrides the version in every trace event", async () => {
-    const trace: AgentTraceEvent<typeof machine>[] = [];
+  test("the machine's own version (not the structural hash) fills every trace event", async () => {
+    const trace: AgentTraceEvent[] = [];
+    const versioned = setup({}).createMachine({
+      id: "versionedTrace",
+      version: "v-declared",
+      context: {},
+      initial: "done",
+      states: { done: { type: "final" } },
+    } as never);
 
-    await runAgent(machine, {
-      input: { topic: "rivers" },
-      machineVersion: "v-override",
+    await runAgent(versioned, {
       onTrace: (event) => trace.push(event),
       executors: {
-        generateText: async () => ({ output: "a draft", usage: { totalTokens: 3 } }),
+        generateText: async () => ({ output: "a draft" }),
       },
     });
 
     expect(trace.length).toBeGreaterThan(0);
     for (const event of trace) {
-      expect(event.machineVersion).toBe("v-override");
+      expect(event.machineVersion).toBe("v-declared");
     }
   });
 });
@@ -2173,15 +2239,15 @@ describe("inspect passthrough (system-wide visibility)", () => {
   });
 });
 
-describe("Feature A: explicit suspension detection (isSuspended)", () => {
-  test("a machine-carried isSuspended predicate settles idle and resumes to done", async () => {
+describe("Feature A: explicit suspension detection (isIdle)", () => {
+  test("a machine-carried isIdle predicate settles idle and resumes to done", async () => {
     const agent = setupAgent({
       context: z.object({}),
       input: z.object({}),
       output: z.object({ approved: z.boolean() }),
       events: { APPROVE: z.object({}) },
       // The machine declares its own wait signal — a tag it chose.
-      isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
+      isIdle: (snapshot) => snapshot.hasTag("awaiting-review"),
     });
     const machine = agent.createMachine({
       context: {},
@@ -2275,7 +2341,7 @@ describe("Feature A: explicit suspension detection (isSuspended)", () => {
         CONTINUE: z.object({}),
       },
       actors: { child: childMachine },
-      isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+      isIdle: (snapshot) => snapshot.hasTag("waiting"),
     });
     const machine = agent.createMachine({
       context: { readies: 0 },
@@ -2389,7 +2455,7 @@ describe("Feature A: explicit suspension detection (isSuspended)", () => {
         DONE: z.object({}),
       },
       actors: { child: childMachine },
-      isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+      isIdle: (snapshot) => snapshot.hasTag("waiting"),
     });
     const machine = agent.createMachine({
       context: {},
@@ -2443,7 +2509,7 @@ describe("Feature A: explicit suspension detection (isSuspended)", () => {
       input: z.object({}),
       output: z.object({ summary: z.string() }),
       events: { APPROVE: z.object({}) },
-      isSuspended: (snapshot) => snapshot.hasTag("awaiting-review"),
+      isIdle: (snapshot) => snapshot.hasTag("awaiting-review"),
       requests: {
         summarize: {
           schemas: { input: z.object({}), output: z.string() },
@@ -2493,7 +2559,7 @@ describe("Feature A: explicit suspension detection (isSuspended)", () => {
     expect((result.snapshot.context as { summary: string | null }).summary).toBe("done-summary");
   });
 
-  test("the runAgent isSuspended option overrides the machine-carried predicate", async () => {
+  test("the runAgent isIdle option overrides the machine-carried predicate", async () => {
     const machineSeen: string[] = [];
     const agent = setupAgent({
       context: z.object({}),
@@ -2502,7 +2568,7 @@ describe("Feature A: explicit suspension detection (isSuspended)", () => {
       events: { GO: z.object({}) },
       // Machine-carried predicate would NEVER fire (wrong state) — proves the
       // host option below wins.
-      isSuspended: (snapshot) => {
+      isIdle: (snapshot) => {
         machineSeen.push(JSON.stringify(snapshot.value));
         return snapshot.matches("done");
       },
@@ -2519,7 +2585,7 @@ describe("Feature A: explicit suspension detection (isSuspended)", () => {
     const seen: string[] = [];
     const result = await runAgent(machine, {
       input: {},
-      isSuspended: (snapshot) => {
+      isIdle: (snapshot) => {
         seen.push(JSON.stringify(snapshot.value));
         return snapshot.matches("paused");
       },
@@ -2541,7 +2607,7 @@ describe("Feature A: explicit suspension detection (isSuspended)", () => {
       input: z.object({}),
       output: z.object({}),
       events: { GO: z.object({}) },
-      isSuspended: (snapshot) => snapshot.matches("paused"),
+      isIdle: (snapshot) => snapshot.matches("paused"),
       requests: {
         noop: {
           schemas: { input: z.object({}), output: z.string() },
@@ -2655,22 +2721,17 @@ describe("Feature B: illegal resume event throws", () => {
     expect(err.acceptedTypes.slice().sort()).toEqual(["APPROVE", "REJECT", "SUBMIT"]);
   });
 
-  test("onIllegalResumeEvent: 'ignore' restores the older silent-drop behavior", async () => {
+  test("an illegal resume event always rejects (there is no opt-out)", async () => {
     const first = await runAgent(machine, { input: {}, executors: { generateText } });
     if (first.status !== "idle") throw new Error("expected idle");
 
-    const second = await runAgent(machine, {
-      snapshot: first.snapshot,
-      event: { type: "NOPE" } as never,
-      onIllegalResumeEvent: "ignore",
-      executors: {
-        generateText,
-      },
-    });
-
-    // No throw: the event is silently dropped and the run settles idle again.
-    expect(second.status).toBe("idle");
-    expect(second.status === "idle" ? second.snapshot.value : undefined).toBe("reviewing");
+    await expect(
+      runAgent(machine, {
+        snapshot: first.snapshot,
+        event: { type: "NOPE" } as never,
+        executors: { generateText },
+      }),
+    ).rejects.toBeInstanceOf(AgentIllegalResumeEventError);
   });
 
   test("a type-legal event a guard rejects does not throw (settles per normal semantics)", async () => {
@@ -3326,7 +3387,7 @@ describe("machine version prop (createMachine({ version }))", () => {
       input: z.object({}),
       output: z.object({}),
       events: { GO: {} },
-      isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+      isIdle: (snapshot) => snapshot.hasTag("waiting"),
     });
     return agentSetup.createMachine({
       version,
@@ -3471,11 +3532,23 @@ describe("snapshot version stamping", () => {
     expect(caught?.to).toBe(getMachineStructuralHash(v2));
   });
 
-  test("machineVersion override is respected on stamp and mismatch", async () => {
-    const machine = buildMachine();
-    const idle = await runAgent(machine, {
+  // The machine's own XState `version` is the single source of truth: it is
+  // what gets stamped, and what a resume is checked against.
+  const buildTaggedMachine = (version: string) =>
+    setupAgent({ schemas: versionSchemas() }).createMachine({
+      id: "versioned",
+      version,
+      context: () => ({ n: 0 }),
+      initial: "waiting",
+      states: {
+        waiting: { on: { GO: { target: "done" } } },
+        done: { type: "final", output: ({ context }) => ({ n: context.n }) },
+      },
+    });
+
+  test("the machine's declared version is stamped, and a bump is a mismatch", async () => {
+    const idle = await runAgent(buildTaggedMachine("v1"), {
       input: {},
-      machineVersion: "v1",
       executors: { generateText },
     });
     if (idle.status !== "idle") throw new Error("expected idle");
@@ -3483,10 +3556,9 @@ describe("snapshot version stamping", () => {
 
     let caught: AgentSnapshotVersionMismatchError | undefined;
     try {
-      await runAgent(machine, {
+      await runAgent(buildTaggedMachine("v2"), {
         snapshot: idle.snapshot,
         event: { type: "GO" },
-        machineVersion: "v2",
         executors: {
           generateText,
         },
@@ -3499,19 +3571,16 @@ describe("snapshot version stamping", () => {
   });
 
   test("migrateSnapshot is called with correct args and its result is used", async () => {
-    const machine = buildMachine();
-    const idle = await runAgent(machine, {
+    const idle = await runAgent(buildTaggedMachine("v1"), {
       input: {},
-      machineVersion: "v1",
       executors: { generateText },
     });
     if (idle.status !== "idle") throw new Error("expected idle");
 
     const calls: Array<{ from: string; to: string }> = [];
-    const done = await runAgent(machine, {
+    const done = await runAgent(buildTaggedMachine("v2"), {
       snapshot: idle.snapshot,
       event: { type: "GO" },
-      machineVersion: "v2",
       migrateSnapshot: (snapshot, info) => {
         calls.push(info);
         return snapshot;
@@ -3525,10 +3594,8 @@ describe("snapshot version stamping", () => {
   });
 
   test("warn mode proceeds", async () => {
-    const machine = buildMachine();
-    const idle = await runAgent(machine, {
+    const idle = await runAgent(buildTaggedMachine("v1"), {
       input: {},
-      machineVersion: "v1",
       executors: { generateText },
     });
     if (idle.status !== "idle") throw new Error("expected idle");
@@ -3538,10 +3605,9 @@ describe("snapshot version stamping", () => {
     console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
     let done;
     try {
-      done = await runAgent(machine, {
+      done = await runAgent(buildTaggedMachine("v2"), {
         snapshot: idle.snapshot,
         event: { type: "GO" },
-        machineVersion: "v2",
         onVersionMismatch: "warn",
         executors: {
           generateText,

--- a/src/run-agent.ts
+++ b/src/run-agent.ts
@@ -66,7 +66,7 @@ import {
 import type { AgentRequest, AgentStepRequest } from "./steps.js";
 import {
   executorBoundLogics,
-  getMachineSuspensionPredicate,
+  getMachineIdlePredicate,
   getRegisteredAgentExecutionOptions,
   isUnboundPlaceholder,
 } from "./internal/registry.js";
@@ -96,8 +96,7 @@ import type { AgentLogEntry, JsonValue } from "./event-log-store.js";
  * {@link getAcceptedEvents}). A programmer/integration error, in the same
  * class as runAgent's bind-time throws — it throws rather than settling an
  * `error` result. A type-legal event a guard rejects is NOT this error (the
- * machine simply takes no transition). Opt out with
- * {@link RunAgentOptions.onIllegalResumeEvent} `'ignore'`.
+ * machine simply takes no transition). Always enforced; there is no opt-out.
  */
 export class AgentIllegalResumeEventError extends AgentError {
   readonly eventType: string;
@@ -173,8 +172,8 @@ export interface AgentUserInputExecutor {
 
 /**
  * The run's machine identity, stamped onto every settled snapshot's `agentMeta`.
- * `machineId` is the machine's `id`; `version` is
- * {@link RunAgentOptions.machineVersion} or the
+ * `machineId` is the machine's `id`; `version` is the machine's own
+ * `version` (XState's `createMachine({ version })`) or, when unversioned, the
  * {@link getMachineStructuralHash} of the machine. Trace events and the
  * `onMessage` info arg carry the same identity flattened, as
  * `machineId`/`machineVersion`.
@@ -192,7 +191,7 @@ export interface AgentRunMeta {
 export interface AgentMessageInfo {
   runId: string;
   machineId: string;
-  /** {@link RunAgentOptions.machineVersion}, else the machine's own `version`, else its structural hash. */
+  /** The machine's own `version`, else its structural hash. */
   machineVersion: string;
 }
 
@@ -212,7 +211,7 @@ export type AgentTraceEvent<TMachine extends AnyStateMachine = AnyStateMachine> 
   seq: number;
   timestamp: string;
   machineId: string;
-  /** {@link RunAgentOptions.machineVersion}, else the machine's own `version`, else its structural hash. */
+  /** The machine's own `version`, else its structural hash. */
   machineVersion: string;
 } & (
   | {
@@ -409,7 +408,7 @@ function toJsonValue(value: unknown, ancestors: readonly object[]): JsonValue | 
  * in a JSONL file). Live values are sanitized rather than trusted:
  *
  * - Snapshots (`run.start`, `machine.transition`, `run.end`) go through the
- *   same JSON round-trip as {@link persistSnapshot}, so what lands on disk is
+ *   same JSON round-trip as `machine.getPersistedSnapshot(...)`, so what lands on disk is
  *   what a resume would see.
  * - `request.end`'s `raw` (a provider SDK object, frequently cyclic) is DROPPED
  *   unless `includeRaw` is set, in which case it is sanitized like everything
@@ -508,29 +507,12 @@ export interface RunAgentOptions<TMachine extends AnyStateMachine> {
    * (or an event-log store) and resume from the log alone.
    */
   events?: readonly AgentLogEntry[];
-  /**
-   * How to handle a resume `event` the restored state cannot accept (a
-   * type-level check via {@link getAcceptedEvents}, only applied when resuming
-   * from a `snapshot`). `'throw'` (default) throws {@link AgentIllegalResumeEventError}
-   * before delivering the event; `'ignore'` restores the older silent behavior
-   * (the event is sent and the machine drops it). A type-legal event a guard
-   * rejects is never an illegal resume event.
-   */
-  onIllegalResumeEvent?: "throw" | "ignore";
-
   // version stamping
   /**
-   * The version stamped onto every settled snapshot's `agentMeta` and compared
-   * against an incoming snapshot's stamp on resume. Defaults to the machine's
-   * own `version` (XState's `createMachine({ version })` prop) when set, else
-   * {@link getMachineStructuralHash} of the machine (a structural fingerprint
-   * that changes on any edit). Set `version` on the machine — or this option —
-   * to control migration boundaries yourself.
-   */
-  machineVersion?: string;
-  /**
    * How to handle a resume `snapshot` whose stamped `agentMeta.version` differs
-   * from the current machine's version. `'throw'` (default) throws
+   * from the current machine's `version` (XState's `createMachine({ version })`
+   * prop — the single source of truth; an unversioned machine falls back to its
+   * {@link getMachineStructuralHash}). `'throw'` (default) throws
    * {@link AgentSnapshotVersionMismatchError} with `from`/`to`; `'warn'`
    * `console.warn`s once and proceeds; `'ignore'` proceeds silently. Ignored
    * when {@link migrateSnapshot} is provided (that runs instead), and never
@@ -542,6 +524,12 @@ export interface RunAgentOptions<TMachine extends AnyStateMachine> {
    * version mismatches the current machine's: receives the incoming snapshot
    * and `{ from, to }`, and its return value is used as the snapshot to resume
    * from. A throw propagates.
+   *
+   * Prefer XState's own `createMachine({ version, migrate })` hook when the
+   * migration belongs to the machine: a machine that declares `migrate` is left
+   * to xstate, and runAgent neither throws nor rewrites the snapshot's version
+   * before restore. This option stays for host-owned migrations (a machine you
+   * do not control, or a migration that needs run-scoped context).
    */
   migrateSnapshot?: (
     snapshot: Snapshot<unknown>,
@@ -567,7 +555,7 @@ export interface RunAgentOptions<TMachine extends AnyStateMachine> {
    * Host override for detecting a snapshot that is an INTENTIONAL wait for an
    * external event — the deterministic replacement for the timing heuristic
    * runAgent uses to settle idle. Resolution order: this option (host override)
-   * → the machine-carried predicate declared via `setupAgent({ isSuspended })`
+   * → the machine-carried predicate declared via `setupAgent({ isIdle })`
    * → the timing heuristic (when neither is present). When the resolved
    * predicate returns true and nothing is in flight (no live requests/
    * invokes; the `agent.userInput` placeholder exemption still applies), runAgent
@@ -577,7 +565,7 @@ export interface RunAgentOptions<TMachine extends AnyStateMachine> {
    * exactly as before (with a one-time dev warning suggesting a predicate).
    * Declare your own signal, e.g. `(s) => s.hasTag('awaiting-review')`.
    */
-  isSuspended?: (snapshot: AnyMachineSnapshot) => boolean;
+  isIdle?: (snapshot: AnyMachineSnapshot) => boolean;
 
   // interpretation — the override to the default invoke-driven contract
   /**
@@ -589,22 +577,15 @@ export interface RunAgentOptions<TMachine extends AnyStateMachine> {
    * tags, a lookup table keyed by state value, wherever you keep them. Return
    * nothing to settle idle (human-wait states).
    *
-   * There is no blessed source for the prompts — this is a recipe seam.
-   * Prompts-in-descriptions, copy-paste and adapt:
+   * There is no blessed source for the prompts — this is a recipe seam. The
+   * shipped prompts-in-descriptions recipe is {@link getSnapshotRequests}:
    *
    * ```ts
-   * getRequests: (snapshot) =>
-   *   snapshot._nodes
-   *     .filter((node) => node.description && !node.tags.includes('waiting'))
-   *     .map((node) => ({
-   *       model: 'writer',
-   *       prompt: node.description!,
-   *       kind: node.tags.includes('decision') ? 'decision' : 'text',
-   *       // single-outcome states advance deterministically; else `decide`
-   *       onDone: node.ownEvents.length === 1 ? { type: node.ownEvents[0] } : undefined,
-   *       allowedEvents: node.ownEvents,
-   *     })),
+   * getRequests: (snapshot) => getSnapshotRequests(snapshot, { model: 'writer' }),
    * ```
+   *
+   * Reach for {@link getSnapshotNodes} when you want to build requests some
+   * other way — between them, host code never touches `snapshot._nodes`.
    *
    * Each request runs per {@link AgentStateRequest.kind}, appends to the
    * run's message log (see {@link RunAgentOptions.messages}), and advances
@@ -705,10 +686,144 @@ export interface RunAgentOptions<TMachine extends AnyStateMachine> {
     | { next?: (inspectionEvent: InspectionEvent) => void };
 
   // control
-  /** Caps the number of model/decision calls this run may make (each retry of a decision counts separately); exceeding it settles `{ status: 'error', cause: 'max-model-calls' }`. Default 100. */
+  /**
+   * Caps the number of model/decision calls this run may make (each retry of a
+   * decision counts separately). Default 100. The overrun is thrown into the
+   * invoke that would have made the call, as an
+   * {@link AgentMaxModelCallsExceededError} with `code: 'max-model-calls'` — so
+   * an `onError` can branch on it and route to a degraded state. Unhandled, it
+   * settles `{ status: 'error', cause: 'max-model-calls' }`.
+   */
   maxModelCalls?: number; // default 100
   /** Aborts the run; settles `{ status: 'error', cause: 'aborted' }` with `signal.reason` as the error. */
   signal?: AbortSignal;
+}
+
+// ─── getSnapshotRequests (the getRequests recipe, without _nodes) ───
+
+/**
+ * One active state node of a snapshot, as {@link getSnapshotRequests} and
+ * {@link getSnapshotNodes} surface it: the prompt-bearing `description`, the
+ * `tags` a recipe branches on, the state `meta`, and `ownEvents` (the event
+ * types this node itself declares transitions for). The shape hosts used to
+ * reach for through the private `snapshot._nodes` array.
+ */
+export interface AgentSnapshotNode {
+  /** The node's full id (e.g. `writer.drafting`). */
+  id: string;
+  /** The node's own key (e.g. `drafting`). */
+  key: string;
+  /** The node's `description` — the prompt, in the prompts-in-descriptions recipe. */
+  description?: string;
+  tags: string[];
+  meta?: unknown;
+  /** Event types this node declares transitions for (xstate's `ownEvents`). */
+  ownEvents: string[];
+  /** True when the node has no child states. */
+  leaf: boolean;
+}
+
+// TODO(xstate): use snapshot.nodes when public — this is the ONE place the
+// private `_nodes` array is read, so host code never has to.
+function snapshotNodes(snapshot: AnyMachineSnapshot): AgentSnapshotNode[] {
+  const nodes = (snapshot as unknown as { _nodes?: readonly unknown[] })._nodes ?? [];
+  return nodes.map((raw) => {
+    const node = raw as {
+      id?: string;
+      key?: string;
+      description?: string;
+      tags?: readonly string[];
+      meta?: unknown;
+      ownEvents?: readonly string[];
+      states?: Record<string, unknown>;
+    };
+    return {
+      id: node.id ?? "",
+      key: node.key ?? "",
+      ...(node.description !== undefined ? { description: node.description } : {}),
+      tags: [...(node.tags ?? [])],
+      ...(node.meta !== undefined ? { meta: node.meta } : {}),
+      ownEvents: [...(node.ownEvents ?? [])],
+      leaf: Object.keys(node.states ?? {}).length === 0,
+    };
+  });
+}
+
+/**
+ * The active state nodes of a snapshot, as plain {@link AgentSnapshotNode}
+ * descriptors. The escape hatch under {@link getSnapshotRequests}: use it when
+ * your `getRequests` hook needs to build requests some other way, so host code
+ * never touches xstate's private `snapshot._nodes`.
+ */
+export function getSnapshotNodes(snapshot: AnyMachineSnapshot): AgentSnapshotNode[] {
+  return snapshotNodes(snapshot);
+}
+
+/** Options for {@link getSnapshotRequests}. */
+export interface GetSnapshotRequestsOptions {
+  /** Executor model name every produced request carries. */
+  model: string;
+  /**
+   * Which active nodes produce a request. Default: every node with a
+   * `description` that is NOT tagged `'waiting'` (a human-wait state settles
+   * idle instead).
+   */
+  filter?: (node: AgentSnapshotNode) => boolean;
+  /**
+   * Shapes (or drops, by returning `undefined`) each node's request before it
+   * is returned — set `system`, `allowedEvents`, a custom `onDone`, …
+   */
+  map?: (request: AgentStateRequest, node: AgentSnapshotNode) => AgentStateRequest | undefined;
+}
+
+/**
+ * Builds the {@link AgentStateRequest}s for a snapshot straight from its active
+ * state nodes — the prompts-in-descriptions recipe as a function, so a
+ * {@link RunAgentOptions.getRequests} hook is one line and never reaches into
+ * xstate's private `snapshot._nodes`:
+ *
+ * ```ts
+ * runAgent(machine, {
+ *   executors,
+ *   getRequests: (snapshot) => getSnapshotRequests(snapshot, { model: 'writer' }),
+ * });
+ * ```
+ *
+ * Each described active node becomes one request: `prompt` from the node's
+ * `description`, `kind: 'decision'` when it is tagged `'decision'`, `system`
+ * from `meta.role` when present, `allowedEvents` scoped to the node's own
+ * events, and an explicit `onDone` when the node has exactly one own event
+ * (single-outcome states advance deterministically; anything else falls
+ * through to a `decide` call). Nodes tagged `'waiting'` produce nothing, so the
+ * run settles idle for a human. Override any of it with `filter`/`map`.
+ */
+export function getSnapshotRequests(
+  snapshot: AnyMachineSnapshot,
+  options: GetSnapshotRequestsOptions,
+): AgentStateRequest[] {
+  const filter =
+    options.filter ??
+    ((node: AgentSnapshotNode) => !!node.description && !node.tags.includes("waiting"));
+  const requests: AgentStateRequest[] = [];
+  for (const node of snapshotNodes(snapshot)) {
+    if (!filter(node)) {
+      continue;
+    }
+    const system = (node.meta as { role?: string } | undefined)?.role;
+    const request: AgentStateRequest = {
+      model: options.model,
+      prompt: node.description ?? "",
+      kind: node.tags.includes("decision") ? "decision" : "text",
+      ...(system !== undefined ? { system } : {}),
+      ...(node.ownEvents.length > 0 ? { allowedEvents: node.ownEvents } : {}),
+      ...(node.ownEvents.length === 1 ? { onDone: { type: node.ownEvents[0]! } } : {}),
+    };
+    const mapped = options.map ? options.map(request, node) : request;
+    if (mapped) {
+      requests.push(mapped);
+    }
+  }
+  return requests;
 }
 
 /**
@@ -795,13 +910,34 @@ export type RunAgentErrorCause =
   | "machine"
   | "stopped";
 
-// Thrown internally by consumeModelCall() past the budget; caught by runAgent's settle loop to produce a 'max-model-calls' error result.
 let nextRunAgentTraceId = 1;
 
-class AgentMaxModelCallsExceededError extends AgentError {
-  constructor() {
-    super("max-model-calls-exceeded", "runAgent exceeded maxModelCalls.");
+/**
+ * Thrown into the invoke that would have made the call once
+ * {@link RunAgentOptions.maxModelCalls} is spent. It reaches the machine
+ * through the normal error channel, so an invoke's `onError` can branch on it
+ * (`error.code === 'max-model-calls'`, the same string the settled result's
+ * `cause` uses) and route to a degraded/finish state instead of failing the
+ * run. Unhandled, it settles `{ status: 'error', cause: 'max-model-calls' }`.
+ *
+ * ```ts
+ * onError: [
+ *   { guard: ({ event }) => event.error?.code === 'max-model-calls', target: 'budgetSpent' },
+ *   { target: 'failed' },
+ * ]
+ * ```
+ */
+export class AgentMaxModelCallsExceededError extends AgentError {
+  /** The budget that was exceeded (`options.maxModelCalls`). */
+  readonly maxModelCalls: number;
+  constructor(maxModelCalls: number) {
+    super(
+      "max-model-calls",
+      `runAgent exceeded maxModelCalls (${maxModelCalls}). Raise the budget, or handle it ` +
+        `in the invoke's onError (error.code === 'max-model-calls').`,
+    );
     this.name = "AgentMaxModelCallsExceededError";
+    this.maxModelCalls = maxModelCalls;
   }
 }
 
@@ -865,7 +1001,7 @@ function collectConfiguredInvokeSrcs(
  * walk into invoked child machines (their internal agent requests are opaque
  * to the parent-level source walk otherwise).
  */
-function isStateMachine(logic: unknown): logic is AnyStateMachine {
+export function isStateMachineLogic(logic: unknown): logic is AnyStateMachine {
   return (
     !!logic &&
     typeof logic === "object" &&
@@ -934,7 +1070,7 @@ function assertMachineBindable(
   for (const { stateName, src } of invokes) {
     if (typeof src !== "string") {
       // Direct-object src.
-      if (isStateMachine(src)) {
+      if (isStateMachineLogic(src)) {
         assertChildMachineBindable(src, src, stateName, executors, ctx);
         continue;
       }
@@ -964,7 +1100,7 @@ function assertMachineBindable(
       );
     }
 
-    if (isStateMachine(logic)) {
+    if (isStateMachineLogic(logic)) {
       assertChildMachineBindable(logic, src, stateName, executors, ctx);
       continue;
     }
@@ -1145,19 +1281,17 @@ interface RunAgentBindContext {
 }
 
 /**
- * True when the snapshot's active states declare a transition for the reserved
- * `'@agent.usage'` type EXPLICITLY. A catch-all `on: { '*': … }` deliberately
- * does not count: a wildcard is a machine's own event vocabulary, not an
- * opt-in to a library-reserved event, and `snapshot.can(event)` alone cannot
- * tell the two apart (it answers "would this event be taken?", which a
- * wildcard makes true for everything). Gating delivery on the explicit
- * declaration is what keeps `@agent.usage` opt-in by construction — and keeps
- * a wildcard machine's context and event log byte-identical to a run without
- * the feature. @internal
+ * True when the snapshot's active states declare a transition that would
+ * receive the reserved `'@agent.usage'` type — an explicit `on: { '@agent.usage'
+ * }` OR a catch-all `on: { '*': … }`. Plain XState semantics apply unmodified:
+ * a wildcard matches every event delivered to the machine, reserved ones
+ * included. (The MODEL-facing side stays closed: `getAcceptedEvents` drops
+ * `@agent.*` before any `allowedEvents` matching, so a wildcard never offers
+ * the reserved event as a decision candidate.) @internal
  */
 function declaresUsageTransition(snapshot: AnyMachineSnapshot): boolean {
   return getNextTransitions(snapshot).some(
-    (transition) => transition.eventType === AGENT_USAGE_EVENT_TYPE,
+    (transition) => transition.eventType === AGENT_USAGE_EVENT_TYPE || transition.eventType === "*",
   );
 }
 
@@ -1342,14 +1476,21 @@ function createCountingDecide(
   runCtx: RunAgentBindContext,
   self: BoundActorSelf | undefined,
 ): AgentDecisionExecutor {
-  return async (attemptRequest) => {
+  return async (attemptRequest, info) => {
     runCtx.consumeModelCall();
     runCtx.emitTrace?.({ type: "request.start", request: attemptRequest }, self);
     try {
+      const { id } = selfIdAndSrc(self);
       // `runId` rides on the request like `signal` does: host-injected
-      // correlation, never serialized into machine state.
+      // correlation, never serialized into machine state. It also rides on the
+      // `info` second argument, where generateText/streamText carry it.
       const result = await runCtx.decide!(
         runCtx.runId !== undefined ? { ...attemptRequest, runId: runCtx.runId } : attemptRequest,
+        {
+          ...info,
+          ...(runCtx.runId !== undefined ? { runId: runCtx.runId } : {}),
+          ...(info?.requestId === undefined && id !== "" ? { requestId: id } : {}),
+        },
       );
       const usage = getCallUsage(result);
       if (usage) {
@@ -1436,12 +1577,16 @@ function bindDecisionLogic(logic: DecisionLogic, runCtx: RunAgentBindContext): D
 
       const request: AgentDecisionRequest = { ...logic.request(input as never), id, events };
 
-      const chosen = await resolveDecision(request, createCountingDecide(runCtx, self), {
-        maxRetries: logic.maxRetries,
-        signal,
-        canTake: (event) =>
-          actorRef ? (actorRef.getSnapshot() as AnyMachineSnapshot).can(event) : true,
-      });
+      const chosen = await resolveDecision(
+        request,
+        { decide: createCountingDecide(runCtx, self) },
+        {
+          maxRetries: logic.maxRetries,
+          signal,
+          canTake: (event) =>
+            actorRef ? (actorRef.getSnapshot() as AnyMachineSnapshot).can(event) : true,
+        },
+      );
 
       // Auto-deliver: send the chosen event to the invoking actor, then
       // complete with it as output. The delivered event's transition typically
@@ -1558,7 +1703,7 @@ function provideTraceSink(onTrace?: (event: AgentTraceEvent) => void): TraceSink
 }
 
 /** Options threaded into the `provideExecutors` bind helpers. @internal */
-interface ProvideBindOptions {
+export interface ProvideBindOptions {
   onChunk?: (chunk: string) => void;
   onTrace?: (event: AgentTraceEvent) => void;
 }
@@ -1612,9 +1757,9 @@ function provideBindContext(
  * under a live `createActor` tree) on the `provideExecutors` path.
  *
  * Gating is identical on both: the target snapshot must be active, must declare
- * an `'@agent.usage'` transition EXPLICITLY (see {@link declaresUsageTransition}
- * — a catch-all `on: { '*' }` is not an opt-in), and must be able to take the
- * event. `onDropped` is the run path's straggler gate: it returns `true` for a
+ * an `'@agent.usage'` transition — explicitly, or through a catch-all
+ * `on: { '*' }` (see {@link declaresUsageTransition}) — and must be able to
+ * take the event. `onDropped` is the run path's straggler gate: it returns `true` for a
  * call that settled after the cycle resolved, which drops the event (traced as
  * `usage.dropped`) rather than delivering it. Uncontrolled mode has no cycle to
  * settle, so it passes no gate and has no dropped stragglers.
@@ -1675,6 +1820,25 @@ export function bindDecisionForProvide(
   options: ProvideBindOptions,
 ): DecisionLogic {
   return bindDecisionLogic(logic, provideBindContext(machine, executors, options));
+}
+
+/**
+ * Recursively binds an invoked child state machine for {@link provideExecutors},
+ * with the same semantics `runAgent` applies ({@link rebindChildMachine}):
+ * string-keyed text/decision sources at any depth inherit the host executors,
+ * a source that carries its own executor is left alone, and a cycle is
+ * returned as-is. Each machine in the tree is bound with its own registered
+ * `setupAgent` schemas. Returns the original machine when nothing needed
+ * wrapping. @internal
+ */
+export function bindChildMachineForProvide(
+  childMachine: AnyStateMachine,
+  executors: Partial<AgentRequestExecutors>,
+  options: ProvideBindOptions,
+  visited: Set<AnyStateMachine>,
+): AnyStateMachine {
+  const ctxFor = (target: AnyStateMachine) => provideBindContext(target, executors, options);
+  return rebindChildMachine(childMachine, ctxFor(childMachine), visited, ctxFor);
 }
 
 /**
@@ -1741,11 +1905,20 @@ function rebindChildMachine(
   childMachine: AnyStateMachine,
   runCtx: RunAgentBindContext,
   visited: Set<AnyStateMachine>,
+  /**
+   * Optional per-machine bind-context factory. `runAgent` shares ONE run-scoped
+   * context at every depth (one budget, one trace envelope, one root actor), so
+   * it omits this. `provideExecutors` passes it so each machine in the tree is
+   * bound with its OWN registered `setupAgent` schemas — a child decision must
+   * validate against the child's event schemas, not the root's. @internal
+   */
+  ctxFor?: (machine: AnyStateMachine) => RunAgentBindContext,
 ): AnyStateMachine {
   if (visited.has(childMachine)) {
     return childMachine;
   }
   const childVisited = new Set([...visited, childMachine]);
+  runCtx = ctxFor ? ctxFor(childMachine) : runCtx;
   const sources = childMachine.sources.actors as Record<string, AnyActorLogic>;
   const wrapped: Record<string, AnyActorLogic> = {};
 
@@ -1762,8 +1935,8 @@ function rebindChildMachine(
       }
       continue;
     }
-    if (isStateMachine(logic)) {
-      const rebound = rebindChildMachine(logic, runCtx, childVisited);
+    if (isStateMachineLogic(logic)) {
+      const rebound = rebindChildMachine(logic, runCtx, childVisited, ctxFor);
       if (rebound !== logic) {
         wrapped[key] = rebound;
       }
@@ -1902,13 +2075,11 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   // enumerable `agentMeta` field so it survives JSON persist/resume, and an
   // incoming snapshot's stamp is checked against this version on resume.
   const machineId = (machine.config as { id?: string }).id ?? machine.id ?? "(machine)";
-  // Resolution order: explicit option → the machine's own `version` (XState's
-  // standard `createMachine({ version })` prop, `.provide`-surviving) → the
-  // structural hash.
+  // The machine's own `version` (XState's standard `createMachine({ version })`
+  // prop, `.provide`-surviving) is the single source of truth; an unversioned
+  // machine falls back to the structural hash.
   const machineVersion =
-    options.machineVersion ??
-    (machine as { version?: string }).version ??
-    getMachineStructuralHash(machine);
+    (machine as { version?: string }).version ?? getMachineStructuralHash(machine);
   const agentMeta: AgentRunMeta = { machineId, version: machineVersion };
 
   // The run's single observation dispatch point: every trace payload in this
@@ -1934,13 +2105,13 @@ function createAgentSession<TMachine extends AnyStateMachine>(
 
   const consumeModelCall = () => {
     if (budgetExceeded) {
-      throw new AgentMaxModelCallsExceededError();
+      throw new AgentMaxModelCallsExceededError(maxModelCalls);
     }
     // Count only calls the budget actually admits, so `usage.modelCalls`
     // reports calls MADE (the rejected attempt never reaches an executor).
     if (modelCallCount + 1 > maxModelCalls) {
       budgetExceeded = true;
-      throw new AgentMaxModelCallsExceededError();
+      throw new AgentMaxModelCallsExceededError(maxModelCalls);
     }
     modelCallCount += 1;
   };
@@ -1955,12 +2126,12 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   // Reserved `@agent.usage` delivery — the seam that puts a settled call's
   // tokens in reach of the machine's own context and guards (see
   // AGENT_USAGE_EVENT_TYPE). Opt-in BY CONSTRUCTION: sent only when the live
-  // root snapshot DECLARES the reserved type explicitly (machine-level `on`
-  // catches every call; a state-scoped one only catches calls made while that
-  // state is active). A catch-all `on: { '*': … }` does NOT count as opt-in —
-  // see declaresUsageTransition. A machine without an explicit declaration
-  // gets no extra transition, no `machine.transition` trace, and no extra
-  // event-log entry — existing runs are byte-identical.
+  // root snapshot DECLARES a transition that receives the reserved type
+  // (machine-level `on` catches every call; a state-scoped one only catches
+  // calls made while that state is active). A catch-all `on: { '*': … }` DOES
+  // receive it, per plain XState wildcard semantics — see
+  // declaresUsageTransition. A machine that declares neither gets no extra
+  // transition, no `machine.transition` trace, and no extra event-log entry.
   //
   // Root actor only: it is the actor whose external inputs the run journals
   // (see the inspect handler), so delivering here is what makes the folded
@@ -2102,7 +2273,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
       continue;
     }
 
-    if (isStateMachine(logic)) {
+    if (isStateMachineLogic(logic)) {
       // An invoked child machine (string-keyed): recursively rebind its own
       // agent sources with the same host-backed wrappers, so requests at any
       // depth inherit runAgent's executors. Skipped if nothing needed wrapping.
@@ -2121,11 +2292,11 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   }) as TMachine;
 
   // Resolution order: host override → machine-carried predicate
-  // (`setupAgent({ isSuspended })`, read off the original machine so it survives
+  // (`setupAgent({ isIdle })`, read off the original machine so it survives
   // the provide/rebind above) → the timing heuristic (`() => false` here — the
   // inspect handler falls through to `scheduleIdleCheck`).
-  const declaredSuspensionPredicate = options.isSuspended ?? getMachineSuspensionPredicate(machine);
-  const isSuspended = declaredSuspensionPredicate ?? (() => false);
+  const declaredIdlePredicate = options.isIdle ?? getMachineIdlePredicate(machine);
+  const isIdle = declaredIdlePredicate ?? (() => false);
 
   // Version stamping (§ item 2): when resuming, compare the incoming snapshot's
   // stamped version against this machine's. A mismatch runs `migrateSnapshot`
@@ -2137,11 +2308,23 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   // policy: after this gate, the snapshot's XState-level `version` field is
   // aligned to the machine's (see below) so `restoreSnapshot`'s own
   // mismatch throw never double-fires.
+  // xstate ships its own migration hook (`createMachine({ version, migrate })`)
+  // and applies it during restore. When the machine declares one, that hook
+  // owns version mismatches: runAgent neither throws nor aligns the snapshot's
+  // `version` field (see below), so xstate's `migrate` sees the real
+  // `fromVersion`. An explicit `options.migrateSnapshot` still wins (a
+  // host-owned migration is the more specific instruction).
+  const machineDeclaresMigrate =
+    typeof (machine.config as { migrate?: unknown }).migrate === "function";
   let effectiveSnapshot = options.snapshot;
   if (effectiveSnapshot !== undefined) {
     const incoming = (effectiveSnapshot as { agentMeta?: { version?: string } }).agentMeta;
     const from = incoming?.version ?? (effectiveSnapshot as { version?: string }).version;
-    if (from !== undefined && from !== machineVersion) {
+    if (
+      from !== undefined &&
+      from !== machineVersion &&
+      !(machineDeclaresMigrate && !options.migrateSnapshot)
+    ) {
       const info = { from, to: machineVersion };
       if (options.migrateSnapshot) {
         effectiveSnapshot = options.migrateSnapshot(effectiveSnapshot, info);
@@ -2197,6 +2380,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   // caller's snapshot object is never mutated.
   const machineOwnVersion = (machine as { version?: string }).version;
   if (
+    !machineDeclaresMigrate &&
     effectiveSnapshot !== undefined &&
     (effectiveSnapshot as { version?: string }).version !== machineOwnVersion
   ) {
@@ -2242,13 +2426,8 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   // here (before the actor starts, like the bind-time throws) against the
   // type-level legal set of the restored snapshot — a live-but-unstarted actor
   // exposes it via getAcceptedEvents. A guard-rejected-but-type-legal event
-  // still appears here, so it is never treated as illegal. Opt out with
-  // onIllegalResumeEvent: 'ignore' (the older silent behavior).
-  if (
-    effectiveSnapshot !== undefined &&
-    options.event !== undefined &&
-    (options.onIllegalResumeEvent ?? "throw") === "throw"
-  ) {
+  // still appears here, so it is never treated as illegal. Always enforced.
+  if (effectiveSnapshot !== undefined && options.event !== undefined) {
     const restoredSnapshot = createActor(boundMachine, {
       snapshot: effectiveSnapshot,
     } as never).getSnapshot() as AnyMachineSnapshot;
@@ -2302,7 +2481,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   let actor: ReturnType<typeof createActor<TMachine>>;
   // True only during the resumed actor's initial (restore) transition, while
   // an `event` is still pending delivery. The restored state may itself be a
-  // suspended/idle snapshot; without this guard, Feature A's immediate settle
+  // idle snapshot; without this guard, Feature A's immediate settle
   // would fire during `start()` and settle idle BEFORE the resume event is
   // sent. Cleared right before `actor.send(options.event)`.
   let deliveringResumeEvent = options.event !== undefined;
@@ -2467,7 +2646,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
       .finally(() => {
         interpreting = false;
         // A transition observed DURING this pass (e.g. our own send while
-        // the machine reads as suspended) saw `interpreting` and skipped
+        // the machine reads as idle) saw `interpreting` and skipped
         // both settling and starting a new pass — re-evaluate now so the
         // run always makes progress (settle, or the next pass).
         if (!settled) {
@@ -2480,7 +2659,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   // Fallback for untagged machines: defer one macrotask so in-flight work
   // that starts synchronously with a transition registers first, then settle
   // idle if the snapshot is at rest. Feature A short-circuits this for
-  // detector-positive (suspended) snapshots — see the inspect handler.
+  // detector-positive (idle) snapshots — see the inspect handler.
   const scheduleIdleCheck = () => {
     if (idleTimer !== undefined) {
       clearTimeout(idleTimer);
@@ -2494,7 +2673,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
       if (isIdleSnapshot(current, { ignoreUserInputChildren: userInputIsPlaceholder })) {
         if (!maybeInterpret(current)) {
           if (
-            !declaredSuspensionPredicate &&
+            !declaredIdlePredicate &&
             current.status === "active" &&
             !warnedHeuristicIdle &&
             process.env.NODE_ENV !== "production"
@@ -2502,9 +2681,9 @@ function createAgentSession<TMachine extends AnyStateMachine>(
             warnedHeuristicIdle = true;
             console.warn(
               `[@statelyai/agent] runAgent settled idle via the timing heuristic (no ` +
-                `suspension predicate declared). This is best-effort; for deterministic ` +
-                `idle detection, declare setupAgent({ isSuspended }) or pass ` +
-                `runAgent(machine, { isSuspended }), e.g. (s) => s.hasTag('waiting').`,
+                `idle predicate declared). This is best-effort; for deterministic ` +
+                `idle detection, declare setupAgent({ isIdle }) or pass ` +
+                `runAgent(machine, { isIdle }), e.g. (s) => s.hasTag('waiting').`,
             );
           }
           settleIdle(current);
@@ -2603,14 +2782,14 @@ function createAgentSession<TMachine extends AnyStateMachine>(
       // flight settles idle immediately and deterministically — no
       // setTimeout race. `deliveringResumeEvent` suppresses this during a
       // resume's restore transition so the pending event is delivered first.
-      // Everything else (untagged machines, or a suspended snapshot with
+      // Everything else (untagged machines, or a idle snapshot with
       // sibling work still running) falls through to the timing heuristic.
       if (
         !deliveringResumeEvent &&
-        isSuspended(snapshot) &&
+        isIdle(snapshot) &&
         isIdleSnapshot(snapshot, { ignoreUserInputChildren: userInputIsPlaceholder })
       ) {
-        // Not settled synchronously: the event that reached this suspended
+        // Not settled synchronously: the event that reached this idle
         // state may have come from an invoked child mid-flush (child →
         // parent, whose handler sendTo's the child back). A sync settle
         // would persist — and, one-shot, stop — the child before its
@@ -2622,14 +2801,14 @@ function createAgentSession<TMachine extends AnyStateMachine>(
           }
           const current = actor.getSnapshot() as AnyMachineSnapshot;
           if (
-            isSuspended(current) &&
+            isIdle(current) &&
             isIdleSnapshot(current, { ignoreUserInputChildren: userInputIsPlaceholder })
           ) {
             if (!maybeInterpret(current)) {
               settleIdle(current);
             }
           } else {
-            // A drained child event started new work (or left suspension)
+            // A drained child event started new work (or left the idle state)
             // without a root transition to re-trigger idle detection — fall
             // back to the timing heuristic so the run still settles.
             scheduleIdleCheck();

--- a/src/run-agent.ts
+++ b/src/run-agent.ts
@@ -28,8 +28,8 @@ import { AgentError } from "./errors.js";
 import {
   findNonSerializableContextPaths,
   getAgentMessages,
-  getMachineStructuralHash,
   isStandardSchema,
+  resolveMachineVersion,
   validateSchemaSync,
 } from "./utils.js";
 import {
@@ -1390,8 +1390,7 @@ function bindTextLogic(logic: TextLogic, runCtx: RunAgentBindContext): TextLogic
     const executor = logic.mode === "stream" ? runCtx.streamText : runCtx.generateText;
     if (!executor) {
       throw new Error(
-        `runAgent: no '${logic.mode === "stream" ? "streamText" : "generateText"}' ` +
-          "executor provided.",
+        `No '${logic.mode === "stream" ? "streamText" : "generateText"}' ` + "executor provided.",
       );
     }
 
@@ -1543,7 +1542,7 @@ function bindDecisionLogic(logic: DecisionLogic, runCtx: RunAgentBindContext): D
   const decisionLogic = createAsyncLogic<ChosenEvent, unknown>({
     run: async ({ input, signal, self: selfArg }) => {
       if (!runCtx.decide) {
-        throw new Error("runAgent: no 'decide' executor provided.");
+        throw new Error("No 'decide' executor provided.");
       }
       const self = selfArg as BoundActorSelf | undefined;
       const { id } = selfIdAndSrc(self);
@@ -1668,7 +1667,7 @@ function rootTraceState(root: AnyActorRef): RootTraceState {
     const logic = (root as { logic?: AnyStateMachine }).logic;
     const machineId =
       (logic?.config as { id?: string } | undefined)?.id ?? logic?.id ?? "(machine)";
-    const machineVersion = logic ? getMachineStructuralHash(logic) : "";
+    const machineVersion = logic ? resolveMachineVersion(logic) : "";
     state = { runId: `run_${nextProvideRunId++}`, seq: 0, machineId, machineVersion };
     rootTraceRegistry.set(root as object, state);
   }
@@ -2078,8 +2077,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   // The machine's own `version` (XState's standard `createMachine({ version })`
   // prop, `.provide`-surviving) is the single source of truth; an unversioned
   // machine falls back to the structural hash.
-  const machineVersion =
-    (machine as { version?: string }).version ?? getMachineStructuralHash(machine);
+  const machineVersion = resolveMachineVersion(machine);
   const agentMeta: AgentRunMeta = { machineId, version: machineVersion };
 
   // The run's single observation dispatch point: every trace payload in this

--- a/src/scripted-executors.test.ts
+++ b/src/scripted-executors.test.ts
@@ -378,3 +378,58 @@ describe("createScriptedExecutors", () => {
     expect(script.decisions).toHaveLength(1);
   });
 });
+
+describe("createScriptedExecutors — userInput", () => {
+  const feedbackSetup = setupAgent({
+    context: z.object({ feedback: z.string().nullable() }),
+    input: z.object({}),
+    output: z.object({ feedback: z.string() }),
+    events: {},
+  });
+
+  const feedbackMachine = feedbackSetup.createMachine({
+    context: () => ({ feedback: null }),
+    output: ({ context }) => ({ feedback: context.feedback ?? "" }),
+    initial: "asking",
+    states: {
+      asking: {
+        invoke: {
+          id: "ask",
+          src: "agent.userInput",
+          input: { prompt: "How was it?" },
+          onDone: ({ output }) => ({ target: "done", context: { feedback: output } }),
+        },
+      },
+      done: { type: "final" },
+    },
+  });
+
+  test("plays the userInput queue back to runAgent's userInput handler", async () => {
+    const scripted = createScriptedExecutors({ userInput: ["great"] });
+    const result = await runAgent(feedbackMachine, {
+      input: {},
+      executors: scripted,
+      userInput: scripted.userInput,
+    });
+
+    expect(result.status).toBe("done");
+    if (result.status !== "done") return;
+    expect(result.output.feedback).toBe("great");
+  });
+
+  test("entries may be functions of the request", async () => {
+    const scripted = createScriptedExecutors({
+      userInput: [({ prompt }) => `answering: ${prompt}`],
+    });
+    await expect(scripted.userInput({ prompt: "How was it?" })).resolves.toBe(
+      "answering: How was it?",
+    );
+  });
+
+  test("a dry userInput queue throws, naming the queue to add to", async () => {
+    const scripted = createScriptedExecutors();
+    await expect(scripted.userInput({ prompt: "How was it?" })).rejects.toThrow(
+      /ran dry on a pending userInput request[\s\S]*`userInput` queue/,
+    );
+  });
+});

--- a/src/scripted-executors.ts
+++ b/src/scripted-executors.ts
@@ -2,7 +2,8 @@
  * Scripted executors — a keyless, deterministic stand-in for a model host.
  *
  * `createScriptedExecutors` builds a full `{ generateText, streamText, decide }`
- * set that plays back canned answers from FIFO queues, so `runAgent` (or
+ * set (plus a `userInput` handler) that plays back canned answers from FIFO
+ * queues, so `runAgent` (or
  * `provideExecutors`, or a bare `TextLogic.execute`) runs with no API key and no
  * network. It is the fastest way to see a machine run, and the least ceremonial
  * way to test one: same machine, same executor contract, scripted answers.
@@ -17,6 +18,7 @@ import type {
   AgentRequestExecutorInfo,
   AgentRequestExecutors,
   AgentTextRequest,
+  AgentUserInput,
 } from "./text-logic.js";
 import type { ChosenEvent } from "./types.js";
 
@@ -65,13 +67,44 @@ export type ScriptedTextEntry =
   | null
   | object;
 
-/** The script {@link createScriptedExecutors} plays back. */
+/**
+ * One entry in the `userInput` queue: the string the simulated human typed, or
+ * a function of the {@link AgentUserInput} request (its `prompt`/`metadata`)
+ * returning one.
+ */
+export type ScriptedUserInputEntry =
+  | string
+  | ((input: AgentUserInput) => string | PromiseLike<string>);
+
+/**
+ * The script {@link createScriptedExecutors} plays back.
+ *
+ * The key names match `simulateAgent`'s script (`decisions`, `text`,
+ * `invokes`, `userInput`), but the shapes differ by design: `simulateAgent`
+ * drives the pure step path and keys each channel BY SRC
+ * (`text: { summarize: [...] }`), while these executors sit behind the real
+ * executor contract, where one flat FIFO queue per channel is the ergonomic
+ * form — route per request inside a function entry (`request.name`) when one
+ * script must serve several requests. There is no `invokes` queue here:
+ * non-`userInput` invokes are plain actors, supplied via `actors`.
+ */
 export interface ScriptedExecutorsScript {
   /** Answers for `decide` requests, consumed in order. */
   decisions?: ScriptedDecisionEntry[];
   /** Answers for text requests, consumed in order. `generateText` and `streamText` share this one queue. */
   text?: ScriptedTextEntry[];
+  /** Answers for `agent.userInput` requests, consumed in order. */
+  userInput?: ScriptedUserInputEntry[];
 }
+
+/**
+ * What {@link createScriptedExecutors} returns: the full executor set, plus a
+ * `userInput` handler for `runAgent`'s own `userInput` option (the builtin
+ * `agent.userInput` actor is not an executor slot).
+ */
+export type ScriptedExecutors = Required<AgentRequestExecutors> & {
+  userInput: (input: AgentUserInput) => Promise<string>;
+};
 
 /** The only own keys an executor-result envelope carries. @internal */
 const TEXT_ENVELOPE_KEYS = new Set(["output", "usage", "raw"]);
@@ -155,12 +188,17 @@ export function emitScriptedChunk(result: unknown, info?: AgentRequestExecutorIn
  *   decisions: [(request) => ({ type: request.events[0]!.type })],
  * });
  * ```
+ *
+ * @example Scripted human input
+ * ```ts
+ * const scripted = createScriptedExecutors({ userInput: ['ship it'] });
+ * await runAgent(machine, { executors: scripted, userInput: scripted.userInput });
+ * ```
  */
-export function createScriptedExecutors(
-  script: ScriptedExecutorsScript = {},
-): Required<AgentRequestExecutors> {
+export function createScriptedExecutors(script: ScriptedExecutorsScript = {}): ScriptedExecutors {
   const decisions = [...(script.decisions ?? [])];
   const text = [...(script.text ?? [])];
+  const userInput = [...(script.userInput ?? [])];
 
   const nextText = async (request: AgentTextRequest, info?: AgentRequestExecutorInfo) => {
     if (text.length === 0) {
@@ -174,6 +212,18 @@ export function createScriptedExecutors(
   };
 
   return {
+    userInput: async (input) => {
+      if (userInput.length === 0) {
+        throw new AgentError(
+          "scripted-executors-exhausted",
+          "createScriptedExecutors: script ran dry on a pending userInput request " +
+            `(prompt: ${input.prompt ? `'${input.prompt}'` : "(none)"}). ` +
+            "Add another entry to the script's `userInput` queue.",
+        );
+      }
+      const entry = userInput.shift()!;
+      return typeof entry === "function" ? await entry(input) : entry;
+    },
     generateText: nextText,
     streamText: async (request, info) => {
       const result = await nextText(request, info);

--- a/src/seam.test.ts
+++ b/src/seam.test.ts
@@ -42,7 +42,7 @@ const setup = setupAgent({
       prompt: ({ input }) => input.prompt,
     },
   },
-  isSuspended: (snapshot) =>
+  isIdle: (snapshot) =>
     typeof snapshot.value === "string" &&
     ["prompting", "asking", "reviewing"].includes(snapshot.value),
 });
@@ -208,11 +208,14 @@ describe("runSeam", () => {
     expect(run.before.statePath).toContain("writing");
   });
 
-  test("addresses the same call by model key", async () => {
+  test("the model key addresses the queue, never the seam", async () => {
+    // Scripts route by request name when one is scripted under it, else by
+    // model key — but the seam itself is addressed by request name only.
     const seen: string[] = [];
     const run = await runSeam(machine, {
-      ...reviseRun(),
-      seam: { model: "writer", occurrence: 1 },
+      scripts: { judge: [COMPLETE], writer: [DRAFT, REVISED] },
+      respond: user({ prompt: "Tell the team.", changes: "Add the ship date." }),
+      seam: { request: "write", occurrence: 1 },
       candidate: async (request) => {
         seen.push(request.model);
         return { output: REVISED };
@@ -224,11 +227,12 @@ describe("runSeam", () => {
     expect(run.after.statePath).toEqual(["reviewing", "done"]);
   });
 
-  test("the last scripted answer repeats, so a longer branch never runs dry", async () => {
+  test("repeatLast replays the last scripted answer down a longer branch", async () => {
     // One scripted draft, but the user asks for a revision: the `write` queue
     // is called twice and its last entry covers the second call.
     const run = await runSeam(machine, {
       scripts: { assess: [COMPLETE], write: [DRAFT] },
+      repeatLast: true,
       respond: user({ prompt: "Tell the team.", changes: "Add the ship date." }),
       seam: { request: "assess" },
     });
@@ -237,6 +241,18 @@ describe("runSeam", () => {
     if (run.result.status !== "done") return;
     expect(run.result.output.draft).toEqual(DRAFT);
     expect(run.after.statePath).toEqual(["writing", "reviewing", "writing", "reviewing", "done"]);
+  });
+
+  test("without repeatLast an exhausted queue fails the run instead of replaying", async () => {
+    const run = await runSeam(machine, {
+      scripts: { assess: [COMPLETE], write: [DRAFT] },
+      respond: user({ prompt: "Tell the team.", changes: "Add the ship date." }),
+      seam: { request: "assess" },
+    });
+
+    expect(run.result.status).toBe("error");
+    if (run.result.status !== "error") return;
+    expect(String((run.result.error as Error).message)).toMatch(/repeatLast/);
   });
 
   test("a dry queue fails the run, naming the request that went unanswered", async () => {
@@ -295,6 +311,7 @@ describe("runSeam", () => {
   test("maxTurns bounds the drive loop", async () => {
     const run = await runSeam(machine, {
       scripts: { assess: [COMPLETE], write: [DRAFT] },
+      repeatLast: true,
       seam: { request: "assess" },
       // The user always revises: without a bound this never settles `done`.
       respond: ({ state }) =>

--- a/src/seam.ts
+++ b/src/seam.ts
@@ -45,26 +45,17 @@ import type { AgentTools } from "./types.js";
 import { getStateMeta, type MetaOfSnapshot } from "./utils.js";
 
 /**
- * Which model call is under test: the Nth call addressed either by request
- * `name` (the `setupAgent({ requests })` key or `createTextLogic({ name })`,
- * the better developer handle) or by `model` key (the `defineModels` key) for
- * requests that carry no name.
+ * Which model call is under test: the Nth call with this request `name` (the
+ * `setupAgent({ requests })` key, or `createTextLogic({ name })`). Name the
+ * requests you want to score — a seam is a developer-facing handle, not a
+ * model binding, so there is no addressing by model key.
  */
-export type SeamRef =
-  | {
-      /** The request's registered `name`. */
-      request: string;
-      model?: undefined;
-      /** 0-based occurrence among the calls matching this key. Default `0`. */
-      occurrence?: number;
-    }
-  | {
-      /** The `defineModels` key the request names. */
-      model: string;
-      request?: undefined;
-      /** 0-based occurrence among the calls matching this key. Default `0`. */
-      occurrence?: number;
-    };
+export interface SeamRef {
+  /** The request's registered `name`. */
+  request: string;
+  /** 0-based occurrence among the calls with this name. Default `0`. */
+  occurrence?: number;
+}
 
 /**
  * One idle pause, handed to {@link RunSeamOptions.respond} so the simulated
@@ -107,11 +98,17 @@ export interface RunSeamOptions<TMachine extends AnyStateMachine> {
    * by model.
    *
    * Entries follow {@link ScriptedTextEntry} conventions (a value, an
-   * `{ output, usage? }` envelope, or a function of the request). The LAST
-   * entry of a queue repeats, so a live seam that sends the run down a longer
-   * branch still finds an answer instead of running dry.
+   * `{ output, usage? }` envelope, or a function of the request). A queue that
+   * runs dry throws; set {@link RunSeamOptions.repeatLast} to replay its last
+   * entry instead.
    */
   scripts?: Record<string, ScriptedTextEntry[]>;
+  /**
+   * Replay the LAST entry of a queue once it is exhausted, so a live seam that
+   * sends the run down a longer branch still finds an answer. Off by default:
+   * a dry queue throws, the same as every other scripted surface.
+   */
+  repeatLast?: boolean;
   /** The call under test. */
   seam: SeamRef;
   /**
@@ -135,7 +132,7 @@ export interface RunSeamOptions<TMachine extends AnyStateMachine> {
    */
   executors?: Partial<AgentRequestExecutors>;
   /** Passed through to `runAgent`: the deterministic idle-state predicate. */
-  isSuspended?: RunAgentOptions<TMachine>["isSuspended"];
+  isIdle?: RunAgentOptions<TMachine>["isIdle"];
   /** Passed through to `runAgent`: actor implementations merged onto the machine. */
   actors?: RunAgentOptions<TMachine>["actors"];
 }
@@ -240,8 +237,8 @@ export async function runSeam<TMachine extends AnyStateMachine>(
 
   /**
    * Consumes this request's slot in the call plan, or resolves `undefined` when
-   * its queue is dry. The LAST entry repeats: a live seam that branches further
-   * still finds an answer instead of running dry.
+   * its queue is dry. With `repeatLast`, the last entry is replayed instead of
+   * running dry.
    */
   const takeScriptedSlot = async (
     request: AgentTextRequest,
@@ -251,7 +248,7 @@ export async function runSeam<TMachine extends AnyStateMachine>(
     if (!queue?.length) {
       return undefined;
     }
-    const entry = queue.length === 1 ? queue[0]! : queue.shift()!;
+    const entry = options.repeatLast && queue.length === 1 ? queue[0]! : queue.shift()!;
     return resolveScriptedTextEntry(entry, request, info);
   };
 
@@ -264,8 +261,8 @@ export async function runSeam<TMachine extends AnyStateMachine>(
       throw new AgentError(
         "seam-script-exhausted",
         `runSeam: no scripted answer left for request ${describeText(request)}. Add an entry ` +
-          `to \`scripts.${queueKeyOf(request)}\` — its last entry repeats, so one extra answer ` +
-          "covers a longer branch.",
+          `to \`scripts.${queueKeyOf(request)}\`, or pass \`repeatLast: true\` to replay its ` +
+          "last entry down a longer branch.",
       );
     }
     return scripted;
@@ -276,8 +273,7 @@ export async function runSeam<TMachine extends AnyStateMachine>(
     info?: AgentRequestExecutorInfo,
   ): Promise<ExecutorReturn> => {
     const callIndex = calls++;
-    const keyMatches =
-      seam.request !== undefined ? request.name === seam.request : request.model === seam.model;
+    const keyMatches = request.name === seam.request;
     const isSeam = keyMatches && seamMatches++ === (seam.occurrence ?? 0);
 
     if (isSeam && candidate) {
@@ -328,7 +324,7 @@ export async function runSeam<TMachine extends AnyStateMachine>(
     result = await runAgent(machine, {
       ...(snapshot ? { snapshot } : { input: options.input }),
       ...(event ? { event } : {}),
-      ...(options.isSuspended ? { isSuspended: options.isSuspended } : {}),
+      ...(options.isIdle ? { isIdle: options.isIdle } : {}),
       ...(options.actors ? { actors: options.actors } : {}),
       events,
       executors,

--- a/src/setup-agent.test.ts
+++ b/src/setup-agent.test.ts
@@ -43,7 +43,7 @@ import {
 import { executeAgentRequest, resolveDecision, type AgentRequest } from "./index.js";
 import { getAgentOutputMode, parseOutput } from "./index.js";
 import { isStructuredOutputSchema } from "./text-logic.js";
-import { getMachineSuspensionPredicate } from "./internal/registry.js";
+import { getMachineIdlePredicate } from "./internal/registry.js";
 
 /**
  * ~15-line Ajv-to-StandardSchema adapter — the recipe for a real
@@ -1612,9 +1612,9 @@ describe("setupAgent", () => {
       "machine_defend",
     ]);
 
-    const chosenEvent = await resolveDecision(request, async () => ({
-      event: { type: "ATTACK", target: "orc" },
-    }));
+    const chosenEvent = await resolveDecision(request, {
+      decide: async () => ({ event: { type: "ATTACK", target: "orc" } }),
+    });
     expect(chosenEvent).toEqual({ type: "ATTACK", target: "orc" });
   });
 
@@ -2598,16 +2598,16 @@ describe("setupAgent", () => {
     },
   };
 
-  test("fromConfig lowers suspendedTags into a machine-carried hasTag predicate", () => {
+  test("fromConfig lowers idleTags into a machine-carried hasTag predicate", () => {
     const { machine } = setupAgent.fromConfig(
-      { id: "suspended-tags", suspendedTags: ["waiting"], ...suspensionConfig },
+      { id: "suspended-tags", idleTags: ["waiting"], ...suspensionConfig },
       { compileSchema: ajvCompiler() },
     );
 
-    const predicate = getMachineSuspensionPredicate(machine);
+    const predicate = getMachineIdlePredicate(machine);
     expect(predicate).toBeDefined();
     // Keyed on the root config, so it survives further `.provide(...)` rebinding.
-    expect(getMachineSuspensionPredicate(machine.provide({}))).toBe(predicate);
+    expect(getMachineIdlePredicate(machine.provide({}))).toBe(predicate);
 
     const actor = createActor(machine).start();
     expect(predicate!(actor.getSnapshot())).toBe(true);
@@ -2615,16 +2615,16 @@ describe("setupAgent", () => {
     expect(predicate!(actor.getSnapshot())).toBe(false);
   });
 
-  test("fromConfig registers options.isSuspended, which wins over suspendedTags", () => {
+  test("fromConfig registers options.isIdle, which wins over idleTags", () => {
     const hostPredicate = () => false;
     const { machine } = setupAgent.fromConfig(
-      { id: "issuspended-option", suspendedTags: ["waiting"], ...suspensionConfig },
-      { compileSchema: ajvCompiler(), isSuspended: hostPredicate },
+      { id: "issuspended-option", idleTags: ["waiting"], ...suspensionConfig },
+      { compileSchema: ajvCompiler(), isIdle: hostPredicate },
     );
-    expect(getMachineSuspensionPredicate(machine)).toBe(hostPredicate);
+    expect(getMachineIdlePredicate(machine)).toBe(hostPredicate);
   });
 
-  test("fromConfig rejects a suspendedTags entry that no state declares", () => {
+  test("fromConfig rejects a idleTags entry that no state declares", () => {
     expect(() =>
       setupAgent.fromConfig(
         {
@@ -2632,19 +2632,19 @@ describe("setupAgent", () => {
           schemas: { context: { type: "object", properties: {} } },
           context: {},
           initial: "start",
-          suspendedTags: ["waiting"],
+          idleTags: ["waiting"],
           states: { start: { type: "final" } },
         },
         { compileSchema: ajvCompiler() },
       ),
-    ).toThrow(/suspendedTags.*'waiting'.*no state declares/s);
+    ).toThrow(/idleTags.*'waiting'.*no state declares/s);
   });
 
-  test("fromConfig + runAgent: suspendedTags settles idle without the heuristic warning", async () => {
+  test("fromConfig + runAgent: idleTags settles idle without the heuristic warning", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
       const { machine } = setupAgent.fromConfig(
-        { id: "suspended-tags-run", suspendedTags: ["waiting"], ...suspensionConfig },
+        { id: "suspended-tags-run", idleTags: ["waiting"], ...suspensionConfig },
         { compileSchema: ajvCompiler() },
       );
 
@@ -2686,9 +2686,9 @@ describe("resolveDecision", () => {
 
   test("resolves on the first attempt", async () => {
     const request = makeRequest();
-    const event = await resolveDecision(request, async () => ({
-      event: { type: "ATTACK", target: "goblin" },
-    }));
+    const event = await resolveDecision(request, {
+      decide: async () => ({ event: { type: "ATTACK", target: "goblin" } }),
+    });
 
     expect(event).toEqual({ type: "ATTACK", target: "goblin" });
   });
@@ -2697,11 +2697,11 @@ describe("resolveDecision", () => {
     const request = makeRequest();
     await expect(
       // Common mistake: bare event instead of the `{ event }` envelope.
-      resolveDecision(request, async () => ({ type: "DEFEND" }) as never),
+      resolveDecision(request, { decide: async () => ({ type: "DEFEND" }) as never }),
     ).rejects.toThrow(/decide executor must return \{ event: \{ type: string/);
 
     await expect(
-      resolveDecision(request, async () => ({ event: { noType: true } }) as never),
+      resolveDecision(request, { decide: async () => ({ event: { noType: true } }) as never }),
     ).rejects.toThrow(/decide executor must return/);
   });
 
@@ -2709,9 +2709,11 @@ describe("resolveDecision", () => {
     const request = makeRequest();
     const calls: AgentDecisionRequest[] = [];
 
-    const event = await resolveDecision(request, async (req) => {
-      calls.push(req);
-      return calls.length === 1 ? { event: { type: "HEAL" } } : { event: { type: "DEFEND" } };
+    const event = await resolveDecision(request, {
+      decide: async (req: AgentDecisionRequest) => {
+        calls.push(req);
+        return calls.length === 1 ? { event: { type: "HEAL" } } : { event: { type: "DEFEND" } };
+      },
     });
 
     expect(event).toEqual({ type: "DEFEND" });
@@ -2732,15 +2734,17 @@ describe("resolveDecision", () => {
     await expect(
       resolveDecision(
         request,
-        async () => ({ event: { type: "ATTACK" } }), // missing required `target`
+        { decide: async () => ({ event: { type: "ATTACK" } }) }, // missing required `target`
         { maxRetries: 0 },
       ),
     ).rejects.toThrow(AgentDecisionExhaustedError);
 
     try {
-      await resolveDecision(request, async () => ({ event: { type: "ATTACK" } }), {
-        maxRetries: 0,
-      });
+      await resolveDecision(
+        request,
+        { decide: async () => ({ event: { type: "ATTACK" } }) },
+        { maxRetries: 0 },
+      );
       expect.fail("expected AgentDecisionExhaustedError");
     } catch (error) {
       expect(error).toBeInstanceOf(AgentDecisionExhaustedError);
@@ -2754,10 +2758,11 @@ describe("resolveDecision", () => {
     const request = makeRequest();
 
     try {
-      await resolveDecision(request, async () => ({ event: { type: "DEFEND" } }), {
-        maxRetries: 0,
-        canTake: () => false,
-      });
+      await resolveDecision(
+        request,
+        { decide: async () => ({ event: { type: "DEFEND" } }) },
+        { maxRetries: 0, canTake: () => false },
+      );
       expect.fail("expected AgentDecisionExhaustedError");
     } catch (error) {
       expect(error).toBeInstanceOf(AgentDecisionExhaustedError);
@@ -2776,9 +2781,11 @@ describe("resolveDecision", () => {
     const request = makeRequest();
 
     try {
-      await resolveDecision(request, async () => ({ event: { type: "UNKNOWN" } }), {
-        maxRetries: 2,
-      });
+      await resolveDecision(
+        request,
+        { decide: async () => ({ event: { type: "UNKNOWN" } }) },
+        { maxRetries: 2 },
+      );
       expect.fail("expected AgentDecisionExhaustedError");
     } catch (error) {
       expect(error).toBeInstanceOf(AgentDecisionExhaustedError);
@@ -3358,8 +3365,69 @@ describe("setupAgent reserved agent.* actor keys", () => {
     ).toThrow(/machine\.provide/);
   });
 
-  test("a non-reserved actors key is accepted", () => {
+  test("the whole 'agent.' namespace is reserved, not just the shipped builtins", () => {
+    expect(() =>
+      setupAgent({
+        schemas,
+        actors: { "agent.summarize": someLogic } as never,
+      }),
+    ).toThrow(/reserved 'agent\.' namespace/);
+
+    expect(() =>
+      setupAgent({
+        schemas,
+        requests: {
+          "agent.classify": { schemas: { input: z.object({}), output: z.object({}) }, model: "m" },
+        } as never,
+      }),
+    ).toThrow(/reserved 'agent\.' namespace/);
+  });
+
+  test("a non-reserved actors key is accepted, including one merely containing 'agent'", () => {
     expect(() => setupAgent({ schemas, actors: { myActor: someLogic } })).not.toThrow();
+    expect(() => setupAgent({ schemas, actors: { agentSummarize: someLogic } })).not.toThrow();
+  });
+});
+
+describe("resolveDecision executor set", () => {
+  test("errors clearly when the executor set has no 'decide'", async () => {
+    const request: AgentDecisionRequest = {
+      kind: "decision",
+      id: "d1",
+      model: "m",
+      events: [{ type: "ATTACK", toolName: "send_event_ATTACK" }],
+      attempts: [],
+    };
+
+    await expect(resolveDecision(request, {})).rejects.toThrow(/no 'decide' function/);
+    await expect(resolveDecision(request, {})).rejects.toMatchObject({
+      code: "missing-decide-executor",
+    });
+  });
+
+  test("passes the same (request, info) pair generateText gets", async () => {
+    const request: AgentDecisionRequest = {
+      kind: "decision",
+      id: "d1",
+      model: "m",
+      events: [{ type: "ATTACK", toolName: "send_event_ATTACK" }],
+      attempts: [],
+    };
+    const controller = new AbortController();
+    let seenInfo: unknown;
+
+    await resolveDecision(
+      request,
+      {
+        decide: async (_request, info) => {
+          seenInfo = info;
+          return { event: { type: "ATTACK" } };
+        },
+      },
+      { signal: controller.signal },
+    );
+
+    expect(seenInfo).toEqual({ signal: controller.signal, requestId: "d1" });
   });
 });
 

--- a/src/setup-agent.ts
+++ b/src/setup-agent.ts
@@ -37,7 +37,7 @@ import {
 import { createDecideActor } from "./decision.js";
 import { AGENT_USAGE_EVENT_TYPE, type AgentUsageEvent } from "./effects.js";
 import { appendMessages } from "./messages.js";
-import { agentExecutionOptions, machineSuspensionPredicates } from "./internal/registry.js";
+import { agentExecutionOptions, machineIdlePredicates } from "./internal/registry.js";
 import type { AgentSchemas } from "./events.js";
 import {
   setupAgentFromConfig,
@@ -638,14 +638,14 @@ type SetupAgentBaseConfig<
   /**
    * Detects a snapshot that is an INTENTIONAL wait for an external event (a
    * human approval, an inbound webhook, …) — the machine's own declaration of
-   * what "suspended" means for it, so `runAgent` settles those snapshots idle
+   * what "idle" means for it, so `runAgent` settles those snapshots idle
    * deterministically instead of using its timing heuristic. Travels with the
-   * machine through `machine.provide(...)`. A `runAgent({ isSuspended })` host
+   * machine through `machine.provide(...)`. A `runAgent({ isIdle })` host
    * override takes precedence; with neither, `runAgent` falls back to the timing
    * heuristic. Declare your own signal — e.g. `(s) => s.hasTag('awaiting-review')`
    * or `(s) => getStateMeta(s).interaction !== undefined`.
    */
-  isSuspended?: (snapshot: AnyMachineSnapshot) => boolean;
+  isIdle?: (snapshot: AnyMachineSnapshot) => boolean;
 };
 
 // The raw xstate `setup(...)` result type for an agent config, before setupAgent's own extensions (schemas/models/requests/appendMessages, plus the wrapped createMachine) are added.
@@ -939,10 +939,10 @@ export function setupAgent<
       agentExecutionOptions.set(machine as object, machineOptions);
       // Carry the wait-state predicate on the machine's root `config` (shared by
       // reference across `.provide`), so it survives provide/executor rebinding.
-      if (config.isSuspended) {
+      if (config.isIdle) {
         const rootConfig = (machine as { config?: object }).config;
         if (rootConfig) {
-          machineSuspensionPredicates.set(rootConfig, config.isSuspended);
+          machineIdlePredicates.set(rootConfig, config.isIdle);
         }
       }
       return machine;
@@ -1178,13 +1178,23 @@ const RESERVED_AGENT_ACTOR_KEYS = [
 ] satisfies readonly (keyof BuiltinAgentActors)[];
 
 /**
+ * The whole `agent.` actor-source namespace is reserved for the library, not
+ * just the shipped builtins: a key starting with this prefix is rejected at
+ * setup time so a future builtin can never collide with (or be shadowed by) a
+ * user source. Name your own sources without it.
+ */
+const RESERVED_AGENT_KEY_PREFIX = "agent.";
+
+/**
  * Runtime guards over the user-supplied `actors`/`requests` keys, in one walk
  * of both groups:
  *
- * 1. A key in the reserved `agent.*` builtin namespace is rejected. Without
- *    this, the builtins-first spread in {@link createAgentActors} lets such a
- *    key overwrite the builtin (`agent.decide`, …) silently. Deliberate
- *    override of a builtin is still possible after the machine is created, via
+ * 1. A key in the reserved `agent.` namespace is rejected — every key with
+ *    that prefix, not only today's builtins. Without this, the builtins-first
+ *    spread in {@link createAgentActors} lets such a key overwrite the builtin
+ *    (`agent.decide`, …) silently, and a builtin added later would start
+ *    colliding with user code. Deliberate override of a builtin is still
+ *    possible after the machine is created, via
  *    `machine.provide({ actors: { 'agent.decide': ... } })`.
  * 2. A key appearing in BOTH groups is almost certainly a mistake (whichever
  *    spread applies last would silently win) — fail fast with a clear message
@@ -1208,6 +1218,14 @@ function assertActorKeys(
             `cannot be redefined here (it would silently clobber the builtin). Reserved keys: ` +
             `${RESERVED_AGENT_ACTOR_KEYS.join(", ")}. To deliberately override a builtin, do it ` +
             `on the created machine instead: machine.provide({ actors: { '${key}': ... } }).`,
+        );
+      }
+      if (key.startsWith(RESERVED_AGENT_KEY_PREFIX)) {
+        throw new Error(
+          `setupAgent: '${groupName}' key '${key}' uses the reserved '` +
+            `${RESERVED_AGENT_KEY_PREFIX}' namespace, which belongs to the library (` +
+            `${RESERVED_AGENT_ACTOR_KEYS.join(", ")}, and anything added later). Rename it ` +
+            `without the '${RESERVED_AGENT_KEY_PREFIX}' prefix.`,
         );
       }
       const existingGroup = seenIn.get(key);

--- a/src/sqlite/index.ts
+++ b/src/sqlite/index.ts
@@ -202,10 +202,7 @@ export function createSqliteEventLogStore(
       return lengthOf(threadId);
     },
 
-    async fork({ threadId, newThreadId, upToIndex, atEventId }) {
-      if (upToIndex !== undefined && atEventId !== undefined) {
-        throw new Error("AgentEventLogStore.fork: pass either upToIndex or atEventId, not both.");
-      }
+    async fork({ threadId, newThreadId, upToIndex }) {
       transact(() => {
         if (lengthOf(newThreadId) > 0) {
           throw new Error(
@@ -216,18 +213,7 @@ export function createSqliteEventLogStore(
         if (sourceLength === 0) {
           throw new Error(`AgentEventLogStore.fork: unknown source thread "${threadId}".`);
         }
-        let upTo = upToIndex ?? sourceLength;
-        if (atEventId !== undefined) {
-          const row = db
-            .prepare(`SELECT idx FROM ${table} WHERE thread_id = ? AND entry_id = ?`)
-            .get(threadId, atEventId) as { idx: number } | undefined;
-          if (!row) {
-            throw new Error(
-              `AgentEventLogStore.fork: thread "${threadId}" has no event id "${atEventId}".`,
-            );
-          }
-          upTo = Number(row.idx) + 1;
-        }
+        const upTo = upToIndex ?? sourceLength;
         if (upTo < 0 || upTo > sourceLength) {
           throw new Error(
             `AgentEventLogStore.fork: thread "${threadId}" (length ${sourceLength}) ` +

--- a/src/steps.ts
+++ b/src/steps.ts
@@ -325,7 +325,7 @@ export function resolveAgentStep<TMachine extends AnyActorLogic>(
  * present. Accepts either a `kind: 'text'` `AgentEffect` (the step-path shape
  * from `getAgentEffects`) or an {@link AgentRequest} envelope.
  * **Text-only**: passing a `kind: 'decision'` request throws, directing the
- * caller to `resolveDecision(request, executors.decide, ...)` instead. Always
+ * caller to `resolveDecision(request, executors, ...)` instead. Always
  * returns both the normalized `output` and the `raw` executor result (tool
  * calls, usage, finish reason — needed for observability and event-sourced
  * replay).
@@ -345,7 +345,7 @@ export async function executeAgentRequest(
   if ((requestOrEffect as { kind: string }).kind === "decision") {
     throw new Error(
       "executeAgentRequest(...) is text-only. Resolve a 'decision' request with " +
-        "resolveDecision(request, executors.decide, ...) instead.",
+        "resolveDecision(request, executors, ...) instead.",
     );
   }
 

--- a/src/text-logic.ts
+++ b/src/text-logic.ts
@@ -103,11 +103,22 @@ export interface AgentTextRequest<TMetadata = Record<string, unknown>> {
   seed?: number;
   stopSequences?: string[];
   /**
+   * Bounds the HOST-side tool-call loop for this one request: the maximum
+   * number of model steps the executor may run before it must return. Omitted
+   * means single-step (one model call, tool results not fed back). Named and
+   * typed to match the AI SDK — the shipped adapter lowers it to
+   * `stopWhen: stepCountIs(maxSteps)`.
+   *
+   * This is a REQUEST budget, distinct from the machine-level `maxTurns` a
+   * preset uses for its own turn budget, and from `runAgent`'s run-wide
+   * `maxModelCalls`.
+   */
+  maxSteps?: number;
+  /**
    * Host-owned per-call options. Use this for provider/runtime details such
    * as Cloudflare bindings, tracing IDs, SDK provider options, or transport
-   * hints. The machine carries it; the host decides what it means — e.g.
-   * the AI SDK adapter (`createAiSdkExecutors`) reads `metadata.maxSteps` to
-   * bound its multi-step tool-call loop for that request.
+   * hints. The machine carries it; the host decides what it means. Not the
+   * place for `maxSteps` any more — that is a typed field above.
    */
   metadata?: TMetadata;
 }
@@ -340,6 +351,7 @@ function createBuiltinTextActor(
           topK: ({ input }) => input.topK,
           seed: ({ input }) => input.seed,
           stopSequences: ({ input }) => input.stopSequences,
+          maxSteps: ({ input }) => input.maxSteps,
           metadata: ({ input }) => input.metadata,
         },
         execute,
@@ -435,6 +447,8 @@ export interface TextLogicConfig<
   topK?: ResolveTextLogicValue<number | undefined, InferOutput<TInputSchema>>;
   seed?: ResolveTextLogicValue<number | undefined, InferOutput<TInputSchema>>;
   stopSequences?: ResolveTextLogicValue<string[] | undefined, InferOutput<TInputSchema>>;
+  /** Bounds this request's host-side tool loop (see {@link AgentTextRequest.maxSteps}). */
+  maxSteps?: ResolveTextLogicValue<number | undefined, InferOutput<TInputSchema>>;
   metadata?: ResolveTextLogicValue<TMetadata | undefined, InferOutput<TInputSchema>>;
 }
 
@@ -545,6 +559,7 @@ export function createTextLogic<
       topK: resolveTextLogicValue(config.topK, args),
       seed: resolveTextLogicValue(config.seed, args),
       stopSequences: resolveTextLogicValue(config.stopSequences, args),
+      maxSteps: resolveTextLogicValue(config.maxSteps, args),
       metadata: resolveTextLogicValue(config.metadata, args),
     };
   };

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
 import { createActor } from "xstate";
-import { getStateMeta, persistSnapshot, setupAgent } from "./index.js";
+import { getStateMeta, setupAgent } from "./index.js";
 import { getJsonSchema, getJsonSchemaSync, getMachineStructuralHash } from "./index.js";
 import { findNonSerializableContextPaths } from "./utils.js";
 import type { StandardSchemaV1 } from "./types.js";
@@ -77,6 +77,23 @@ describe("getStateMeta", () => {
     expect(meta.interaction).toEqual({ label: "child", eventType: "DONE" });
   });
 
+  test("equal-depth parallel siblings merge by state id (later id wins)", () => {
+    const machine = agent.createMachine({
+      context: {},
+      type: "parallel",
+      states: {
+        // Declared in reverse alphabetical order on purpose: the merge order is
+        // by state id, not by declaration order.
+        zeta: { meta: { banner: "zeta" } },
+        alpha: { meta: { banner: "alpha" } },
+      },
+    });
+    const snapshot = createActor(machine).start().getSnapshot();
+
+    // Both regions are at the same depth, so the later id alphabetically wins.
+    expect(getStateMeta(snapshot).banner).toBe("zeta");
+  });
+
   test("recovers the meta type from the snapshot generic", () => {
     const machine = agent.createMachine({
       context: {},
@@ -89,27 +106,6 @@ describe("getStateMeta", () => {
     // Type-level: `banner` is a `string | undefined`, not `unknown`.
     const banner: string | undefined = meta.banner;
     expect(banner).toBe("hi");
-  });
-});
-
-describe("persistSnapshot", () => {
-  test("returns a plain-JSON deep clone (equal value, not same reference)", () => {
-    const snapshot = { value: "reviewing", context: { draft: { body: "hi" } } };
-    const persisted = persistSnapshot(snapshot);
-
-    expect(persisted).toEqual(snapshot);
-    expect(persisted).not.toBe(snapshot);
-    expect(persisted.context).not.toBe(snapshot.context);
-  });
-
-  test("drops non-JSON values exactly as JSON round-trip does", () => {
-    const persisted = persistSnapshot({
-      keep: 1,
-      fn: () => 1,
-      undef: undefined,
-    });
-
-    expect(persisted).toEqual({ keep: 1 });
   });
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -94,6 +94,32 @@ describe("getStateMeta", () => {
     expect(getStateMeta(snapshot).banner).toBe("zeta");
   });
 
+  test("a deeper state with a custom id still wins over its ancestor", () => {
+    const machine = agent.createMachine({
+      context: {},
+      initial: "parent",
+      states: {
+        parent: {
+          meta: { interaction: { label: "parent", eventType: "GO" } },
+          initial: "child",
+          states: {
+            child: {
+              // A custom id has no dots, so id-string depth would misrank it.
+              id: "review",
+              meta: { interaction: { label: "child", eventType: "DONE" } },
+            },
+          },
+        },
+      },
+    });
+    const snapshot = createActor(machine).start().getSnapshot();
+
+    expect(getStateMeta(snapshot).interaction).toEqual({
+      label: "child",
+      eventType: "DONE",
+    });
+  });
+
   test("recovers the meta type from the snapshot generic", () => {
     const machine = agent.createMachine({
       context: {},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,19 +14,9 @@ import type {
 } from "./types.js";
 
 /**
- * Deep-clones a snapshot to a plain-JSON value via a `JSON` round-trip, the
- * shape you persist and later feed back to `runAgent({ snapshot })`. Asserts
- * JSON-serializability: functions, `undefined`, and other non-JSON values are
- * dropped or throw exactly as `JSON.stringify`/`JSON.parse` would. Returns a
- * plain-JSON deep clone, not a live snapshot.
- */
-export function persistSnapshot<TSnapshot>(snapshot: TSnapshot): TSnapshot {
-  return JSON.parse(JSON.stringify(snapshot)) as TSnapshot;
-}
-
-/**
  * Walks a context value and returns the dot-paths of the first few values that
- * would NOT survive a JSON persist/resume round-trip (see {@link persistSnapshot}):
+ * would NOT survive a JSON persist/resume round-trip (persist with XState's
+ * `actor.getPersistedSnapshot()`, resume with `createActor(machine, { snapshot })`):
  * `Date`, `Map`, `Set`, `RegExp`, functions, `undefined`, `bigint`, class
  * instances (non-plain objects), and circular references. Plain objects,
  * arrays, and JSON primitives are walked/allowed. Returns `[]` for a
@@ -102,7 +92,7 @@ export function findNonSerializableContextPaths(context: unknown, limit = 5): st
  * Used by {@link runAgent} to stamp settled snapshots with a `version` and to
  * detect a structurally-edited machine on resume. It is a change detector, not
  * a cryptographic digest — collisions are possible but unlikely for real
- * configs. Pass an explicit `machineVersion` to `runAgent` to override it.
+ * configs. Declare `createMachine({ version })` to pin an explicit version instead.
  */
 export function getMachineStructuralHash(machine: AnyStateMachine): string {
   return djb2Hex(stableStructuralString((machine as { config: unknown }).config));
@@ -205,8 +195,14 @@ export type MetaOfSnapshot<TSnapshot extends { getMeta(): Record<string, unknown
  *
  * `snapshot.getMeta()` is keyed by state id; a leaf machine has one active
  * state, but parallel/nested machines can have several. This shallow-merges
- * every active state's meta into one object (later/deeper entries win) and
- * returns `{}` when no active state declares meta.
+ * every active state's meta into one object and returns `{}` when no active
+ * state declares meta.
+ *
+ * Merge order is fixed and does not depend on XState's internal node order:
+ * entries are sorted by depth (the number of `.` segments in the state id),
+ * then by state id lexicographically, and merged in that order. So a deeper
+ * state's key wins over an ancestor's, and between equal-depth parallel
+ * siblings the later state id alphabetically wins.
  *
  * The return type is recovered from the snapshot's own `getMeta()` type, so a
  * schema-typed machine (`setupAgent({ meta })`) yields the meta schema's
@@ -223,12 +219,12 @@ export function getStateMeta<
   TSnapshot extends { getMeta(): Record<string, unknown> } = AnyMachineSnapshot,
   TMeta = MetaOfSnapshot<TSnapshot>,
 >(snapshot: TSnapshot): Partial<TMeta> {
-  return Object.assign(
-    {},
-    ...Object.values(snapshot.getMeta()).filter(
-      (meta): meta is Record<string, unknown> => meta != null,
-    ),
-  );
+  const depth = (id: string) => id.split(".").length;
+  const entries = Object.entries(snapshot.getMeta())
+    .filter((entry): entry is [string, Record<string, unknown>] => entry[1] != null)
+    .sort(([a], [b]) => depth(a) - depth(b) || (a < b ? -1 : a > b ? 1 : 0));
+
+  return Object.assign({}, ...entries.map(([, meta]) => meta));
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -199,10 +199,11 @@ export type MetaOfSnapshot<TSnapshot extends { getMeta(): Record<string, unknown
  * state declares meta.
  *
  * Merge order is fixed and does not depend on XState's internal node order:
- * entries are sorted by depth (the number of `.` segments in the state id),
- * then by state id lexicographically, and merged in that order. So a deeper
- * state's key wins over an ancestor's, and between equal-depth parallel
- * siblings the later state id alphabetically wins.
+ * entries are sorted by structural depth (the state node's distance from the
+ * root, regardless of custom `id` strings), then by state id lexicographically,
+ * and merged in that order. So a deeper state's key wins over an ancestor's,
+ * and between equal-depth parallel siblings the later state id alphabetically
+ * wins.
  *
  * The return type is recovered from the snapshot's own `getMeta()` type, so a
  * schema-typed machine (`setupAgent({ meta })`) yields the meta schema's
@@ -219,7 +220,13 @@ export function getStateMeta<
   TSnapshot extends { getMeta(): Record<string, unknown> } = AnyMachineSnapshot,
   TMeta = MetaOfSnapshot<TSnapshot>,
 >(snapshot: TSnapshot): Partial<TMeta> {
-  const depth = (id: string) => id.split(".").length;
+  // Structural depth per active node id. A custom `id: 'review'` on a nested
+  // state has no dots, so the id string is not a usable depth proxy.
+  // TODO(xstate): use snapshot.nodes when public.
+  const nodes = (snapshot as { _nodes?: Array<{ id: string; path: string[] }> })
+    ._nodes;
+  const depthById = new Map(nodes?.map((node) => [node.id, node.path.length]));
+  const depth = (id: string) => depthById.get(id) ?? id.split(".").length;
   const entries = Object.entries(snapshot.getMeta())
     .filter((entry): entry is [string, Record<string, unknown>] => entry[1] != null)
     .sort(([a], [b]) => depth(a) - depth(b) || (a < b ? -1 : a > b ? 1 : 0));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,6 +98,18 @@ export function getMachineStructuralHash(machine: AnyStateMachine): string {
   return djb2Hex(stableStructuralString((machine as { config: unknown }).config));
 }
 
+/**
+ * The version a machine is stamped with everywhere: an explicitly declared
+ * `createMachine({ version })` when present, else its
+ * {@link getMachineStructuralHash}. Single source of truth so `runAgent`,
+ * `provideExecutors`/`traceTransitions` trace envelopes, and the event-log
+ * helpers (`initEntry`, `createReplayEntry`, `replay`) never disagree.
+ * @internal
+ */
+export function resolveMachineVersion(machine: AnyStateMachine): string {
+  return (machine as { version?: string }).version ?? getMachineStructuralHash(machine);
+}
+
 // Deterministic structural serialization: sorted object keys, function/
 // undefined/symbol values omitted, cycles collapsed. Not reversible — only used
 // as hash input, so the exact string shape is irrelevant as long as it is
@@ -223,8 +235,7 @@ export function getStateMeta<
   // Structural depth per active node id. A custom `id: 'review'` on a nested
   // state has no dots, so the id string is not a usable depth proxy.
   // TODO(xstate): use snapshot.nodes when public.
-  const nodes = (snapshot as { _nodes?: Array<{ id: string; path: string[] }> })
-    ._nodes;
+  const nodes = (snapshot as { _nodes?: Array<{ id: string; path: string[] }> })._nodes;
   const depthById = new Map(nodes?.map((node) => [node.id, node.path.length]));
   const depth = (id: string) => depthById.get(id) ?? id.split(".").length;
   const entries = Object.entries(snapshot.getMeta())

--- a/src/validate/index.ts
+++ b/src/validate/index.ts
@@ -5,9 +5,11 @@
  * stays dependency-free. This module imports `ajv`, which is declared as an
  * optional peer dependency.
  */
-import { existsSync, readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import Ajv2020, { type ValidateFunction } from "ajv/dist/2020.js";
+// The schema is imported as a JSON module so bundlers inline it into the
+// built output — no runtime file read, so `/validate` works in edge runtimes
+// and bundles that have no `node:fs`.
+import workflowSchema from "../../schemas/agent-workflow.json";
 
 /**
  * One schema-validation finding from {@link validateAgentConfig}. `path` is a
@@ -33,28 +35,11 @@ export interface AgentConfigValidationResult {
 
 let compiledWorkflowValidator: ValidateFunction | undefined;
 
-/**
- * Resolves `schemas/agent-workflow.json` relative to this module. The built
- * output is flat (`dist/validate.mjs`), while the source lives one level
- * deeper (`src/validate/index.ts`), so both candidates are checked.
- */
-function resolveSchemaPath(): string {
-  const candidates = ["../schemas/agent-workflow.json", "../../schemas/agent-workflow.json"];
-  for (const candidate of candidates) {
-    const path = fileURLToPath(new URL(candidate, import.meta.url));
-    if (existsSync(path)) {
-      return path;
-    }
-  }
-  throw new Error("Could not locate schemas/agent-workflow.json");
-}
-
 function getWorkflowValidator(): ValidateFunction {
   if (!compiledWorkflowValidator) {
-    const schema = JSON.parse(readFileSync(resolveSchemaPath(), "utf8")) as Record<string, unknown>;
     // The published schema is draft 2020-12, so it needs Ajv's 2020 build.
     const ajv = new Ajv2020({ strict: false, allowUnionTypes: true, allErrors: true });
-    compiledWorkflowValidator = ajv.compile(schema);
+    compiledWorkflowValidator = ajv.compile(workflowSchema as Record<string, unknown>);
   }
   return compiledWorkflowValidator;
 }

--- a/src/validate/index.ts
+++ b/src/validate/index.ts
@@ -1,0 +1,83 @@
+/**
+ * Schema validation for agent workflow configs.
+ *
+ * Lives behind the `@statelyai/agent/validate` subpath so the core package
+ * stays dependency-free. This module imports `ajv`, which is declared as an
+ * optional peer dependency.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020.js";
+
+/**
+ * One schema-validation finding from {@link validateAgentConfig}. `path` is a
+ * JSON Pointer into the config (`/states/idle/invoke`, `/` for the root) and
+ * `message` explains what the schema rejected. Mirrors the shape of
+ * `AgentLintDiagnostic` so config validation and machine linting report the
+ * same way.
+ */
+export interface AgentConfigDiagnostic {
+  severity: "error";
+  /** JSON Pointer into the config (`/` for the root). */
+  path: string;
+  message: string;
+  /** The schema keyword that failed (`required`, `type`, `enum`, ...). */
+  keyword: string;
+}
+
+/** Result of {@link validateAgentConfig}. */
+export interface AgentConfigValidationResult {
+  valid: boolean;
+  errors: AgentConfigDiagnostic[];
+}
+
+let compiledWorkflowValidator: ValidateFunction | undefined;
+
+/**
+ * Resolves `schemas/agent-workflow.json` relative to this module. The built
+ * output is flat (`dist/validate.mjs`), while the source lives one level
+ * deeper (`src/validate/index.ts`), so both candidates are checked.
+ */
+function resolveSchemaPath(): string {
+  const candidates = ["../schemas/agent-workflow.json", "../../schemas/agent-workflow.json"];
+  for (const candidate of candidates) {
+    const path = fileURLToPath(new URL(candidate, import.meta.url));
+    if (existsSync(path)) {
+      return path;
+    }
+  }
+  throw new Error("Could not locate schemas/agent-workflow.json");
+}
+
+function getWorkflowValidator(): ValidateFunction {
+  if (!compiledWorkflowValidator) {
+    const schema = JSON.parse(readFileSync(resolveSchemaPath(), "utf8")) as Record<string, unknown>;
+    // The published schema is draft 2020-12, so it needs Ajv's 2020 build.
+    const ajv = new Ajv2020({ strict: false, allowUnionTypes: true, allErrors: true });
+    compiledWorkflowValidator = ajv.compile(schema);
+  }
+  return compiledWorkflowValidator;
+}
+
+/**
+ * Validates a value against the shipped `schemas/agent-workflow.json` before
+ * you hand it to `setupAgent(...).fromConfig(...)`. Returns diagnostics rather
+ * than throwing; `valid: true` means the config is structurally sound (it does
+ * not check that named guards/actions/actors are implemented, which
+ * `fromConfig` does). The compiled validator is cached across calls.
+ */
+export function validateAgentConfig(config: unknown): AgentConfigValidationResult {
+  const validate = getWorkflowValidator();
+  if (validate(config)) {
+    return { valid: true, errors: [] };
+  }
+  return {
+    valid: false,
+    errors: (validate.errors ?? []).map((error) => ({
+      severity: "error" as const,
+      path: error.instancePath || "/",
+      message: error.message ?? "is invalid",
+      keyword: error.keyword,
+    })),
+  };
+}

--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 import { z } from "zod";
 import {
   AgentLintError,
-  assertAgentMachine,
   canReach,
   createTextLogic,
   explorePaths,
@@ -36,7 +35,7 @@ function createRefundMachine() {
       APPROVE: z.object({}),
       DENY: z.object({}),
     },
-    isSuspended: (snapshot) => snapshot.hasTag("awaiting-human"),
+    isIdle: (snapshot) => snapshot.hasTag("awaiting-human"),
   });
 
   return agent.createMachine({
@@ -467,7 +466,7 @@ describe("simulateAgent — keyless deterministic playthrough", () => {
     const result = await canReach(twentyQuestionsMachine, "gameOver", {
       input: { questionsRemaining: 1 },
     });
-    expect(result.canReach).toBe(true);
+    expect(result.reachable).toBe(true);
   });
 
   test("does not drain the caller's scripted queues", async () => {
@@ -538,7 +537,7 @@ describe("canReach — reachability with a witness path", () => {
     const result = await canReach(createRefundMachine(), "denied", {
       input: { request: "x", amount: 5000 },
     });
-    expect(result.canReach).toBe(true);
+    expect(result.reachable).toBe(true);
     expect(result.witness?.map((event) => event.type)).toEqual(["NEEDS_REVIEW", "DENY"]);
   });
 
@@ -546,14 +545,14 @@ describe("canReach — reachability with a witness path", () => {
     const result = await canReach(createRefundMachine(), "nonexistent", {
       input: { request: "x", amount: 5000 },
     });
-    expect(result.canReach).toBe(false);
+    expect(result.reachable).toBe(false);
     expect(result.witness).toBeUndefined();
   });
 });
 
-describe("assertAgentMachine — one-line pass/fail for tests", () => {
+describe("lintAgentMachine({ throw: true }) — one-line pass/fail for tests", () => {
   test("returns silently for a clean machine", () => {
-    expect(() => assertAgentMachine(jokeMachine)).not.toThrow();
+    expect(() => lintAgentMachine(jokeMachine, { throw: true })).not.toThrow();
   });
 
   test("throws AgentLintError with the findings for a broken machine", () => {
@@ -574,7 +573,7 @@ describe("assertAgentMachine — one-line pass/fail for tests", () => {
 
     let thrown: unknown;
     try {
-      assertAgentMachine(machine);
+      lintAgentMachine(machine, { throw: true });
     } catch (error) {
       thrown = error;
     }
@@ -603,8 +602,10 @@ describe("assertAgentMachine — one-line pass/fail for tests", () => {
       },
     });
 
-    expect(() => assertAgentMachine(machine)).not.toThrow();
-    expect(() => assertAgentMachine(machine, { warnings: true })).toThrow(AgentLintError);
+    expect(() => lintAgentMachine(machine, { throw: true })).not.toThrow();
+    expect(() => lintAgentMachine(machine, { throw: true, warnings: true })).toThrow(
+      AgentLintError,
+    );
   });
 
   test("forwards lint options: a disabled check no longer fails the assert", () => {
@@ -622,7 +623,94 @@ describe("assertAgentMachine — one-line pass/fail for tests", () => {
       },
     });
 
-    expect(() => assertAgentMachine(machine)).toThrow(AgentLintError);
-    expect(() => assertAgentMachine(machine, { disable: ["unreachable-state"] })).not.toThrow();
+    expect(() => lintAgentMachine(machine, { throw: true })).toThrow(AgentLintError);
+    expect(() =>
+      lintAgentMachine(machine, { throw: true, disable: ["unreachable-state"] }),
+    ).not.toThrow();
+  });
+});
+
+// A machine whose only pending work is an `agent.userInput` invoke, for the
+// scripted `userInput` channel.
+function createFeedbackMachine() {
+  const agent = setupAgent({
+    context: z.object({ feedback: z.string().nullable() }),
+    input: z.object({}),
+    output: z.object({ feedback: z.string() }),
+    events: {},
+  });
+  return agent.createMachine({
+    id: "feedback",
+    context: () => ({ feedback: null }),
+    initial: "asking",
+    states: {
+      asking: {
+        invoke: {
+          id: "ask",
+          src: "agent.userInput",
+          input: { prompt: "How was it?" },
+          onDone: ({ output }) => ({ target: "done", context: { feedback: output } }),
+        },
+      },
+      done: {
+        type: "final",
+        output: ({ context }) => ({ feedback: context.feedback ?? "" }),
+      },
+    },
+  });
+}
+
+describe("scripted key taxonomy — userInput", () => {
+  test("simulateAgent resolves agent.userInput from the `userInput` queue", async () => {
+    const result = await simulateAgent(createFeedbackMachine(), {
+      input: {},
+      script: { userInput: ["great"] },
+    });
+
+    expect(result.status).toBe("done");
+    expect(result.snapshot.context.feedback).toBe("great");
+    expect(result.trail).toContainEqual(
+      expect.objectContaining({
+        resolvedRequest: expect.objectContaining({ kind: "userInput", src: "agent.userInput" }),
+      }),
+    );
+  });
+
+  test("simulateAgent still accepts the by-src `invokes` form", async () => {
+    const result = await simulateAgent(createFeedbackMachine(), {
+      input: {},
+      script: { invokes: { "agent.userInput": ["fine"] } },
+    });
+    expect(result.snapshot.context.feedback).toBe("fine");
+  });
+
+  test("a dry userInput queue throws, naming the queue to add to", async () => {
+    await expect(simulateAgent(createFeedbackMachine(), { input: {}, script: {} })).rejects.toThrow(
+      /script ran dry on a pending userInput request.*`userInput` queue/s,
+    );
+  });
+
+  test("explorePaths resolves agent.userInput from `userInput`, and reports a missing one", async () => {
+    const explored = await explorePaths(createFeedbackMachine(), {
+      input: {},
+      userInput: "great",
+    });
+    expect(explored.terminals.map((terminal) => terminal.status)).toEqual(["done"]);
+
+    const blocked = await explorePaths(createFeedbackMachine(), { input: {} });
+    expect(blocked.terminals[0]).toEqual(
+      expect.objectContaining({ status: "needs-output", missingSrc: "agent.userInput" }),
+    );
+  });
+
+  test("explorePaths reads text requests from `text`", async () => {
+    const report = await explorePaths(jokeMachine, {
+      input: { topic: "state machines" },
+      text: {
+        tellJoke: "Why did the state cross the transition?",
+        rateJoke: { rating: 4, explanation: "Setup drags." },
+      },
+    });
+    expect(report.terminals.some((terminal) => terminal.status === "needs-output")).toBe(false);
   });
 });

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -38,6 +38,7 @@ import {
 // Well-known builtin invoke srcs (kept local to avoid widening the public
 // surface of text-logic/decision internals).
 const DECIDE_SRC = "agent.decide";
+const USER_INPUT_SRC = "agent.userInput";
 
 // ─── Diagnostics ───
 
@@ -65,10 +66,18 @@ export interface AgentLintDiagnostic {
   message: string;
 }
 
-/** Options for {@link lintAgentMachine}. Reserved for future check selection. */
+/** Options for {@link lintAgentMachine}. */
 export interface LintAgentMachineOptions {
   /** Skip these check codes entirely. */
   disable?: AgentLintDiagnostic["code"][];
+  /**
+   * Throw {@link AgentLintError} on failing diagnostics instead of returning
+   * them. Fails on error-severity findings; add `warnings: true` to fail on
+   * warnings too.
+   */
+  throw?: boolean;
+  /** With `throw: true`, also fail on warning-severity findings. Default: errors only. */
+  warnings?: boolean;
 }
 
 // ─── State-config model ───
@@ -657,10 +666,22 @@ const LINT_CHECKS: Array<(ctx: LintContext) => AgentLintDiagnostic[]> = [
  * call this to catch dead states, undeliverable decisions, un-rebindable
  * invoke srcs, and output-contract gaps before ever running it.
  *
+ * Pass `{ throw: true }` for the one-liner form used in tests and generation
+ * loops: it returns silently when the machine is clean and throws
+ * {@link AgentLintError} (findings on `.diagnostics`) on error-severity
+ * findings, or on warnings too with `{ throw: true, warnings: true }`.
+ *
  * @example
  * ```ts
  * const errors = lintAgentMachine(machine).filter((d) => d.severity === 'error');
  * if (errors.length) throw new Error(errors.map((e) => `${e.path}: ${e.message}`).join('\n'));
+ * ```
+ *
+ * @example Throwing form
+ * ```ts
+ * test('agent machine is structurally sound', () => {
+ *   lintAgentMachine(machine, { throw: true });
+ * });
  * ```
  */
 export function lintAgentMachine(
@@ -683,17 +704,25 @@ export function lintAgentMachine(
   };
 
   const disabled = new Set(options.disable ?? []);
-  return LINT_CHECKS.flatMap((check) => check(ctx)).filter((d) => !disabled.has(d.code));
-}
+  const diagnostics = LINT_CHECKS.flatMap((check) => check(ctx)).filter(
+    (d) => !disabled.has(d.code),
+  );
 
-/** Options for {@link assertAgentMachine}. */
-export interface AssertAgentMachineOptions extends LintAgentMachineOptions {
-  /** Also fail on warning-severity findings. Default: errors only. */
-  warnings?: boolean;
+  if (options.throw) {
+    const failing = options.warnings
+      ? diagnostics
+      : diagnostics.filter((d) => d.severity === "error");
+    if (failing.length > 0) {
+      throw new AgentLintError(machine.id ?? "(machine)", failing);
+    }
+  }
+
+  return diagnostics;
 }
 
 /**
- * Thrown by {@link assertAgentMachine} when lint finds failing diagnostics.
+ * Thrown by `lintAgentMachine(machine, { throw: true })` when lint finds
+ * failing diagnostics.
  * `diagnostics` holds the findings; the message lists them one per finding,
  * so a test runner's failure output reads like the CLI's lint report.
  */
@@ -713,32 +742,6 @@ export class AgentLintError extends AgentError {
   }
 }
 
-/**
- * Asserts a machine passes {@link lintAgentMachine}: returns silently when
- * clean, throws {@link AgentLintError} (with the findings on `.diagnostics`)
- * otherwise. Fails on error-severity findings; set `warnings: true` to fail on
- * warnings too. The one-liner for tests and generation loops:
- *
- * @example
- * ```ts
- * test('agent machine is structurally sound', () => {
- *   assertAgentMachine(machine);
- * });
- * ```
- */
-export function assertAgentMachine(
-  machine: AnyStateMachine,
-  options: AssertAgentMachineOptions = {},
-): void {
-  const diagnostics = lintAgentMachine(machine, options);
-  const failing = options.warnings
-    ? diagnostics
-    : diagnostics.filter((d) => d.severity === "error");
-  if (failing.length > 0) {
-    throw new AgentLintError(machine.id ?? "(machine)", failing);
-  }
-}
-
 // ─── Simulation ───
 
 /**
@@ -749,13 +752,17 @@ export function assertAgentMachine(
  *   `setupAgent({ requests })` key, or `agent.generateText`/`agent.streamText`).
  * - `decisions` — the {@link ChosenEvent} to apply for a decision request,
  *   keyed by decision src (usually `agent.decide`).
- * - `invokes` — output values for scripted invokes (notably `agent.userInput`,
- *   and any other actor whose output must be canned), keyed by src.
+ * - `invokes` — output values for scripted invokes (any actor whose output must
+ *   be canned), keyed by src.
+ * - `userInput` — a flat FIFO queue of answers for `agent.userInput`, the
+ *   shorthand for `invokes: { 'agent.userInput': [...] }`. Entries here are
+ *   consumed before that src's `invokes` queue.
  */
 export interface SimulationScript {
   text?: Record<string, unknown[]>;
   decisions?: Record<string, ChosenEvent[]>;
   invokes?: Record<string, unknown[]>;
+  userInput?: unknown[];
 }
 
 /** One entry in a {@link SimulateAgentResult.trail}: the state after this step, plus what drove the step. */
@@ -844,6 +851,14 @@ export async function simulateAgent(
     decisions: mapValues(options.script.decisions ?? {}, (arr) => [...arr]),
     invokes: mapValues(options.script.invokes ?? {}, (arr) => [...arr]),
   };
+  if (options.script.userInput?.length) {
+    // `userInput` is the shorthand queue for the `agent.userInput` src, and is
+    // consumed before that src's own `invokes` entries.
+    script.invokes![USER_INPUT_SRC] = [
+      ...options.script.userInput,
+      ...(script.invokes![USER_INPUT_SRC] ?? []),
+    ];
+  }
 
   let step = initialAgentStep(machine, options.input);
   const trail: SimulationTrailEntry[] = [];
@@ -918,9 +933,17 @@ function scriptDryError(
     request?.kind === "decision"
       ? ` Candidate events: ${request.events.map((e) => e.type).join(", ") || "(none)"}.`
       : "";
+  const key =
+    kind === "text"
+      ? `text['${src}']`
+      : kind === "decision"
+        ? `decisions['${src}']`
+        : src === USER_INPUT_SRC
+          ? "userInput"
+          : `invokes['${src}']`;
   return new Error(
     `simulateAgent: script ran dry on a pending ${kind} request for src '${src}' (id '${id}'). ` +
-      `Add a '${kind}' entry for '${src}' to the script.${events}`,
+      `Add an entry to the script's \`${key}\` queue.${events}`,
   );
 }
 
@@ -933,8 +956,17 @@ export interface ExplorePathsOptions {
   maxDepth?: number;
   /** Total path cap before exploration stops (reported via `hitPathCap`). Default 200. */
   maxPaths?: number;
-  /** Canned outputs for text/userInput invokes, keyed by src. A missing src halts that branch with a `needs-output` note. */
-  textOutputs?: Record<string, unknown>;
+  /**
+   * Canned output for each text request, keyed by src (the
+   * `setupAgent({ requests })` key, or `agent.generateText`/`agent.streamText`).
+   * One value per src, reused every time that src is reached. A missing src
+   * halts that branch with a `needs-output` terminal.
+   */
+  text?: Record<string, unknown>;
+  /** Canned output for scripted invokes, keyed by src. Same one-value-per-src rule as `text`. */
+  invokes?: Record<string, unknown>;
+  /** Canned output for `agent.userInput`, the shorthand for `invokes['agent.userInput']`. */
+  userInput?: unknown;
 }
 
 /** A single explored path's terminal outcome. */
@@ -978,7 +1010,11 @@ async function explore(
 ): Promise<{ report: AgentPathReport; witness?: ChosenEvent[] }> {
   const maxDepth = options.maxDepth ?? 8;
   const maxPaths = options.maxPaths ?? 200;
-  const textOutputs = options.textOutputs ?? {};
+  const textScript = options.text ?? {};
+  const invokeOutputs: Record<string, unknown> = { ...(options.invokes ?? {}) };
+  if ("userInput" in options) {
+    invokeOutputs[USER_INPUT_SRC] = options.userInput;
+  }
 
   const reachedStates = new Set<string>();
   const reachedValues: unknown[] = [];
@@ -1015,10 +1051,10 @@ async function explore(
       }
       const request = current.requests[0] as AgentStepRequest | undefined;
       if (request && request.kind === "text") {
-        if (!(request.src in textOutputs)) {
+        if (!(request.src in textScript)) {
           return { step: current, blockedSrc: request.src };
         }
-        current = resolveAgentStep(machine, current, request, textOutputs[request.src]);
+        current = resolveAgentStep(machine, current, request, textScript[request.src]);
         recordState(current.snapshot);
         continue;
       }
@@ -1028,10 +1064,10 @@ async function explore(
       // No request: maybe a pending scripted invoke (userInput), else a wait.
       const [invoke] = pendingInvokes(current);
       if (invoke) {
-        if (!(invoke.src in textOutputs)) {
+        if (!(invoke.src in invokeOutputs)) {
           return { step: current, blockedSrc: invoke.src };
         }
-        current = resolveAgentStep(machine, current, invoke.id, textOutputs[invoke.src]);
+        current = resolveAgentStep(machine, current, invoke.id, invokeOutputs[invoke.src]);
         recordState(current.snapshot);
         continue;
       }
@@ -1134,9 +1170,10 @@ async function explore(
  * depth, model-free, and reports which states are reached and how each path
  * terminates. At each decision request it forks one branch per candidate event
  * (guard-rejected candidates are counted in `prunedByGuard`, not explored); at
- * an idle wait it forks per externally-accepted event. Text/`userInput` invokes
- * are resolved from `textOutputs` (a by-src canned-output map) — a missing src
- * halts that branch with a `needs-output` terminal rather than throwing.
+ * an idle wait it forks per externally-accepted event. Text requests resolve
+ * from `text`, other invokes from `invokes` (or `userInput` for
+ * `agent.userInput`) — all by-src canned-output maps, and a missing src halts
+ * that branch with a `needs-output` terminal rather than throwing.
  *
  * Combinatorics are bounded by `maxDepth` (default 8) and `maxPaths` (default
  * 200, reported via `hitPathCap`).
@@ -1156,20 +1193,22 @@ export async function explorePaths(
 
 /** The result of a {@link canReach} query. */
 export interface CanReachResult {
-  canReach: boolean;
+  /** True when the target state was reached within the exploration bounds. */
+  reachable: boolean;
   /** When reachable, the sequence of chosen/applied events that gets there. */
   witness?: ChosenEvent[];
 }
 
 /**
  * Answers "can the machine reach `statePath`?" by exploring its branches (a
- * thin wrapper over {@link explorePaths}). Returns `{ canReach: true, witness }`
- * with the event sequence that reaches it, or `{ canReach: false }`.
+ * thin wrapper over {@link explorePaths}). Returns
+ * `{ reachable: true, witness }` with the event sequence that reaches it, or
+ * `{ reachable: false }`.
  *
  * @example
  * ```ts
- * const { canReach, witness } = await canReach(refundMachine, 'denied', { input: { request: 'x', amount: 5000 } });
- * // canReach → true; witness → [{ type: 'NEEDS_REVIEW' }, { type: 'DENY' }]
+ * const { reachable, witness } = await canReach(refundMachine, 'denied', { input: { request: 'x', amount: 5000 } });
+ * // reachable → true; witness → [{ type: 'NEEDS_REVIEW' }, { type: 'DENY' }]
  * ```
  */
 export async function canReach(
@@ -1184,5 +1223,5 @@ export async function canReach(
       return false;
     }
   });
-  return witness !== undefined ? { canReach: true, witness } : { canReach: false };
+  return witness !== undefined ? { reachable: true, witness } : { reachable: false };
 }

--- a/src/workflow-config-schema.test.ts
+++ b/src/workflow-config-schema.test.ts
@@ -9,6 +9,7 @@ import {
   type SchemaCompiler,
   type StandardSchemaV1,
 } from "./index.js";
+import { validateAgentConfig } from "./validate/index.js";
 
 const workflowSchema = JSON.parse(
   readFileSync(fileURLToPath(new URL("../schemas/agent-workflow.json", import.meta.url)), "utf8"),
@@ -206,5 +207,35 @@ describe("schemas/agent-workflow.json", () => {
         guards: { isReady: () => true },
       }),
     ).not.toThrow();
+  });
+});
+
+describe("validateAgentConfig", () => {
+  test("accepts configs the shipped schema allows", () => {
+    expect(validateAgentConfig(exampleWorkflow)).toEqual({ valid: true, errors: [] });
+    expect(validateAgentConfig(kitchenSinkWorkflow)).toEqual({ valid: true, errors: [] });
+  });
+
+  test("reports diagnostics with a JSON Pointer path for an invalid config", () => {
+    const result = validateAgentConfig({
+      key: "broken",
+      // `initial` and `states` are missing; `requests` has the wrong type.
+      requests: "nope",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    for (const error of result.errors) {
+      expect(error.severity).toBe("error");
+      expect(error.path.startsWith("/")).toBe(true);
+      expect(typeof error.message).toBe("string");
+      expect(typeof error.keyword).toBe("string");
+    }
+    expect(result.errors.some((error) => error.path === "/requests")).toBe(true);
+  });
+
+  test("agrees with a directly-compiled Ajv validator", () => {
+    const config = { key: "x" };
+    expect(validateAgentConfig(config).valid).toBe(schemaErrors(config).length === 0);
   });
 });

--- a/src/workflow-config.ts
+++ b/src/workflow-config.ts
@@ -26,7 +26,7 @@ import { type AgentRequestMode } from "./text-logic.js";
 import {
   agentExecutionOptions,
   machineStaticTransitionTargets,
-  machineSuspensionPredicates,
+  machineIdlePredicates,
   missingActor,
 } from "./internal/registry.js";
 import {
@@ -160,14 +160,14 @@ export interface AgentWorkflowConfig {
   /**
    * State tags that mark an INTENTIONAL wait for an external event (a human
    * approval, an inbound webhook, …) — the declarative form of `setupAgent({
-   * isSuspended })`, since a config cannot carry a function. Lowered to a
+   * isIdle })`, since a config cannot carry a function. Lowered to a
    * `snapshot.hasTag(...)`-any-of predicate so `runAgent` settles those
    * snapshots idle deterministically instead of using its timing heuristic.
    * Every listed tag must appear in some state's `tags` — an unused tag is a
-   * build-time error. A `fromConfig(config, { isSuspended })` option takes
-   * precedence; a `runAgent({ isSuspended })` host override beats both.
+   * build-time error. A `fromConfig(config, { isIdle })` option takes
+   * precedence; a `runAgent({ isIdle })` host override beats both.
    */
-  suspendedTags?: string[];
+  idleTags?: string[];
   meta?: Record<string, unknown>;
 }
 
@@ -910,33 +910,33 @@ function collectDeclaredStateTags(
   return tags;
 }
 
-// Resolves the machine-carried suspension predicate for a fromConfig machine:
-// the host `options.isSuspended` function when given, else the config's
-// declarative `suspendedTags` lowered to a hasTag-any-of predicate. A
-// `suspendedTags` entry no state declares is a typo'd silent no-op — the
-// machine would never test as suspended there — so it throws at build time.
-function resolveSuspensionPredicate(
+// Resolves the machine-carried idle predicate for a fromConfig machine:
+// the host `options.isIdle` function when given, else the config's
+// declarative `idleTags` lowered to a hasTag-any-of predicate. A
+// `idleTags` entry no state declares is a typo'd silent no-op — the
+// machine would never tests as idle there — so it throws at build time.
+function resolveIdlePredicate(
   config: AgentWorkflowConfig,
   options: FromConfigOptions,
 ): ((snapshot: AnyMachineSnapshot) => boolean) | undefined {
-  if (options.isSuspended) {
-    return options.isSuspended;
+  if (options.isIdle) {
+    return options.isIdle;
   }
-  const suspendedTags = config.suspendedTags ?? [];
-  if (!suspendedTags.length) {
+  const idleTags = config.idleTags ?? [];
+  if (!idleTags.length) {
     return undefined;
   }
   const declaredTags = collectDeclaredStateTags(config.states);
-  const unknown = suspendedTags.filter((tag) => !declaredTags.has(tag));
+  const unknown = idleTags.filter((tag) => !declaredTags.has(tag));
   if (unknown.length) {
     throw new Error(
-      `setupAgent.fromConfig: 'suspendedTags' lists ${unknown
+      `setupAgent.fromConfig: 'idleTags' lists ${unknown
         .map((tag) => `'${tag}'`)
         .join(", ")}, which no state declares in its 'tags'. Tag the waiting state(s) — e.g. ` +
         `"tags": ["${unknown[0]}"] — or remove the entry.`,
     );
   }
-  return (snapshot) => suspendedTags.some((tag) => snapshot.hasTag(tag));
+  return (snapshot) => idleTags.some((tag) => snapshot.hasTag(tag));
 }
 
 // Implementation backing the public `setupAgent.fromConfig(...)` namespace member (see setup-agent.ts) — translates an AgentWorkflowConfig into MachineJSON and builds the machine through xstate's createMachineFromConfig.
@@ -1005,12 +1005,12 @@ export function setupAgentFromConfig(
   if (machine.config) {
     machineStaticTransitionTargets.set(machine.config as object, translation.transitionTargets);
   }
-  // The wait-state predicate (options.isSuspended, or the config's declarative
-  // `suspendedTags`), carried on the root config like setupAgent's — so it
+  // The wait-state predicate (options.isIdle, or the config's declarative
+  // `idleTags`), carried on the root config like setupAgent's — so it
   // survives further `machine.provide(...)` executor rebinding.
-  const isSuspended = resolveSuspensionPredicate(config, options);
-  if (isSuspended && machine.config) {
-    machineSuspensionPredicates.set(machine.config as object, isSuspended);
+  const isIdle = resolveIdlePredicate(config, options);
+  if (isIdle && machine.config) {
+    machineIdlePredicates.set(machine.config as object, isIdle);
   }
   return { machine, schemas };
 }
@@ -1064,12 +1064,12 @@ export interface FromConfigOptions {
   actions?: Record<string, (params: any) => unknown>;
   /**
    * Detects a snapshot that is an INTENTIONAL wait for an external event —
-   * the same machine-carried predicate `setupAgent({ isSuspended })` declares
+   * the same machine-carried predicate `setupAgent({ isIdle })` declares
    * for TS-authored machines, registered here because a function cannot live
    * in the workflow config itself. Takes precedence over the config's
-   * declarative {@link AgentWorkflowConfig.suspendedTags}; a
-   * `runAgent({ isSuspended })` host override beats both. Travels with the
+   * declarative {@link AgentWorkflowConfig.idleTags}; a
+   * `runAgent({ isIdle })` host override beats both. Travels with the
    * machine through `machine.provide(...)`.
    */
-  isSuspended?: (snapshot: AnyMachineSnapshot) => boolean;
+  isIdle?: (snapshot: AnyMachineSnapshot) => boolean;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "declaration": true,
     "sourceMap": true,
     "isolatedModules": true,
+    "resolveJsonModule": true,
     "paths": {
       "@statelyai/agent": ["./src/index.ts"],
       "@statelyai/agent/ai-sdk": ["./src/ai-sdk/index.ts"],

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     machines: "src/machines/index.ts",
     otel: "src/otel/index.ts",
     sqlite: "src/sqlite/index.ts",
+    validate: "src/validate/index.ts",
   },
   format: ["esm", "cjs"],
   dts: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,10 @@ export default {
     // clobbers the subpath imports.
     alias: [
       { find: "@statelyai/agent/ai-sdk", replacement: src("ai-sdk/index.ts") },
+      { find: "@statelyai/agent/machines", replacement: src("machines/index.ts") },
+      { find: "@statelyai/agent/otel", replacement: src("otel/index.ts") },
       { find: "@statelyai/agent/sqlite", replacement: src("sqlite/index.ts") },
+      { find: "@statelyai/agent/validate", replacement: src("validate/index.ts") },
       { find: /^@statelyai\/agent$/, replacement: src("index.ts") },
     ],
   },


### PR DESCRIPTION
## Summary

Two coordinated passes, verified together (795 tests green, typecheck/build green, `docs:check` 115 blocks / 0 failed).

### API consistency pass (approved item-by-item)

**Renames**
- `isSuspended` → `isIdle`, `suspendedTags` → `idleTags` (matches `status: 'idle'`)
- `canReach` → `{ reachable, witness }`
- `AgentEventLogConflictError.actualLength` → `actualIndex`
- `createLoopMachine` `maxIterations` → `maxTurns`; `createToolLoopMachine` `maxTurns` → `maxSteps`
- Budget error code `max-model-calls`, exported as `AgentMaxModelCallsExceededError` (branchable in `onError`)

**Removals**
- `persistSnapshot` (XState-native `getPersistedSnapshot` / `result.persistedSnapshot`)
- `verifyReplay` (→ `replay(..., { verify: 'strict' })`)
- `assertAgentMachine` (→ `lintAgentMachine(m, { throw: true })`)
- `explorePaths.textOutputs` (→ `text` / `invokes` / `userInput` channels)
- fork `atEventId` (`upToIndex` exclusive is the only address)
- `onIllegalResumeEvent` (illegal resume always rejects)
- `runAgent({ machineVersion })` (`createMachine({ version })` is the single source; xstate-native `migrate` owns mismatches)
- `runSeam` `{ model }` form (→ `{ request, occurrence }`; last-entry repeat now opt-in `repeatLast`)
- `interruptOn` (was a no-op convention; tool-call gating moved to roadmap)

**Behavior**
- `'*'` receives `@agent.usage` (plain wildcard semantics; model-facing `allowedEvents` still excludes `@agent.*`)
- `provideExecutors` inherits executors recursively into child machines (same as `runAgent`)
- `decide(request, info)`; `resolveDecision(request, executors, options)`
- Typed request `maxSteps` (adapter falls back to `metadata.maxSteps`)
- `setupAgent` throws on user keys with the reserved `agent.` prefix
- Scripted queues throw when dry; `userInput` queues added
- `getStateMeta` merge is deterministic (depth, then state id)

**New**
- `validateAgentConfig` at `@statelyai/agent/validate` (ajv optional peer; root bundle dependency-free)
- `getSnapshotRequests` / `getSnapshotNodes` (no more `snapshot._nodes` in host code)

### Docs restyle
- All 30 pages rewritten to plain reference prose (style contract in `.scratch/docs-style-contract.md`)
- 54 `<!-- viz: -->` placeholders for diagrams
- Sample bugs fixed and verified against src (quickstart guard-retry now demonstrated, from-a-loop models `lookupOrder` + model-chosen `amount`, langgraph examples equivalent and honest, `seamCasesFrom` matches by done event)
- Verified-semantics statements added (billing authority of `result.usage`, verification-hash ownership, restore precedence, fromConfig validation contract)
- New `CONTRIBUTING.md`; package entry-points table on index; roadmap re-split Planned / Not planned

Changeset included (`minor`, alpha pre-mode).

### Follow-ups (not in this PR)
- xstate: public `snapshot.nodes` getter (one `// TODO(xstate)` marks the remaining internal `_nodes` read)
- `.gitignore`: `node_modules/` doesn't match symlinked node_modules (bit this worktree)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/agent/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->