### PR TITLE
docs: raise XState peer requirement

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -163,7 +163,7 @@ Most patterns are one self-contained `index.ts`, with no shared harness and no l
 2. Install the runtime dependencies. The provider package major version must match your installed `ai` major version. This repo uses `ai@6`, so it uses `@ai-sdk/openai@3` rather than 4.
 
    ```sh
-   pnpm add @statelyai/agent@alpha ai@^6.0.67 zod@^4 xstate@6.0.0-alpha.43 @ai-sdk/openai@^3
+   pnpm add @statelyai/agent@alpha ai@^6.0.67 zod@^4 xstate@6.0.0-alpha.46 @ai-sdk/openai@^3
    pnpm add -D @types/node typescript tsx
    ```
 
@@ -172,7 +172,7 @@ Most patterns are one self-contained `index.ts`, with no shared harness and no l
 
 <!-- peer ranges from package.json#peerDependencies and example schema dependency from package.json#devDependencies -->
 
-`@statelyai/agent` declares these peer ranges: `ai@^6.0.67`, `xstate@>=6.0.0-alpha.43 <6.0.0`, and optionally `@opentelemetry/api@^1`. The examples use Zod 4 directly. The `@alpha` tag floats, so pin the exact version it installs once you have a working build.
+`@statelyai/agent` declares these peer ranges: `ai@^6.0.67`, `xstate@>=6.0.0-alpha.46 <6.0.0`, and optionally `@opentelemetry/api@^1`. The examples use Zod 4 directly. The `@alpha` tag floats, so pin the exact version it installs once you have a working build.
 
 ## Running from the repo
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,7 @@ pnpm add @statelyai/agent@alpha xstate@alpha zod ai@^6 @ai-sdk/openai@^3
 ```
 
 - The `@alpha` tag floats. Install it once, then run `npm ls @statelyai/agent` and pin the resolved version, so a later alpha cannot change the API.
-- `xstate` is the only required peer dependency, at v6 alpha.43 or newer. Node must be 22.18 or newer.
+- `xstate` is the only required peer dependency, at v6 alpha.46 or newer. Node must be 22.18 or newer.
 - Provider packages must match your `ai` major version. `@ai-sdk/openai@^3` pairs with `ai@^6`. A bare `@ai-sdk/openai` resolves to `@latest`, whose `LanguageModel` spec version may not match your `ai` peer.
 - The package is ESM-first. Every entry point also ships a CommonJS build, so `require()` works. The examples use top-level `await`, which requires ESM. Set `"type": "module"` in `package.json`, or use `.mts` files.
 

--- a/docs/thinking-in-state-machines.md
+++ b/docs/thinking-in-state-machines.md
@@ -13,7 +13,7 @@ For the mechanical refactor of an existing codebase, see [Migrating from a hand-
 
 <!-- xstate version requirement from package.json#peerDependencies -->
 
-> **Version requirement.** Build the machine with the `xstate` install this package peers on, v6 alpha.43 or newer. See [Installation](quickstart.md#installation). Machines authored for XState v5 usually port with few changes, but a machine object imported from a separate `xstate@5` install does not bind. Write event-transition guards as functions that return `undefined`. XState v6 drops named string guards on `on`, and the function form is what makes `snapshot.can(event)` reflect the guard.
+> **Version requirement.** Build the machine with the `xstate` install this package peers on, v6 alpha.46 or newer. See [Installation](quickstart.md#installation). Machines authored for XState v5 usually port with few changes, but a machine object imported from a separate `xstate@5` install does not bind. Write event-transition guards as functions that return `undefined`. XState v6 drops named string guards on `on`, and the function form is what makes `snapshot.can(event)` reflect the guard.
 
 ## The loop to model
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ pnpm add @statelyai/agent@alpha xstate@alpha zod ai@^6 @ai-sdk/openai@^3
 
 Requirements:
 
-- Node 22.18 or newer, and XState v6 alpha.43 or newer.
+- Node 22.18 or newer, and XState v6 alpha.46 or newer.
 - The package is ESM-first. CommonJS builds are published too, so `require()` works.
 - Provider packages must match your `ai` major: `@ai-sdk/openai@^3` pairs with `ai@^6`. A bare `@ai-sdk/openai` resolves to `@latest`, which can mismatch the `ai` peer.
 


### PR DESCRIPTION
## Summary

- update installation examples from XState alpha.43 to alpha.46
- keep full docs aligned with the package peer range merged in #103

## Validation

- `pnpm docs:check` (116 snippets)
- `pnpm build`
- `pnpm check:dts`
- peer-range source assertion
- `git diff --check`