### PR TITLE
Durable timer support for runDurableAgent

### DIFF
--- a/.changeset/durable-timers.md
+++ b/.changeset/durable-timers.md
@@ -1,0 +1,10 @@
+---
+"@statelyai/agent": minor
+---
+
+**`runDurableAgent` timers.** `after(...)` delays now work on durable hosts, in two modes via `options.timers`:
+
+- `'live'` (default): timers arm on real in-process `setTimeout`s; the run stays open until they fire and each firing is journaled (`{ type: 'xstate.timer', id }`), so a replay never re-waits.
+- `'external'`: timers are recorded but never armed — the run settles `idle` with `pendingTimers: [{ id, delayMs }]`, the host schedules its own wake-up (a Durable Object alarm, a delayed message, a cron), and resumes with the timer's firing event. Stale firings (state already exited) are ignored by the machine, so at-least-once schedulers are safe.
+
+Replayed frontiers never re-arm a timer whose firing is journaled, and an event that exits a delayed state cancels its timer through the adapter.

--- a/src/durable.test.ts
+++ b/src/durable.test.ts
@@ -292,3 +292,44 @@ describe("runDurableAgent timers", () => {
     expect(counters.modelCalls).toBe(1);
   });
 });
+
+describe("runDurableAgent timer/idle interplay", () => {
+  test("live mode: isIdle settling a delayed wait state disarms the timer and reports it", async () => {
+    // The 'wait for human, auto-proceed after timeout' pattern: the state is
+    // an isIdle wait AND carries an after(...). Settling idle must not leak
+    // the armed setTimeout (it would hold the process open and fire into a
+    // discarded mailbox).
+    const agent = setupAgent({
+      context: z.object({}),
+      events: { APPROVE: z.object({}) },
+    });
+    const machine = agent.createMachine({
+      id: "idle-timer",
+      context: {},
+      initial: "waiting",
+      states: {
+        waiting: {
+          tags: ["awaiting-user"],
+          after: { 60_000: { target: "timedOut" } },
+          on: { APPROVE: { target: "done" } },
+        },
+        timedOut: { type: "final" },
+        done: { type: "final" },
+      },
+    });
+
+    const started = Date.now();
+    const idle = await runDurableAgent(machine, {
+      isIdle: (snapshot) => snapshot.hasTag("awaiting-user"),
+    });
+    // Settles immediately — not held open by the 60s timer.
+    expect(Date.now() - started).toBeLessThan(1000);
+    expect(idle.status).toBe("idle");
+    if (idle.status !== "idle") throw new Error("unreachable");
+    // The disarmed timer is still reported, so a host can schedule the
+    // auto-proceed wake-up; a resume re-arms it (firing was never journaled).
+    expect(idle.pendingTimers).toEqual([
+      { id: expect.stringContaining("xstate.after"), delayMs: 60_000 },
+    ]);
+  });
+});

--- a/src/durable.test.ts
+++ b/src/durable.test.ts
@@ -183,3 +183,112 @@ describe("runDurableAgent", () => {
     expect(streamed).toEqual(result.entries.map((entry) => entry.event.type));
   });
 });
