### PR TITLE
docs: synchronize recent audit findings

### DIFF
--- a/docs/evals.md
+++ b/docs/evals.md
@@ -152,6 +152,7 @@ To eval a seam, run the machine end to end but route every request except one to
 
 <!-- viz: seam eval: chain of model calls in one run, all scripted except the seam under test, with before/after trajectory slices marked at the seam's completion -->
 
+<!-- runSeam options and result fields from src/seam.ts -->
 
 ```ts
 import { matchesTrajectory, runSeam } from "@statelyai/agent";
@@ -184,7 +185,9 @@ The result carries the seam's own answer and two slices, ready for `matchesTraje
 
 ```ts
 run.seamOutput; // what the seam call returned
+run.seamUsage; // token usage reported by the seam call, when available
 run.callsBeforeSeam; // model calls made before it (-1 if never reached)
+run.calls; // ordered text-call ledger: routing key, source, and seam marker
 run.before; // { statePath, events } up to the seam's completion
 run.after; // { statePath, events } from it onward: the branch the seam caused
 run.result; // the full RunAgentResult; `events` is the whole run's log

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -185,9 +185,7 @@ The result carries the seam's own answer and two slices, ready for `matchesTraje
 
 ```ts
 run.seamOutput; // what the seam call returned
-run.seamUsage; // token usage reported by the seam call, when available
 run.callsBeforeSeam; // model calls made before it (-1 if never reached)
-run.calls; // ordered text-call ledger: routing key, source, and seam marker
 run.before; // { statePath, events } up to the seam's completion
 run.after; // { statePath, events } from it onward: the branch the seam caused
 run.result; // the full RunAgentResult; `events` is the whole run's log

--- a/docs/machines.md
+++ b/docs/machines.md
@@ -79,6 +79,13 @@ Both `enq.emit({ type: 'EVALUATED', ... })` and the host-side `on: { EVALUATED: 
 
 > **Note:** To reuse one schema set across machines or the step helpers, declare it once with `createAgentSchemas({ context, input, output, events })` and pass it as `setupAgent({ schemas })`. This is equivalent to the inline form. See [Authoring forms](#authoring-forms).
 
+<!-- getAgentSchemas registration and lookup from src/setup-agent.ts -->
+
+When a generic host receives only a machine, call `getAgentSchemas(machine)` to
+recover its schema pack for validation or form generation. It returns
+`undefined` for plain XState machines. Read it before `machine.provide(...)`;
+the provided machine is a new object and does not carry the registration.
+
 ## Agent setup
 
 <!-- setupAgent config surface (models, requests, actors, builtins) from src/setup-agent.ts -->

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -163,7 +163,10 @@ Exploration is bounded by `maxDepth`, which defaults to 8, and `maxPaths`, which
 
 ## Reachability checks
 
-`canReach(machine, statePath, opts)` wraps `explorePaths` to report whether a state is reachable, along with a witness path. It is async.
+<!-- canReach contract from src/verify.ts -->
+
+`canReach(machine, target, opts)` wraps `explorePaths` to answer whether a state
+path or snapshot predicate is reachable, with a witness path when it is.
 
 ```ts
 import { canReach } from "@statelyai/agent";

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -166,7 +166,7 @@ Exploration is bounded by `maxDepth`, which defaults to 8, and `maxPaths`, which
 <!-- canReach contract from src/verify.ts -->
 
 `canReach(machine, target, opts)` wraps `explorePaths` to answer whether a state
-path or snapshot predicate is reachable, with a witness path when it is.
+path is reachable, with a witness path when it is.
 
 ```ts
 import { canReach } from "@statelyai/agent";

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 
 Each example lives in a flat `examples/*` directory with an `index.ts` or `index.mts` entrypoint and a `metadata.json` file describing its origin and comparison purpose.
 
-Every example is dual-mode: run it directly against a real model with `OPENAI_API_KEY=... npx tsx examples/<name>/index.ts`, while its tests use injected mocks. Nothing auto-loads `.env`; copy `.env.template` to `.env` and pass it explicitly (Node 22+):
+Model-backed examples run directly with `OPENAI_API_KEY=... npx tsx examples/<name>/index.ts`, while their tests use injected mocks. Verification, migration, and scripted-eval examples are intentionally keyless. Nothing auto-loads `.env`; copy `.env.template` to `.env` and pass it explicitly (Node 22+):
 
 ```bash
 npx tsx --env-file=.env examples/<name>/index.ts
@@ -41,7 +41,7 @@ Good first reads: [`twenty-questions`](twenty-questions/index.ts), [`go-fish`](g
 - [`email-drafter-inspector/index.ts`](email-drafter-inspector/index.ts): the email-drafter machine run as one live `createActor` session wired to `createInspector`, so the whole flow is visible in the Stately Inspector.
 - [`guardrails/index.ts`](guardrails/index.ts): input and output guardrails as explicit gate states that refuse out-of-scope questions and verify answers before returning them.
 - [`context-compaction/index.ts`](context-compaction/index.ts): a self-managing chat loop whose `compacting` state folds stale messages into a running summary once history exceeds a threshold.
-- [`described-workflow/index.ts`](described-workflow/index.ts): a plain invoke-less `createMachine` run as an agent via `runAgent({ getRequests })`, with prompts read from state descriptions.
+- [`described-workflow/index.ts`](described-workflow/index.ts): a plain `createMachine` whose writing states send their described prompts directly and whose idle judging gate is interpreted through `runAgent({ getRequests })`.
 - [`plain-xstate/index.ts`](plain-xstate/index.ts): a normal XState v6 `setup(...)` machine with zero knowledge of the library, adopted as an agent through `getAcceptedEvents` and `resolveDecision`.
 - [`json-agent/index.ts`](json-agent/index.ts): `setupAgent.fromConfig(...)` lowering a support-ticket workflow authored as a real `.json` file.
 - [`preset-machine/index.ts`](preset-machine/index.ts): `createParallelMachine` from `@statelyai/agent/machines`, running two review branches as regions of one parallel state and joining by branch name.
@@ -70,8 +70,8 @@ Good first reads: [`twenty-questions`](twenty-questions/index.ts), [`go-fish`](g
 - [`subflows/index.ts`](subflows/index.ts): agent machines invoking other agent machines as XState child actors, each keeping its own executor binding.
 - [`fan-out/index.ts`](fan-out/index.ts): dynamic runtime fan-out, where a planner produces N subtopics, the machine spawns one live child branch each, and a reducer composes the results.
 - [`rag/index.ts`](rag/index.ts): retrieval as a typed plain actor feeding a grounded answer, with conversational memory in context.
-- [`corrective-rag/index.ts`](corrective-rag/index.ts): corrective RAG as explicit states, grading documents and branching into query rewrite and a web-search fallback.
-- [`adaptive-rag/index.ts`](adaptive-rag/index.ts): adaptive RAG routing between local retrieval and search, then grading, bounded rewriting, and verifying the generation.
+- [`corrective-rag/index.ts`](corrective-rag/index.ts): corrective RAG as explicit states, grading documents and branching into query rewrite and a separate sample-index fallback.
+- [`adaptive-rag/index.ts`](adaptive-rag/index.ts): adaptive RAG routing between a local corpus and sample web index, then grading, bounded rewriting, and verifying the generation.
 - [`deep-research/index.ts`](deep-research/index.ts): planning complementary searches, one dynamically spawned researcher per query, coverage reflection, and a sourced report.
 - [`reflection-writer/index.ts`](reflection-writer/index.ts): a generate and critique loop with a typed `maxRevisions` bound and a structured early exit.
 - [`code-assistant/index.ts`](code-assistant/index.ts): self-correcting code generation with sandboxed `node:vm` checks and a bounded reflect-and-regenerate branch.


### PR DESCRIPTION
## Summary
- refresh eval, machine, verification, and examples documentation
- align documented outputs and options with current source

## Validation
- `pnpm docs:check` (115 blocks checked, 0 failed)
- `git diff --check`