### PR TITLE
docs: document durable runner requirements

### DIFF
--- a/docs/choosing-a-run-mode.md
+++ b/docs/choosing-a-run-mode.md
@@ -1,32 +1,36 @@
 ---
 title: Choosing a run mode
-description: Three ways to execute the same agent machine, what each one owns, and which to reach for.
+description: Four ways to execute the same agent machine, what each one owns, and which to reach for.
 ---
 
 > **Alpha:** `@statelyai/agent` 2.0 is in alpha. APIs can change between releases; pin an exact version. Feedback: [github.com/statelyai/agent](https://github.com/statelyai/agent/issues).
 
-This page describes the three ways to execute an agent machine and how to choose between them.
+This page describes the four ways to execute an agent machine and how to choose between them.
 
-## Three ways to execute one machine
+## Four ways to execute one machine
 
-An agent machine declares states, requests, and decisions. It does not run itself and does not call a model. A host drives it. There are three hosts to choose from:
+<!-- public execution modes from src/index.ts, src/run.ts, src/provide-executors.ts, src/durable.ts, and src/effects.ts -->
+
+An agent machine declares states, requests, and decisions. It does not run itself and does not call a model. A host drives it. There are four hosts to choose from:
 
 - `runAgent` (controlled). The library owns the actor and the run loop.
 - `provideExecutors` with `createActor` (uncontrolled). You own the actor and XState drives it.
+- `runDurableAgent` (durable runtime). The library owns an event-sourced durable loop.
 - The step path (`getAgentEffects`, `executeAgentRequest`, `replay`). You own the loop and the persistence.
 
-The machine is the same in all three modes. The same file runs under each one, and the same tests cover it. Only the host changes.
+The machine is the same in all four modes. The same file runs under each one, and the same tests cover it. Only the host changes.
 
-<!-- viz: one machine feeding three hosts: runAgent (library-owned actor + loop), provideExecutors + createActor (user-owned actor), step path (user-owned loop + event log) -->
+<!-- viz: one machine feeding four hosts: runAgent (library-owned actor + loop), provideExecutors + createActor (user-owned actor), runDurableAgent (library-owned durable loop + event log), step path (user-owned loop + event log) -->
 
 
 ## Decision table
 
-| Mode                   | You own                                             | The library owns                                                    | Durability                                                  | Reach for it when                                                                                                 |
-| ---------------------- | --------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **`runAgent`**         | The call site and the executors                     | The actor, the run loop, request retries, usage aggregation, traces | Snapshot per settle, plus a replayable `result.events` log  | Scripts, HTTP handlers, workers, and anything with a request/response boundary                                    |
-| **`provideExecutors`** | `createActor`, the actor lifecycle, subscriptions   | Executor binding for agent sources only                             | Whatever you persist off the actor (`getPersistedSnapshot`) | A host that already owns an actor lifecycle, such as React, a Durable Object, or a long-lived process             |
-| **Step path**          | The loop, the event log, when to persist, the clock | Pure effect derivation, request execution, replay, verification     | Event-sourced. Append before continue, resume by `replay`   | Serverless per turn, queue-driven work, durable execution engines, and crash recovery that cannot re-bill model calls |
+| Mode                    | You own                                             | The library owns                                                    | Durability                                                  | Reach for it when                                                                                                 |
+| ----------------------- | --------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **`runAgent`**          | The call site and the executors                     | The actor, the run loop, request retries, usage aggregation, traces | Snapshot per settle, plus a replayable `result.events` log  | Scripts, HTTP handlers, workers, and anything with a request/response boundary                                    |
+| **`provideExecutors`**  | `createActor`, the actor lifecycle, subscriptions   | Executor binding for agent sources only                             | Whatever you persist off the actor (`getPersistedSnapshot`) | A host that already owns an actor lifecycle, such as React, a Durable Object, or a long-lived process             |
+| **`runDurableAgent`**   | Journal persistence and the external event boundary | The durable runtime loop, executor binding, and replay              | Event-sourced. Persist `entries`; resume with an event       | Durable request/response turns without writing the host loop                                                      |
+| **Step path**           | The loop, the event log, when to persist, the clock | Pure effect derivation, request execution, replay, verification     | Event-sourced. Append before continue, resume by `replay`   | Custom durable engines and crash recovery that cannot re-bill completed model calls                               |
 
 ### Idle handling
 
@@ -34,6 +38,7 @@ Each mode reaches the point where the machine waits for an outside event differe
 
 - `runAgent` settles with status `idle` and returns a snapshot to resume from.
 - `provideExecutors` does not settle. The actor stays alive in its current state until you send it an event.
+- `runDurableAgent` settles with status `idle`; persist `entries` and resume with them plus an external `event`.
 - On the step path, you detect idle yourself. When no asynchronous effect is owed, persist and return.
 
 ## Start with `runAgent`
@@ -43,7 +48,8 @@ Each mode reaches the point where the machine waits for an outside event differe
 Choose another mode when one of these is true:
 
 - The host already owns an actor and a render loop. Use the uncontrolled mode instead of running a second loop inside it.
-- Each turn is a separate process invocation, or a crash between two model calls must not re-run the completed call. Use the step path.
+- Each turn is a separate process invocation and the standard durable loop fits. Use `runDurableAgent`.
+- You need custom persistence, scheduling, or effect execution. Use the step path.
 
 Everything else uses `runAgent` with a persisted snapshot, including human-in-the-loop pauses that last days.
 
@@ -93,6 +99,27 @@ actor.start();
 - To trace an uncontrolled run, pass `onTrace` to `provideExecutors` and pass `traceTransitions(onTrace)` to the actor's `inspect` option. The two produce one merged stream.
 
 Read more about [Use in any stack](any-stack.md#controlled-and-uncontrolled).
+
+## Durable runtime: `runDurableAgent`
+
+```ts
+import { runDurableAgent } from "@statelyai/agent";
+
+const first = await runDurableAgent(machine, { input, executors });
+await store.save(first.entries);
+
+const next = await runDurableAgent(machine, {
+  entries: await store.load(),
+  event: { type: "APPROVE" },
+  executors,
+});
+```
+
+- The result is `done` with `output`, or `idle` awaiting an external event.
+- `entries` is the complete journal. Persist it after each call and pass it back on resume.
+- Recorded invoke completions replay without re-running; work still in flight at a crash runs again.
+- Use `onEntry` when the store should persist each append incrementally.
+- This mode is experimental because it uses XState's experimental durable runtime.
 
 ## Owning the loop: the step path
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -163,7 +163,7 @@ Most patterns are one self-contained `index.ts`, with no shared harness and no l
 2. Install the runtime dependencies. The provider package major version must match your installed `ai` major version. This repo uses `ai@6`, so it uses `@ai-sdk/openai@3` rather than 4.
 
    ```sh
-   pnpm add @statelyai/agent@alpha ai@^6.0.67 zod@^4 xstate@6.0.0-alpha.25 @ai-sdk/openai@^3
+   pnpm add @statelyai/agent@alpha ai@^6.0.67 zod@^4 xstate@6.0.0-alpha.43 @ai-sdk/openai@^3
    pnpm add -D @types/node typescript tsx
    ```
 
@@ -172,7 +172,7 @@ Most patterns are one self-contained `index.ts`, with no shared harness and no l
 
 <!-- peer ranges from package.json#peerDependencies and example schema dependency from package.json#devDependencies -->
 
-`@statelyai/agent` declares these peer ranges: `ai@^6.0.67`, `xstate@>=6.0.0-alpha.25 <6.0.0`, and optionally `@opentelemetry/api@^1`. The examples use Zod 4 directly. The `@alpha` tag floats, so pin the exact version it installs once you have a working build.
+`@statelyai/agent` declares these peer ranges: `ai@^6.0.67`, `xstate@>=6.0.0-alpha.43 <6.0.0`, and optionally `@opentelemetry/api@^1`. The examples use Zod 4 directly. The `@alpha` tag floats, so pin the exact version it installs once you have a working build.
 
 ## Running from the repo
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,7 @@ pnpm add @statelyai/agent@alpha xstate@alpha zod ai@^6 @ai-sdk/openai@^3
 ```
 
 - The `@alpha` tag floats. Install it once, then run `npm ls @statelyai/agent` and pin the resolved version, so a later alpha cannot change the API.
-- `xstate` is the only required peer dependency, at v6 alpha.25 or newer. Node must be 22.18 or newer.
+- `xstate` is the only required peer dependency, at v6 alpha.43 or newer. Node must be 22.18 or newer.
 - Provider packages must match your `ai` major version. `@ai-sdk/openai@^3` pairs with `ai@^6`. A bare `@ai-sdk/openai` resolves to `@latest`, whose `LanguageModel` spec version may not match your `ai` peer.
 - The package is ESM-first. Every entry point also ships a CommonJS build, so `require()` works. The examples use top-level `await`, which requires ESM. Set `"type": "module"` in `package.json`, or use `.mts` files.
 
@@ -212,7 +212,7 @@ If a run must reach a final state, use `generateResult(machine, options)` instea
 
 ### Other ways to run the same machine
 
-`runAgent` is the default, but not the only option. `provideExecutors` binds the executors onto the machine and returns it for use with a plain `createActor`. The step path lets a durable host own the loop and the persistence. The machine is identical in all three modes. See [Choosing a run mode](choosing-a-run-mode.md).
+`runAgent` is the default, but not the only option. `provideExecutors` binds the executors onto the machine for a plain `createActor`. `runDurableAgent` owns an event-sourced durable loop, while the step path lets your host own that loop and persistence. The machine is identical in all four modes. See [Choosing a run mode](choosing-a-run-mode.md).
 
 ### Testing without an API key
 

--- a/docs/thinking-in-state-machines.md
+++ b/docs/thinking-in-state-machines.md
@@ -11,7 +11,9 @@ The example is a support triage agent. It classifies a ticket, drafts a reply, h
 
 For the mechanical refactor of an existing codebase, see [Migrating from a hand-rolled loop](from-a-loop.md). This page covers the design work that comes first.
 
-> **Version requirement.** Build the machine with the `xstate` install this package peers on, v6 alpha.25 or newer. See [Installation](quickstart.md#installation). Machines authored for XState v5 usually port with few changes, but a machine object imported from a separate `xstate@5` install does not bind. Write event-transition guards as functions that return `undefined`. XState v6 drops named string guards on `on`, and the function form is what makes `snapshot.can(event)` reflect the guard.
+<!-- xstate version requirement from package.json#peerDependencies -->
+
+> **Version requirement.** Build the machine with the `xstate` install this package peers on, v6 alpha.43 or newer. See [Installation](quickstart.md#installation). Machines authored for XState v5 usually port with few changes, but a machine object imported from a separate `xstate@5` install does not bind. Write event-transition guards as functions that return `undefined`. XState v6 drops named string guards on `on`, and the function form is what makes `snapshot.can(event)` reflect the guard.
 
 ## The loop to model
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ pnpm add @statelyai/agent@alpha xstate@alpha zod ai@^6 @ai-sdk/openai@^3
 
 Requirements:
 
-- Node 22.18 or newer, and XState v6 alpha.25 or newer.
+- Node 22.18 or newer, and XState v6 alpha.43 or newer.
 - The package is ESM-first. CommonJS builds are published too, so `require()` works.
 - Provider packages must match your `ai` major: `@ai-sdk/openai@^3` pairs with `ai@^6`. A bare `@ai-sdk/openai` resolves to `@latest`, which can mismatch the `ai` peer.
 


### PR DESCRIPTION
Summary:
- update the XState peer floor to alpha.43
- document runDurableAgent as the fourth execution mode
- add source-linked documentation markers

Validation:
- pnpm docs:check
- pnpm build
- pnpm check:dts
- pnpm vitest run src/durable.test.ts
- local Markdown link scan
- git diff --check