+
+// A reminder machine: drafting (model call) → grace period (`after`) → sent,
+// with NUDGE escaping the wait early. Exercises both timer modes.
+function buildTimerMachine(counters: { modelCalls: number }) {
+  const agent = setupAgent({
+    context: z.object({ draft: z.string().nullable() }),
+    output: z.object({ draft: z.string() }),
+    events: { NUDGE: z.object({}) },
+    requests: {
+      draft: {
+        schemas: { input: z.object({}), output: z.string() },
+        model: "m",
+        prompt: () => "write it",
+      },
+    },
+  });
+  return agent.createMachine({
+    id: "timed-draft",
+    context: { draft: null },
+    initial: "drafting",
+    states: {
+      drafting: {
+        invoke: {
+          src: "draft",
+          input: () => ({}),
+          onDone: ({ output }) => ({ target: "grace", context: { draft: output } }),
+        },
+      },
+      grace: {
+        after: { 30: { target: "sent" } },
+        on: { NUDGE: { target: "sent" } },
+      },
+      sent: { type: "final", output: ({ context }) => ({ draft: context.draft ?? "" }) },
+    },
+  });
+}
+
+describe("runDurableAgent timers", () => {
+  test("live mode: the after() timer fires in-process, is journaled, and replays without re-arming", async () => {
+    const counters = { modelCalls: 0 };
+    const machine = buildTimerMachine(counters);
+    const executors = makeExecutors(counters);
+
+    const done = await runDurableAgent(machine, { executors });
+    expect(done.status).toBe("done");
+    const types = done.entries.map((entry) => entry.event.type);
+    expect(types).toContain("xstate.timer");
+
+    // Resume from the complete journal: replays instantly to done — the model
+    // is not re-called and no timer is re-armed (the run would otherwise hang
+    // or take another 30ms).
+    const started = Date.now();
+    const replayed = await runDurableAgent(machine, { entries: done.entries, executors });
+    expect(replayed.status).toBe("done");
+    expect(counters.modelCalls).toBe(1);
+    expect(Date.now() - started).toBeLessThan(25);
+  });
+
+  test("external mode: settles idle with pendingTimers; the host's timer event completes the run", async () => {
+    const counters = { modelCalls: 0 };
+    const machine = buildTimerMachine(counters);
+    const executors = makeExecutors(counters);
+
+    const idle = await runDurableAgent(machine, { executors, timers: "external" });
+    expect(idle.status).toBe("idle");
+    if (idle.status !== "idle") throw new Error("unreachable");
+    expect(idle.pendingTimers).toHaveLength(1);
+    expect(idle.pendingTimers[0]!.delayMs).toBe(30);
+
+    // The host's scheduler fires later, in a fresh process:
+    const done = await runDurableAgent(machine, {
+      entries: idle.entries,
+      event: { type: "xstate.timer", id: idle.pendingTimers[0]!.id } as never,
+      executors,
+      timers: "external",
+    });
+    expect(done.status).toBe("done");
+    expect(counters.modelCalls).toBe(1);
+  });
+
+  test("external mode: an event exiting the delayed state cancels the timer; a stale firing is a no-op", async () => {
+    const counters = { modelCalls: 0 };
+    const machine = buildTimerMachine(counters);
+    const executors = makeExecutors(counters);
+
+    const idle = await runDurableAgent(machine, { executors, timers: "external" });
+    if (idle.status !== "idle") throw new Error("expected idle");
+    const timerId = idle.pendingTimers[0]!.id;
+
+    // Human nudges before the grace period elapses.
+    const done = await runDurableAgent(machine, {
+      entries: idle.entries,
+      event: { type: "NUDGE" },
+      executors,
+      timers: "external",
+    });
+    expect(done.status).toBe("done");
+
+    // The host's alarm still fires (at-least-once): stale firing is ignored.
+    const after = await runDurableAgent(machine, {
+      entries: done.entries,
+      event: { type: "xstate.timer", id: timerId } as never,
+      executors,
+      timers: "external",
+    });
+    expect(after.status).toBe("done");
+    expect(counters.modelCalls).toBe(1);
+  });
+});

--- a/src/durable.ts
+++ b/src/durable.ts
@@ -37,7 +37,16 @@ import { provideExecutors, type ProvideExecutorsOptions } from "./provide-execut
 import type { AgentRequestExecutors } from "./text-logic.js";
 
 const DONE_ACTOR_EVENT_TYPE = "xstate.done.actor";
+const TIMER_EVENT_TYPE = "xstate.timer";
 const ERROR_ACTOR_EVENT_TYPE = "xstate.error.actor";
+
+function timerEventId(event: EventObject): string | undefined {
+  if (event.type !== TIMER_EVENT_TYPE) {
+    return undefined;
+  }
+  const id = (event as EventObject & { id?: unknown }).id;
+  return typeof id === "string" ? id : undefined;
+}
 
 function completionActorId(event: EventObject): string | undefined {
   if (event.type !== DONE_ACTOR_EVENT_TYPE && event.type !== ERROR_ACTOR_EVENT_TYPE) {
@@ -75,6 +84,20 @@ export interface RunDurableAgentOptions<TMachine extends AnyStateMachine> extend
   /** Explicit machine version for entry stamping; defaults to the structural hash. */
   machineVersion?: string;
   /**
+   * How `after(...)` delays are executed.
+   *
+   * - `'live'` (default): each logical timer runs on a real in-process
+   *   `setTimeout`; the run stays open until it fires (or its state is
+   *   exited) and the firing is journaled like any other event.
+   * - `'external'`: timers are recorded but never armed. The run settles
+   *   `idle` with {@link DurableAgentResult} `pendingTimers`; the host owns
+   *   the clock (an alarm, a delayed message, a cron) and resumes with the
+   *   timer's firing event: `{ type: 'xstate.timer', id }`. A stale firing —
+   *   its state already exited — is ignored by the machine, so at-least-once
+   *   host schedulers are safe.
+   */
+  timers?: "live" | "external";
+  /**
    * Record replay-verification hashes on appended entries. Off by default:
    * hashing replays the whole prefix per entry, which is quadratic in log
    * length.
@@ -97,7 +120,21 @@ export type DurableAgentResult<TMachine extends AnyStateMachine> =
       status: "idle";
       snapshot: SnapshotFrom<TMachine>;
       entries: AgentLogEntry[];
+      /**
+       * Logical timers pending at the frontier (`timers: 'external'` hosts
+       * schedule a wake-up from these and resume with
+       * `{ type: 'xstate.timer', id }`).
+       */
+      pendingTimers: PendingDurableTimer[];
     };
+
+/** One pending `after(...)` timer at an idle frontier. */
+export interface PendingDurableTimer {
+  /** The logical timer id — deterministic, derived from the machine's structure. */
+  id: string;
+  /** The declared delay, in milliseconds. */
+  delayMs: number;
+}
 
 /** Thrown by the adapter's `waitForEvent` when nothing can produce an event. */
 const IDLE = Symbol("agent.durable.idle");
@@ -188,12 +225,19 @@ export async function runDurableAgent<TMachine extends AnyStateMachine>(
   const journal = priorEntries.slice(hasInit ? 1 : 0).map((entry) => entry.event);
 
   // Completions already recorded, per invoke site id: the Nth start of a site
-  // is suppressed while N ≤ its recorded completion count.
+  // is suppressed while N ≤ its recorded completion count. Timer firings get
+  // the same treatment per logical timer id, so a replayed frontier never
+  // re-arms a timer whose firing is already journaled.
   const journaledCompletions = new Map<string, number>();
+  const journaledTimerFirings = new Map<string, number>();
   for (const event of journal) {
     const actorId = completionActorId(event);
     if (actorId !== undefined) {
       journaledCompletions.set(actorId, (journaledCompletions.get(actorId) ?? 0) + 1);
+    }
+    const timerId = timerEventId(event);
+    if (timerId !== undefined) {
+      journaledTimerFirings.set(timerId, (journaledTimerFirings.get(timerId) ?? 0) + 1);
     }
   }
 
@@ -223,6 +267,22 @@ export async function runDurableAgent<TMachine extends AnyStateMachine>(
   const startsSeen = new Map<string, number>();
   // Invoke ids started live this run and not yet completed — pending work.
   const liveInFlight = new Set<string>();
+  const timersMode = options.timers ?? "live";
+  // Pending logical timers by id. In 'live' mode each holds its armed
+  // setTimeout handle; in 'external' mode `handle` stays undefined and the
+  // set is surfaced on the idle result instead.
+  const pendingTimers = new Map<
+    string,
+    { delayMs: number; handle?: ReturnType<typeof setTimeout> }
+  >();
+  const timersSeen = new Map<string, number>();
+  const clearPendingTimer = (id: string) => {
+    const pending = pendingTimers.get(id);
+    if (pending?.handle !== undefined) {
+      clearTimeout(pending.handle);
+    }
+    pendingTimers.delete(id);
+  };
 
   const findChildRef = (effect: unknown): (AnyActor & { id: string }) | undefined => {
     const raw = effect as { actor?: unknown; args?: unknown[] };
@@ -251,6 +311,34 @@ export async function runDurableAgent<TMachine extends AnyStateMachine>(
         return;
       }
       deliverEvent(source as never, target as never, event as never);
+    },
+    scheduleTimer(_source, id, delay) {
+      const seen = (timersSeen.get(id) ?? 0) + 1;
+      timersSeen.set(id, seen);
+      if (seen <= (journaledTimerFirings.get(id) ?? 0)) {
+        // This occurrence already fired in the journal; the replayed firing
+        // event advances the machine.
+        return;
+      }
+      pendingTimers.set(id, {
+        delayMs: delay,
+        ...(timersMode === "live"
+          ? {
+              handle: setTimeout(() => {
+                pendingTimers.delete(id);
+                mailbox.push({ type: TIMER_EVENT_TYPE, id } as EventObject);
+              }, delay),
+            }
+          : {}),
+      });
+    },
+    cancelTimer(_source, id) {
+      clearPendingTimer(id);
+    },
+    cancelAllTimers() {
+      for (const id of [...pendingTimers.keys()]) {
+        clearPendingTimer(id);
+      }
     },
     runtime(_metadata, effect) {
       const type = (effect as { type?: string }).type;
@@ -291,12 +379,16 @@ export async function runDurableAgent<TMachine extends AnyStateMachine>(
       if (mailbox.size() > 0) {
         return (await mailbox.take()) as EventFromLogic<TMachine>;
       }
+      const armedTimers =
+        timersMode === "live" &&
+        [...pendingTimers.values()].some((timer) => timer.handle !== undefined);
       if (
-        liveInFlight.size > 0 &&
+        (liveInFlight.size > 0 || armedTimers) &&
         !(options.isIdle?.(latestSnapshot as SnapshotFrom<TMachine>) ?? false)
       ) {
-        // Live work is in flight (a model call, a task): wait for its event
-        // before considering the host's own — the machine is not at rest yet.
+        // Live work is in flight (a model call, a task, an armed timer): wait
+        // for its event before considering the host's own — the machine is
+        // not at rest yet.
         return (await mailbox.take()) as EventFromLogic<TMachine>;
       }
       if (!liveEventConsumed && options.event !== undefined) {
@@ -375,6 +467,10 @@ export async function runDurableAgent<TMachine extends AnyStateMachine>(
             status: "idle",
             snapshot: snapshot as SnapshotFrom<TMachine>,
             entries,
+            pendingTimers: [...pendingTimers.entries()].map(([id, timer]) => ({
+              id,
+              delayMs: timer.delayMs,
+            })),
           };
         }
         throw error;
@@ -384,6 +480,10 @@ export async function runDurableAgent<TMachine extends AnyStateMachine>(
     const completedId = completionActorId(event);
     if (completedId !== undefined) {
       liveInFlight.delete(completedId);
+    }
+    const firedTimerId = timerEventId(event);
+    if (firedTimerId !== undefined) {
+      clearPendingTimer(firedTimerId);
     }
     if (!fromJournal) {
       appendEntry(event);

--- a/src/durable.ts
+++ b/src/durable.ts
@@ -283,6 +283,19 @@ export async function runDurableAgent<TMachine extends AnyStateMachine>(
     }
     pendingTimers.delete(id);
   };
+  // Disarms armed setTimeouts without forgetting the timers, for an idle
+  // settle: an orphaned handle would keep the process alive and fire into a
+  // discarded mailbox. The timers stay in `pendingTimers` so the idle result
+  // reports them — their firings were never journaled, so a resume re-arms
+  // them (restarting the full delay) or an external scheduler wakes the run.
+  const disarmPendingTimers = () => {
+    for (const pending of pendingTimers.values()) {
+      if (pending.handle !== undefined) {
+        clearTimeout(pending.handle);
+        pending.handle = undefined;
+      }
+    }
+  };
 
   const findChildRef = (effect: unknown): (AnyActor & { id: string }) | undefined => {
     const raw = effect as { actor?: unknown; args?: unknown[] };
@@ -463,6 +476,7 @@ export async function runDurableAgent<TMachine extends AnyStateMachine>(
         event = await execution.waitForEvent();
       } catch (error) {
         if (error === IDLE) {
+          disarmPendingTimers();
           return {
             status: "idle",
             snapshot: snapshot as SnapshotFrom<TMachine>,


### PR DESCRIPTION
Stacked on #103 (retarget to `next` after it merges).

The last runtime-integration gap for durable hosts: machines with `after(...)` delays. Verified against alpha.46's actual timer contract (`scheduleTimer` receives a **stable path-derived id**; `snapshot.timers` is a serializable pending-timer map; `transition` accepts `{ type: 'xstate.timer', id }` and safely ignores stale ids) — so no xstate changes were needed.

- **`timers: 'live'` (default)**: timers arm on in-process `setTimeout`s; the run stays open until they fire; firings are journaled so replays never re-wait (test asserts a resumed 30ms-timer run completes in <25ms with no re-arm).
- **`timers: 'external'`**: timers are recorded, never armed; the run settles `idle` with `pendingTimers: [{ id, delayMs }]`; the host schedules its own wake-up (DO alarm, delayed message, cron) and resumes with the firing event. Stale firings no-op, so at-least-once schedulers are safe.
- `cancelTimer`/`cancelAllTimers` route through the adapter: exiting a delayed state clears its pending timer (and, in live mode, its `setTimeout`).
- Replay suppression is occurrence-counted per logical timer id, mirroring the invoke suppression.

Three new tests (810 total pass); typecheck/lint/format/knip clean; changeset added.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/agent/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->