### PR TITLE
Verification upgrades + four new examples (chameleon, just-one, seam-scoring, snapshot-migration)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -17,12 +17,15 @@ Exceptions to the `OPENAI_API_KEY` + `tsx` default:
 
 ## Start here
 
-**No API key needed.** Three examples run fully scripted, in about a second each, with no key and no network:
+**No API key needed.** Six examples run fully scripted, in about a second each, with no key and no network:
 
 ```bash
 npx tsx examples/crash-recovery/index.ts
 npx tsx examples/session-actor/index.ts
 npx tsx examples/preset-machine/index.ts
+npx tsx examples/verification/index.ts
+npx tsx examples/snapshot-migration/index.ts
+npx tsx examples/seam-scoring/index.ts
 ```
 
 Good first reads: [`twenty-questions`](twenty-questions/index.ts), [`go-fish`](go-fish/index.ts), [`joke`](joke/index.ts), [`email-drafter`](email-drafter/agent-logic.ts), [`human-in-the-loop`](human-in-the-loop/index.ts), [`retrofit`](retrofit/index.ts), [`json-agent`](json-agent/index.ts), [`ai-sdk-host`](ai-sdk-host/index.ts). The [hosts and executors guide](../docs/hosts.md) explains what the runtime side of each one is doing.
@@ -31,6 +34,8 @@ Good first reads: [`twenty-questions`](twenty-questions/index.ts), [`go-fish`](g
 
 - [`twenty-questions/index.ts`](twenty-questions/index.ts): a decision loop with guard-enforced legality where every player turn is an idle state offering buttons or free text a classifier interprets.
 - [`go-fish/index.ts`](go-fish/index.ts): a hidden-information card game where the model asks and the machine enforces the rules, with the human's turn as an idle state resumed by a free-text `ASK` event.
+- [`just-one/index.ts`](just-one/index.ts): the cooperative word game where three clue-givers write simultaneously as isolated parallel regions, and the machine strikes every duplicate clue before the human guesser sees it.
+- [`chameleon/index.ts`](chameleon/index.ts): the hidden-role word game where the chameleon's request input has no `secretWord` field at all, so the secret cannot reach it, and the human detective votes from an idle state.
 - [`game-agent/index.ts`](game-agent/index.ts): a turn-based combat machine whose decision `allowedEvents` are computed from context, plus an interactive rock-paper-scissors match driven from `meta.interaction` buttons.
 - [`game-loop-agent/index.ts`](game-loop-agent/index.ts): a long-lived player agent invoked once at the game machine's `playing` state, so one agent spans substates and rounds.
 - [`river-crossing/index.ts`](river-crossing/index.ts): the machine as a verifiable environment where guards reject illegal wolf, goat, and cabbage crossings and the run narrates both banks.
@@ -57,6 +62,7 @@ Good first reads: [`twenty-questions`](twenty-questions/index.ts), [`go-fish`](g
 - [`customer-support/index.ts`](customer-support/index.ts): intent routing plus safe question answering, with sensitive actions gated behind an idle `confirming` state.
 - [`time-travel/index.ts`](time-travel/index.ts): checkpointing each settle, rewinding to a past checkpoint, and forking a divergent branch while the main branch stays unchanged.
 - [`crash-recovery/index.ts`](crash-recovery/index.ts): events-only resume, where a crash mid-request recovers from `runAgent({ events })` alone and the in-flight request re-executes idempotently.
+- [`snapshot-migration/index.ts`](snapshot-migration/index.ts): resuming a paused run after the machine was redeployed, where `machineVersion` stamping makes a stale snapshot throw with `from`/`to` and `migrateSnapshot` adapts it at the boundary.
 - [`session-actor/index.ts`](session-actor/index.ts): `createAgentActor` session mode, one live actor across turns on a single replayable log with cumulative usage.
 - [`file-snapshot-store/index.ts`](file-snapshot-store/index.ts): durable checkpoints in a file-backed snapshot store, where each idle settle writes JSON to disk.
 
@@ -123,7 +129,9 @@ The same agent machine served from real app frameworks, in both modes: controlle
 
 ## Evals and observability
 
+- [`verification/index.ts`](verification/index.ts): the whole keyless verification suite over a refund-approval machine, where `canReach` proves an over-limit payout without human approval is unreachable rather than merely discouraged.
 - [`braintrust-evals/index.ts`](braintrust-evals/index.ts): a Braintrust `Eval()` over the unmodified email-drafter machine, scoring output, state path, trajectory, and usage, keyless and offline by default.
+- [`seam-scoring/index.ts`](seam-scoring/index.ts): `runSeam` scoring one model call of the unmodified email-drafter machine while every other request is served from the call plan, comparing a good and a bad candidate for that call in a single table.
 - [`langsmith-otel/index.ts`](langsmith-otel/index.ts): tracing a run to LangSmith over OpenTelemetry with a real OTLP exporter, printing the span tree when run keyless.
 
 See [Evals](../docs/evals.md) for scoring runs, and [Observability](../docs/observability.md) for the trace stream.

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,7 +62,7 @@ Good first reads: [`twenty-questions`](twenty-questions/index.ts), [`go-fish`](g
 - [`customer-support/index.ts`](customer-support/index.ts): intent routing plus safe question answering, with sensitive actions gated behind an idle `confirming` state.
 - [`time-travel/index.ts`](time-travel/index.ts): checkpointing each settle, rewinding to a past checkpoint, and forking a divergent branch while the main branch stays unchanged.
 - [`crash-recovery/index.ts`](crash-recovery/index.ts): events-only resume, where a crash mid-request recovers from `runAgent({ events })` alone and the in-flight request re-executes idempotently.
-- [`snapshot-migration/index.ts`](snapshot-migration/index.ts): resuming a paused run after the machine was redeployed, where `machineVersion` stamping makes a stale snapshot throw with `from`/`to` and `migrateSnapshot` adapts it at the boundary.
+- [`snapshot-migration/index.ts`](snapshot-migration/index.ts): resuming a paused run after the machine was redeployed, where the machine's own `version` stamp makes a stale snapshot throw with `from`/`to` and `migrateSnapshot` adapts it at the boundary.
 - [`session-actor/index.ts`](session-actor/index.ts): `createAgentActor` session mode, one live actor across turns on a single replayable log with cumulative usage.
 - [`file-snapshot-store/index.ts`](file-snapshot-store/index.ts): durable checkpoints in a file-backed snapshot store, where each idle settle writes JSON to disk.
 

--- a/examples/chameleon/index.test.ts
+++ b/examples/chameleon/index.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from "vitest";
+import { getStateMeta, runAgent } from "@statelyai/agent";
+import type { AgentRequestExecutor } from "@statelyai/agent";
+import {
+  type AccuseEvent,
+  chameleonMachine,
+  idlePrompt,
+  isCorrectGuess,
+  PLAYERS,
+} from "./index.js";
+
+/** Every request the scripted players saw, as the executor received it. */
+interface CapturedRequest {
+  name?: string;
+  system?: string;
+  prompt?: string;
+  serialized: string;
+}
+
+interface Script {
+  /** One word per seat, in speaking order. */
+  words: string[];
+  /** What the chameleon says when it is caught. */
+  guess?: string;
+}
+
+/**
+ * Scripted players. `sayWord` requests arrive strictly in turn order, so the
+ * executor can just take the next word off the script.
+ */
+function createPlayers(script: Script, captured: CapturedRequest[] = []) {
+  let turn = 0;
+  const executor: AgentRequestExecutor = async (request) => {
+    captured.push({
+      name: request.name,
+      system: request.system,
+      prompt: request.prompt,
+      serialized: JSON.stringify(request),
+    });
+    if (request.name === "guessSecret") {
+      return { output: { guess: script.guess ?? "", reasoning: "the words all circled it" } };
+    }
+    const word = script.words[turn] ?? "";
+    turn += 1;
+    return { output: { word, reasoning: `seat ${turn}` } };
+  };
+  return { executor, captured };
+}
+
+interface PlayOptions {
+  input?: { category?: string; secretWord?: string; chameleonIndex?: number };
+  script: Script;
+  accuse: AccuseEvent;
+  captured?: CapturedRequest[];
+}
+
+/** Runs the round, votes at the idle state, and returns the finished run. */
+async function play(options: PlayOptions) {
+  const { executor } = createPlayers(options.script, options.captured);
+  const shared = { executors: { generateText: executor } };
+
+  const idle = await runAgent(chameleonMachine, { input: options.input ?? {}, ...shared });
+  expect(idle.status).toBe("idle");
+  if (idle.status !== "idle") throw new Error(`expected idle, got ${idle.status}`);
+
+  // The idle vote must advertise how a host can unblock it.
+  expect(getStateMeta(idle.snapshot).interaction).toBeDefined();
+  expect(idle.snapshot.can(options.accuse as never)).toBe(true);
+  const prompt = idlePrompt(idle.snapshot);
+
+  const result = await runAgent(chameleonMachine, {
+    snapshot: idle.persistedSnapshot,
+    event: options.accuse,
+    ...shared,
+  });
+  if (result.status !== "done") throw new Error(`expected done, got ${result.status}`);
+  return { result, prompt, idle };
+}
+
+const OCEAN: Script = { words: ["ink", "tentacle", "reef", "suction"], guess: "octopus" };
+
+describe("chameleon", () => {
+  test("the chameleon's request never receives the secret word", async () => {
+    const captured: CapturedRequest[] = [];
+    await play({
+      input: { category: "Ocean creatures", secretWord: "octopus", chameleonIndex: 2 },
+      script: OCEAN,
+      accuse: { type: "ACCUSE_P0" },
+      captured,
+    });
+
+    const wordRequests = captured.filter((request) => request.name === "sayWord");
+    expect(wordRequests).toHaveLength(4);
+
+    // Exactly three requests carry the secret — never seat 2's.
+    const carryingSecret = wordRequests
+      .map((request, seat) => ({
+        seat,
+        leaks: request.serialized.toLowerCase().includes("octopus"),
+      }))
+      .filter((entry) => entry.leaks)
+      .map((entry) => entry.seat);
+    expect(carryingSecret).toEqual([0, 1, 3]);
+
+    // The whole request — system, prompt, messages, everything — is checked.
+    expect(wordRequests[2]!.serialized.toLowerCase()).not.toContain("octopus");
+    expect(wordRequests[2]!.prompt).toContain("You do not know the secret word.");
+    expect(wordRequests[2]!.system).toContain("You are the CHAMELEON");
+
+    // The public record grows by turn order: seat N sees exactly N words.
+    for (const [seat, request] of wordRequests.entries()) {
+      expect(request.prompt).toContain(`You speak ${seat + 1} of 4.`);
+      for (const [earlier, word] of OCEAN.words.slice(0, seat).entries()) {
+        expect(request.prompt).toContain(`${PLAYERS[earlier]}: ${word}`);
+      }
+      // Nothing said after this seat is visible to it.
+      for (const word of OCEAN.words.slice(seat + 1)) {
+        expect(request.prompt).not.toContain(word);
+      }
+    }
+  });
+
+  test("a correct accusation gives the chameleon one guess; a wrong guess loses it", async () => {
+    const captured: CapturedRequest[] = [];
+    const { result, prompt } = await play({
+      script: { ...OCEAN, guess: "jellyfish" },
+      accuse: { type: "ACCUSE_P2" },
+      captured,
+    });
+
+    expect(prompt).toBe(
+      "Category: Ocean creatures. Ada: ink, Bruno: tentacle, Cleo: reef, Dev: suction. Who is the chameleon?",
+    );
+    // The steal attempt happens only because the accusation landed.
+    const guessRequest = captured.find((request) => request.name === "guessSecret");
+    expect(guessRequest).toBeDefined();
+    // Even the caught chameleon's request never contains the secret.
+    expect(guessRequest!.serialized.toLowerCase()).not.toContain("octopus");
+
+    expect(result.output.outcome).toBe("detectives-win");
+    expect(result.output.chameleon).toBe("Cleo");
+    expect(result.output.accused).toBe("Cleo");
+    expect(result.output.summary).toContain(
+      'Detectives win. Cleo was the chameleon and could not name "octopus".',
+    );
+    expect(result.output.log).toEqual([
+      "Category: Ocean creatures. One of Ada, Bruno, Cleo, Dev does not know the secret word.",
+      "Words — Ada: ink, Bruno: tentacle, Cleo: reef, Dev: suction.",
+      "You accused Cleo.",
+      "Caught — Cleo was the chameleon, and gets one guess at the secret word.",
+      'Cleo guessed "jellyfish" — wrong. The secret word was "octopus".',
+    ]);
+  });
+
+  test("a caught chameleon that names the secret steals the win", async () => {
+    const { result } = await play({ script: OCEAN, accuse: { type: "ACCUSE_P2" } });
+
+    expect(result.output.outcome).toBe("chameleon-steals");
+    expect(result.output.summary).toContain(
+      'Chameleon steals it. Cleo was caught, then named "octopus".',
+    );
+    expect(result.output.log.at(-1)).toBe('Cleo guessed "octopus" — right, and steals the win.');
+  });
+
+  test("a wrong accusation lets the chameleon escape without guessing", async () => {
+    const captured: CapturedRequest[] = [];
+    const { result } = await play({
+      script: OCEAN,
+      accuse: { type: "ACCUSE_P3" },
+      captured,
+    });
+
+    expect(captured.some((request) => request.name === "guessSecret")).toBe(false);
+    expect(result.output.outcome).toBe("chameleon-escapes");
+    expect(result.output.accused).toBe("Dev");
+    expect(result.output.summary).toContain(
+      "Chameleon escapes. Cleo was the chameleon; you accused Dev.",
+    );
+  });
+
+  test("the vote snapshot round-trips as JSON and resumes with an accusation", async () => {
+    const { executor } = createPlayers({
+      words: ["stripes", "roar", "savanna", "whiskers"],
+      guess: "lion",
+    });
+    const shared = { executors: { generateText: executor } };
+
+    const idle = await runAgent(chameleonMachine, {
+      input: { category: "Big cats", secretWord: "Lion", chameleonIndex: 0 },
+      ...shared,
+    });
+    expect(idle.status).toBe("idle");
+    if (idle.status !== "idle") throw new Error("expected idle");
+    expect(idlePrompt(idle.snapshot)).toBe(
+      "Category: Big cats. Ada: stripes, Bruno: roar, Cleo: savanna, Dev: whiskers. Who is the chameleon?",
+    );
+
+    // Persist mid-vote as JSON, then resume a fresh run from it.
+    const resumed = await runAgent(chameleonMachine, {
+      snapshot: JSON.parse(JSON.stringify(idle.persistedSnapshot)),
+      event: { type: "ACCUSE_P0" },
+      ...shared,
+    });
+
+    expect(resumed.status).toBe("done");
+    if (resumed.status !== "done") throw new Error("expected done");
+    // "lion" vs the secret "Lion": the machine normalizes before comparing.
+    expect(resumed.output.outcome).toBe("chameleon-steals");
+    expect(resumed.output.words.map((entry) => entry.word)).toEqual([
+      "stripes",
+      "roar",
+      "savanna",
+      "whiskers",
+    ]);
+  });
+
+  test("the steal comparison ignores case, punctuation, and plurals", () => {
+    expect(isCorrectGuess("Octopus", "octopus")).toBe(true);
+    expect(isCorrectGuess("  octopus! ", "octopus")).toBe(true);
+    expect(isCorrectGuess("octopuses", "octopus")).toBe(true);
+    expect(isCorrectGuess("squid", "octopus")).toBe(false);
+    expect(isCorrectGuess("", "octopus")).toBe(false);
+    expect(isCorrectGuess("octopus", "")).toBe(false);
+  });
+});

--- a/examples/chameleon/index.ts
+++ b/examples/chameleon/index.ts
@@ -228,7 +228,7 @@ const agentSetup = setupAgent({
   models,
   // Deterministic idle detection: the run settles exactly when it is waiting on
   // the detective, instead of falling back to the timing heuristic.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
   requests: {
     /**
      * ONE request definition for all four players. Its input is a union, and

--- a/examples/chameleon/index.ts
+++ b/examples/chameleon/index.ts
@@ -1,0 +1,598 @@
+/**
+ * The Chameleon — hidden-role deduction where the secret is withheld by the
+ * *shape of a request input*, not by an instruction in a prompt.
+ *
+ * Four AI players each say ONE word about a secret word from a known category.
+ * Three of them know the secret. The fourth — the chameleon — knows only the
+ * category, and has to blend in by inferring the secret from what has already
+ * been said. The human is the detective: watch the round, accuse a player, and
+ * if the accusation lands the chameleon gets one guess at the secret to steal
+ * the win.
+ *
+ * Two properties this example exists to show:
+ *
+ *   1. Asymmetric information is structural. `sayWord` takes a UNION input: a
+ *      knowing player's turn is built as
+ *      `{ knowsSecret: true, category, secretWord, wordsSoFar, position }`,
+ *      and the chameleon's turn as
+ *      `{ knowsSecret: false, category, wordsSoFar, position }` — there is no
+ *      `secretWord` field on that branch for the secret to travel in. Nothing
+ *      redacts or masks it; the request the chameleon's model call receives
+ *      cannot contain it. `index.test.ts` regression-tests exactly that by
+ *      deep-stringifying every captured request.
+ *
+ *      The bluff still lives in the model: the chameleon is told there is a
+ *      secret word it does not have, and must reason from prior words to say
+ *      something plausibly specific. It just never gets the word.
+ *
+ *   2. Turn order is sequential and machine-owned. Unlike `just-one`, where
+ *      isolation means writing in parallel, here each player must SEE the words
+ *      said before them — so `clueRound` is a loop of one request at a time,
+ *      appending to a single `words` array from a single state. `wordsSoFar` is
+ *      therefore exactly the public record at that player's position, and the
+ *      chameleon's advantage of speaking later is a fact about the graph.
+ *
+ * The vote is an idle state (no invoke) carrying `meta.interaction`: the
+ * category and the four spoken words in the label, one `ACCUSE_P*` button per
+ * player. Resume with
+ * `runAgent(machine, { snapshot: result.persistedSnapshot, event })`.
+ *
+ * Run: OPENAI_API_KEY=... npx tsx examples/chameleon/index.ts
+ */
+import { z } from "zod";
+import type { SnapshotFrom } from "xstate";
+import { openai } from "@ai-sdk/openai";
+import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
+import { createAgentSchemas, getStateMeta, runAgent, setupAgent } from "@statelyai/agent";
+
+/** The table, in speaking order. Index doubles as the player's seat. */
+export const PLAYERS = ["Ada", "Bruno", "Cleo", "Dev"] as const;
+
+const spokenWordSchema = z.object({
+  player: z.string(),
+  word: z.string(),
+  reasoning: z.string(),
+});
+type SpokenWord = z.infer<typeof spokenWordSchema>;
+
+const wordDraftSchema = z.object({
+  word: z.string(),
+  reasoning: z.string(),
+});
+
+const guessDraftSchema = z.object({
+  guess: z.string(),
+  reasoning: z.string(),
+});
+
+/** The public record a player sees on their turn: who spoke, and what. */
+const publicWordSchema = z.object({ player: z.string(), word: z.string() });
+
+/**
+ * Typed `meta.interaction` hints. Hosts read them off the idle snapshot to
+ * label the prompt and render one button per suspect.
+ */
+const metaSchema = z.object({
+  interaction: z
+    .object({
+      label: z.string(),
+      events: z
+        .record(
+          z.string(),
+          z.object({
+            label: z.string().optional(),
+            style: z.enum(["primary", "danger", "default"]).optional(),
+          }),
+        )
+        .optional(),
+      textEvent: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const chameleonSchemas = createAgentSchemas({
+  meta: metaSchema,
+  context: z.object({
+    category: z.string(),
+    secretWord: z.string(),
+    chameleonIndex: z.number(),
+    /** Seat order with roles resolved from `chameleonIndex`. */
+    players: z.array(z.object({ name: z.string(), isChameleon: z.boolean() })),
+    /** Whose turn it is in `clueRound`; also the index into `players`. */
+    turnIndex: z.number(),
+    /** Append-only, written by one state at a time — the round IS this array. */
+    words: z.array(spokenWordSchema),
+    /** The four spoken words, interpolated into the idle label. */
+    wordSummary: z.string(),
+    /** Seat the detective accused; `-1` until the vote is in. */
+    accusedIndex: z.number(),
+    /** The chameleon's steal attempt; empty unless it was caught. */
+    chameleonGuess: z.string(),
+    outcome: z.enum(["", "detectives-win", "chameleon-steals", "chameleon-escapes"]),
+    log: z.array(z.string()),
+  }),
+  input: z.object({
+    category: z.string().default("Ocean creatures"),
+    secretWord: z.string().default("octopus"),
+    /** Which seat is the chameleon. Fixed, so a run is fully reproducible. */
+    chameleonIndex: z.number().int().min(0).max(3).default(2),
+  }),
+  output: z.object({
+    /** Headline: a readable narration of the whole game. */
+    summary: z.string(),
+    outcome: z.enum(["detectives-win", "chameleon-steals", "chameleon-escapes"]),
+    chameleon: z.string(),
+    secretWord: z.string(),
+    accused: z.string(),
+    words: z.array(spokenWordSchema),
+    log: z.array(z.string()),
+  }),
+  events: {
+    ACCUSE_P0: z.object({}),
+    ACCUSE_P1: z.object({}),
+    ACCUSE_P2: z.object({}),
+    ACCUSE_P3: z.object({}),
+  },
+});
+
+const models = defineModels({ player: openai("gpt-5.4-mini") });
+
+// ─── Rules (pure functions — the machine's, not the prompt's) ───
+
+/** Lowercase, strip accents and punctuation, collapse whitespace. */
+export function normalizeWord(raw: string): string {
+  return raw
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/**
+ * The forms a word is allowed to match in: itself, plus a naive de-inflection.
+ * Comparing form SETS (rather than one canonical key) makes "octopuses" match
+ * "octopus" without also having to know that "octopus" is not itself a plural.
+ */
+function wordForms(raw: string): string[] {
+  const word = normalizeWord(raw);
+  if (word.length > 3 && word.endsWith("es")) return [word, word.slice(0, -2)];
+  if (word.length > 3 && word.endsWith("s")) return [word, word.slice(0, -1)];
+  return [word];
+}
+
+/** `true` when the chameleon's steal attempt names the secret word. */
+export function isCorrectGuess(guess: string, secretWord: string): boolean {
+  const secretForms = wordForms(secretWord);
+  if (secretForms[0] === "") return false;
+  return wordForms(guess).some((form) => form !== "" && secretForms.includes(form));
+}
+
+/** Roles are a pure function of the seat the chameleon was dealt. */
+export function assignRoles(chameleonIndex: number) {
+  return PLAYERS.map((name, index) => ({ name, isChameleon: index === chameleonIndex }));
+}
+
+/** What a player at `position` is allowed to see: everything said before them. */
+function publicRecord(words: SpokenWord[]) {
+  return words.map(({ player, word }) => ({ player, word }));
+}
+
+function renderWords(words: SpokenWord[]): string {
+  return words.map(({ player, word }) => `${player}: ${word || "(silent)"}`).join(", ");
+}
+
+/** Joins the log into readable prose for the machine output. */
+function narrate(context: {
+  category: string;
+  secretWord: string;
+  chameleonIndex: number;
+  words: SpokenWord[];
+  accusedIndex: number;
+  outcome: string;
+  log: string[];
+}): string {
+  const chameleon = PLAYERS[context.chameleonIndex] ?? "nobody";
+  const accused = PLAYERS[context.accusedIndex] ?? "nobody";
+  const headline =
+    context.outcome === "detectives-win"
+      ? `Detectives win. ${chameleon} was the chameleon and could not name "${context.secretWord}".`
+      : context.outcome === "chameleon-steals"
+        ? `Chameleon steals it. ${chameleon} was caught, then named "${context.secretWord}".`
+        : `Chameleon escapes. ${chameleon} was the chameleon; you accused ${accused}.`;
+  return `${headline}\n\n${context.log.join("\n")}`;
+}
+
+// ─── Agent ───
+
+const KNOWING_SYSTEM_PROMPT = [
+  "You are a player in The Chameleon, a hidden-role party game.",
+  "Everyone at the table sees the category. You and two other players also know the SECRET WORD; one player does not — that player is the chameleon, and is trying to blend in.",
+  "On your turn you say exactly ONE word related to the secret word. Players speak in order and hear every word said before them.",
+  "Your word has to walk a line: specific enough that the other knowing players believe you know the secret, vague enough that the chameleon cannot deduce the secret from it.",
+  "Saying the secret word, a spelling of it, or something that only makes sense for it hands the chameleon the game. Saying something that fits the whole category equally well makes YOU look like the chameleon.",
+  "Never mention the secret word itself. Reason briefly, then commit to one word.",
+].join(" ");
+
+const CHAMELEON_SYSTEM_PROMPT = [
+  "You are the CHAMELEON in The Chameleon, a hidden-role party game.",
+  "You know the category. You do NOT know the secret word — it was never given to you, and you cannot ask for it.",
+  "Three other players know it. On your turn you must say exactly ONE word and pass as one of them.",
+  "Use the words already said to infer what the secret might be, then say something plausibly specific for that guess.",
+  "Too vague and you look like someone covering for not knowing; too specific and you are wrong out loud. If you speak early with little to go on, pick a word that stays defensible across several candidate secrets.",
+  "After everyone has spoken the table votes. Reason briefly, then commit to one word.",
+].join(" ");
+
+const agentSetup = setupAgent({
+  schemas: chameleonSchemas,
+  models,
+  // Deterministic idle detection: the run settles exactly when it is waiting on
+  // the detective, instead of falling back to the timing heuristic.
+  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  requests: {
+    /**
+     * ONE request definition for all four players. Its input is a union, and
+     * the union IS the hidden-role rule: the `knowsSecret: false` branch has no
+     * `secretWord` field, so the chameleon's turn cannot carry the secret even
+     * by mistake. The prompt narrows on the discriminant.
+     */
+    sayWord: {
+      schemas: {
+        input: z.union([
+          z.object({
+            knowsSecret: z.literal(true),
+            category: z.string(),
+            secretWord: z.string(),
+            wordsSoFar: z.array(publicWordSchema),
+            position: z.number(),
+          }),
+          z.object({
+            knowsSecret: z.literal(false),
+            category: z.string(),
+            wordsSoFar: z.array(publicWordSchema),
+            position: z.number(),
+          }),
+        ]),
+        output: wordDraftSchema,
+      },
+      model: "player",
+      system: ({ input }) => (input.knowsSecret ? KNOWING_SYSTEM_PROMPT : CHAMELEON_SYSTEM_PROMPT),
+      prompt: ({ input }) =>
+        [
+          `Category: ${input.category}`,
+          input.knowsSecret
+            ? `Secret word: ${input.secretWord}`
+            : "You do not know the secret word.",
+          `You speak ${input.position} of ${PLAYERS.length}.`,
+          input.wordsSoFar.length === 0
+            ? "Nobody has spoken yet."
+            : `Said so far — ${input.wordsSoFar.map((entry) => `${entry.player}: ${entry.word}`).join(", ")}`,
+          "Say your one word.",
+        ].join("\n"),
+    },
+
+    /**
+     * The caught chameleon's one shot. It finally sees all four words — still
+     * never the secret — and names what it thinks the secret was.
+     */
+    guessSecret: {
+      schemas: {
+        input: z.object({
+          category: z.string(),
+          words: z.array(publicWordSchema),
+        }),
+        output: guessDraftSchema,
+      },
+      model: "player",
+      system: [
+        "You are the chameleon in The Chameleon, and you have just been caught by the vote.",
+        "You get one guess at the secret word. Name it and you steal the win outright; miss and the detectives take it.",
+        "You never learned the secret word. All you have is the category and the four words said at the table — three of them by players who knew it.",
+        "Weigh the words the others said against each other: the secret is the thing all three were circling. Answer with a single word.",
+      ].join(" "),
+      prompt: ({ input }) =>
+        [
+          `Category: ${input.category}`,
+          `Words said: ${input.words.map((entry) => `${entry.player}: ${entry.word}`).join(", ")}`,
+          "What was the secret word?",
+        ].join("\n"),
+    },
+  },
+});
+
+export const chameleonMachine = agentSetup.createMachine({
+  id: "chameleon",
+  context: ({ input }) => ({
+    category: input.category,
+    secretWord: input.secretWord,
+    chameleonIndex: input.chameleonIndex,
+    players: assignRoles(input.chameleonIndex),
+    turnIndex: 0,
+    words: [],
+    wordSummary: "",
+    accusedIndex: -1,
+    chameleonGuess: "",
+    outcome: "" as const,
+    log: [],
+  }),
+  output: ({ context }) => ({
+    summary: narrate(context),
+    // `outcome` is written on the way into a final state, so it is never "".
+    outcome: (context.outcome || "chameleon-escapes") as
+      | "detectives-win"
+      | "chameleon-steals"
+      | "chameleon-escapes",
+    chameleon: PLAYERS[context.chameleonIndex] ?? "",
+    secretWord: context.secretWord,
+    accused: PLAYERS[context.accusedIndex] ?? "",
+    words: context.words,
+    log: context.log,
+  }),
+  initial: "dealing",
+  states: {
+    // Roles are dealt once, deterministically, from the input seat.
+    dealing: {
+      always: ({ context }) => ({
+        target: "clueRound",
+        context: {
+          log: [
+            `Category: ${context.category}. One of ${PLAYERS.join(", ")} does not know the secret word.`,
+          ],
+        },
+      }),
+    },
+
+    // Sequential turns: exactly one `sayWord` request is in flight at a time,
+    // and each one is built from the words already appended. The chameleon's
+    // input is a different shape from everyone else's — see `sayWord`.
+    clueRound: {
+      initial: "turn",
+      onDone: { target: "voting" },
+      states: {
+        turn: {
+          invoke: {
+            src: "sayWord",
+            input: ({ context }) => {
+              const shared = {
+                category: context.category,
+                wordsSoFar: publicRecord(context.words),
+                position: context.turnIndex + 1,
+              };
+              return context.players[context.turnIndex]?.isChameleon
+                ? { knowsSecret: false as const, ...shared }
+                : { knowsSecret: true as const, secretWord: context.secretWord, ...shared };
+            },
+            onDone: ({ context, output }) => ({
+              target: "advancing",
+              context: {
+                words: [
+                  ...context.words,
+                  {
+                    player: PLAYERS[context.turnIndex] ?? "",
+                    word: output.word.trim(),
+                    reasoning: output.reasoning,
+                  },
+                ],
+              },
+            }),
+            // A failed request is a silent player: the round goes on, and the
+            // empty word is simply weak evidence for the detective.
+            onError: ({ context }) => ({
+              target: "advancing",
+              context: {
+                words: [
+                  ...context.words,
+                  { player: PLAYERS[context.turnIndex] ?? "", word: "", reasoning: "" },
+                ],
+              },
+            }),
+          },
+        },
+        advancing: {
+          always: ({ context }) =>
+            context.turnIndex + 1 < PLAYERS.length
+              ? { target: "turn", context: { turnIndex: context.turnIndex + 1 } }
+              : {
+                  target: "spoken",
+                  context: {
+                    wordSummary: renderWords(context.words),
+                    log: [...context.log, `Words — ${renderWords(context.words)}.`],
+                  },
+                },
+        },
+        spoken: { type: "final" },
+      },
+    },
+
+    // No invoke: the run settles idle here and a host resumes it with one
+    // `ACCUSE_P*` event, one per seat.
+    voting: {
+      tags: ["waiting"],
+      meta: {
+        interaction: {
+          label: "Category: {category}. {wordSummary}. Who is the chameleon?",
+          events: {
+            ACCUSE_P0: { label: "Ada" },
+            ACCUSE_P1: { label: "Bruno" },
+            ACCUSE_P2: { label: "Cleo" },
+            ACCUSE_P3: { label: "Dev" },
+          },
+        },
+      },
+      on: {
+        ACCUSE_P0: accuse(0),
+        ACCUSE_P1: accuse(1),
+        ACCUSE_P2: accuse(2),
+        ACCUSE_P3: accuse(3),
+      },
+    },
+
+    // The reveal is a branch on context, not an entry action: the accusation
+    // either lands (the chameleon gets its steal attempt) or it does not.
+    reveal: {
+      always: ({ context }) =>
+        context.accusedIndex === context.chameleonIndex
+          ? {
+              target: "chameleonGuessing",
+              context: {
+                log: [
+                  ...context.log,
+                  `Caught — ${PLAYERS[context.chameleonIndex]} was the chameleon, and gets one guess at the secret word.`,
+                ],
+              },
+            }
+          : {
+              target: "chameleonEscapes",
+              context: {
+                outcome: "chameleon-escapes" as const,
+                log: [
+                  ...context.log,
+                  `Wrong — ${PLAYERS[context.chameleonIndex]} was the chameleon and walks away with it. The secret word was "${context.secretWord}".`,
+                ],
+              },
+            },
+    },
+
+    chameleonGuessing: {
+      invoke: {
+        src: "guessSecret",
+        input: ({ context }) => ({
+          category: context.category,
+          words: publicRecord(context.words),
+        }),
+        // The comparison is the machine's, not the model's: a normalized match
+        // against the secret the request never received.
+        onDone: ({ context, output }) => {
+          const guess = output.guess.trim();
+          const correct = isCorrectGuess(guess, context.secretWord);
+          return {
+            target: correct ? "chameleonSteals" : "detectivesWin",
+            context: {
+              chameleonGuess: guess,
+              outcome: correct ? ("chameleon-steals" as const) : ("detectives-win" as const),
+              log: [
+                ...context.log,
+                correct
+                  ? `${PLAYERS[context.chameleonIndex]} guessed "${guess}" — right, and steals the win.`
+                  : `${PLAYERS[context.chameleonIndex]} guessed "${guess}" — wrong. The secret word was "${context.secretWord}".`,
+              ],
+            },
+          };
+        },
+        onError: ({ context }) => ({
+          target: "detectivesWin",
+          context: {
+            outcome: "detectives-win" as const,
+            log: [
+              ...context.log,
+              `${PLAYERS[context.chameleonIndex]} had no guess. The secret word was "${context.secretWord}".`,
+            ],
+          },
+        }),
+      },
+    },
+
+    detectivesWin: { type: "final" },
+    chameleonSteals: { type: "final" },
+    chameleonEscapes: { type: "final" },
+  },
+});
+
+/** One accusation transition per seat; the reveal branch does the rest. */
+function accuse(seat: number) {
+  return ({ context }: { context: { accusedIndex: number; log: string[] } }) => ({
+    target: "reveal" as const,
+    context: {
+      accusedIndex: seat,
+      log: [...context.log, `You accused ${PLAYERS[seat]}.`],
+    },
+  });
+}
+
+// ─── Host helpers ───
+
+type ChameleonSnapshot = SnapshotFrom<typeof chameleonMachine>;
+
+/** What a host sends to unblock the idle vote. */
+export type AccuseEvent = { type: `ACCUSE_P${0 | 1 | 2 | 3}` };
+
+/** `{key}` placeholders in interaction labels resolve against context. */
+export function resolveInteractionLabel(label: string, context: Record<string, unknown>): string {
+  return label
+    .replace(/\{(\w+)\}/g, (_, key: string) => {
+      const value = context[key];
+      return typeof value === "string" || typeof value === "number" ? String(value) : "";
+    })
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** The label a host shows on the idle vote. */
+export function idlePrompt(snapshot: ChameleonSnapshot): string {
+  const interaction = getStateMeta(snapshot).interaction;
+  return resolveInteractionLabel(interaction?.label ?? "Who is the chameleon?", snapshot.context);
+}
+
+/** Free text ("cleo", "2", "player 3") to an accusation, if it names a seat. */
+export function toAccuseEvent(text: string): AccuseEvent | undefined {
+  const trimmed = normalizeWord(text);
+  const byName = PLAYERS.findIndex((name) => normalizeWord(name) === trimmed);
+  const seat = byName >= 0 ? byName : Number.parseInt(trimmed.replace(/[^0-9]/g, ""), 10);
+  return seat >= 0 && seat < PLAYERS.length
+    ? ({ type: `ACCUSE_P${seat}` } as AccuseEvent)
+    : undefined;
+}
+
+// ─── Dual-mode entrypoint ───
+
+export async function main() {
+  const shared = { executors: createAiSdkExecutors({ models }) };
+
+  let result = await runAgent(chameleonMachine, {
+    input: { category: "Ocean creatures", secretWord: "octopus", chameleonIndex: 2 },
+    ...shared,
+  });
+
+  // The vote settles the run idle. Resume from `persistedSnapshot`.
+  while (result.status === "idle") {
+    const text = await promptLine(
+      `${idlePrompt(result.snapshot)}\n(${PLAYERS.map((name, index) => `${index}=${name}`).join(", ")})\n> `,
+    );
+    const event = toAccuseEvent(text);
+    if (!event) {
+      console.log("Name a player or a seat number.");
+      continue;
+    }
+    result = await runAgent(chameleonMachine, {
+      snapshot: result.persistedSnapshot,
+      event,
+      ...shared,
+    });
+  }
+
+  if (result.status !== "done") throw new Error(`Chameleon did not complete: ${result.status}`);
+  console.log(result.output.summary);
+}
+
+/** Prompt once on stdin and resolve the trimmed reply. */
+async function promptLine(query: string): Promise<string> {
+  const { createInterface } = await import("node:readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return (await rl.question(query)).trim();
+  } finally {
+    rl.close();
+  }
+}
+
+// Run directly (`tsx index.ts`); skipped when a test imports this module.
+if (import.meta.url === new URL(process.argv[1]!, "file:").href) {
+  if (!process.env.OPENAI_API_KEY) {
+    console.error("Set OPENAI_API_KEY to run this example.");
+    process.exit(1);
+  }
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/examples/chameleon/metadata.json
+++ b/examples/chameleon/metadata.json
@@ -1,0 +1,28 @@
+{
+  "name": "chameleon",
+  "title": "The Chameleon",
+  "kind": "agent-workflow",
+  "origin": {
+    "type": "stately-agent",
+    "source": "Created in this repository",
+    "url": null
+  },
+  "comparison": {
+    "targets": ["LangGraph", "Burr", "CrewAI Flow"],
+    "purpose": "Hidden-role asymmetry is expressed as per-request input shaping: the chameleon's turn is built from a union branch with no secretWord field, so its request provably never receives the secret, while the other three players' turns do."
+  },
+  "starters": [
+    {
+      "label": "Ocean creatures — octopus (Cleo is the chameleon)",
+      "input": { "category": "Ocean creatures", "secretWord": "octopus", "chameleonIndex": 2 }
+    },
+    {
+      "label": "Big cats — lion (Ada is the chameleon)",
+      "input": { "category": "Big cats", "secretWord": "lion", "chameleonIndex": 0 }
+    },
+    {
+      "label": "Musical instruments — violin (Dev is the chameleon)",
+      "input": { "category": "Musical instruments", "secretWord": "violin", "chameleonIndex": 3 }
+    }
+  ]
+}

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -30,6 +30,12 @@ export { plainWriterMachine, runPlainXstateExample } from "./plain-xstate/index.
 export { triageMachine, triageSchemas, triageSchema } from "./triage/index.js";
 export { twentyQuestionsMachine, twentyQuestionsSchemas } from "./twenty-questions/index.js";
 export { goFishMachine, goFishSchemas, ranks as goFishRanks } from "./go-fish/index.js";
+export {
+  justOneMachine,
+  justOneSchemas,
+  judgeClues,
+  main as runJustOneExample,
+} from "./just-one/index.js";
 export { humanInTheLoopMachine, runHumanInTheLoopExample } from "./human-in-the-loop/index.js";
 export { ragMachine, runRAGExample } from "./rag/index.js";
 export { correctiveRagMachine, runCorrectiveRagExample } from "./corrective-rag/index.js";
@@ -143,3 +149,28 @@ export {
   longRunningOnboardingMachine,
   runLongRunningOnboardingExample,
 } from "./long-running-onboarding/index.js";
+export {
+  APPROVAL_THRESHOLD,
+  // `refundMachine` is already taken by machine-as-tool.
+  refundMachine as verifiedRefundMachine,
+  verificationSchemas,
+  main as runVerificationExample,
+} from "./verification/index.js";
+export {
+  orderApprovalMachine,
+  orderApprovalMachineV1,
+  migrateOrderSnapshot,
+  runSnapshotMigrationExample,
+} from "./snapshot-migration/index.js";
+export {
+  BAD_DRAFT,
+  GOOD_DRAFT,
+  runCandidate as runSeamScoringCandidate,
+  main as runSeamScoringExample,
+} from "./seam-scoring/index.js";
+export {
+  chameleonMachine,
+  chameleonSchemas,
+  PLAYERS as CHAMELEON_PLAYERS,
+  main as runChameleonExample,
+} from "./chameleon/index.js";

--- a/examples/just-one/index.test.ts
+++ b/examples/just-one/index.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "vitest";
+import { getStateMeta, runAgent } from "@statelyai/agent";
+import type { AgentRequestExecutor } from "@statelyai/agent";
+import { type GuesserEvent, idlePrompt, justOneMachine, PERSONAS } from "./index.js";
+
+/** Every request the scripted clue-giver saw, as the executor received it. */
+interface CapturedRequest {
+  name?: string;
+  system?: string;
+  prompt?: string;
+  serialized: string;
+}
+
+/**
+ * Scripted clue-givers: one clue per persona, per round. The executor routes on
+ * the persona name in the prompt — the only thing that distinguishes the three
+ * otherwise identical requests.
+ */
+function createClueGivers(script: Record<string, string[]>, captured: CapturedRequest[] = []) {
+  const counts = new Map<string, number>();
+  const executor: AgentRequestExecutor = async (request) => {
+    captured.push({
+      name: request.name,
+      system: request.system,
+      prompt: request.prompt,
+      serialized: JSON.stringify(request),
+    });
+    const persona = PERSONAS.find((entry) => request.prompt?.includes(`You are ${entry.name}.`));
+    if (!persona) throw new Error(`unrecognized clue request: ${request.prompt}`);
+    const round = counts.get(persona.name) ?? 0;
+    counts.set(persona.name, round + 1);
+    const clue = script[persona.name]?.[round] ?? "";
+    return { output: { clue, reasoning: `${persona.name} round ${round + 1}` } };
+  };
+  return { executor, captured };
+}
+
+interface PlayOptions {
+  input: { rounds: number; deck?: string[] };
+  script: Record<string, string[]>;
+  /** Consumed in order on each idle settle. */
+  guesserEvents: GuesserEvent[];
+  captured?: CapturedRequest[];
+}
+
+/** Drives the machine through its idle-resume loop, recording each idle prompt. */
+async function play(options: PlayOptions) {
+  const queued = [...options.guesserEvents];
+  const prompts: string[] = [];
+  const { executor } = createClueGivers(options.script, options.captured);
+  const shared = { executors: { generateText: executor } };
+
+  let result = await runAgent(justOneMachine, { input: options.input, ...shared });
+
+  while (result.status === "idle") {
+    // Every idle state must advertise how a host can unblock it.
+    const interaction = getStateMeta(result.snapshot).interaction;
+    expect(
+      interaction,
+      `no interaction meta on ${JSON.stringify(result.snapshot.value)}`,
+    ).toBeDefined();
+    prompts.push(idlePrompt(result.snapshot));
+
+    const event = queued.shift();
+    if (!event) throw new Error(`ran out of guesser events at: ${prompts.at(-1)}`);
+    expect(result.snapshot.can(event as never)).toBe(true);
+
+    result = await runAgent(justOneMachine, {
+      snapshot: result.persistedSnapshot,
+      event,
+      ...shared,
+    });
+  }
+
+  if (result.status !== "done") throw new Error(`expected done, got ${result.status}`);
+  return { result, prompts };
+}
+
+describe("just-one", () => {
+  test("colliding clues cancel each other before the guesser sees them", async () => {
+    const { result, prompts } = await play({
+      input: { rounds: 1, deck: ["volcano"] },
+      script: { Iris: ["lava"], Milo: ["lava"], Nadia: ["eruption"] },
+      guesserEvents: [{ type: "GUESS", guess: "volcano" }],
+    });
+
+    // Only the surviving clue reaches the guesser.
+    expect(prompts).toEqual(["Clues: eruption. What is the secret word?"]);
+    expect(result.output.score).toBe(1);
+    expect(result.output.log).toEqual([
+      'Round 1 — secret "volcano". Clues: lava [duplicate — cancelled], ' +
+        "lava [duplicate — cancelled], eruption (Nadia).",
+      'Guessed "volcano" — correct.',
+    ]);
+  });
+
+  test("a round where every clue is struck is skipped without a guessing turn", async () => {
+    const captured: CapturedRequest[] = [];
+    const { executor } = createClueGivers(
+      { Iris: ["magma"], Milo: ["magma"], Nadia: ["magma"] },
+      captured,
+    );
+
+    const result = await runAgent(justOneMachine, {
+      input: { rounds: 1, deck: ["volcano"] },
+      executors: { generateText: executor },
+    });
+
+    // The run never settles idle: `judging` goes straight to `roundEnd`.
+    expect(result.status).toBe("done");
+    if (result.status !== "done") throw new Error("expected done");
+    expect(result.output.score).toBe(0);
+    expect(result.output.log.at(-1)).toBe("All clues cancelled — round skipped.");
+    expect(result.output.summary).toContain("Guessed 0 of 1 word.");
+    expect(captured).toHaveLength(3);
+  });
+
+  test("a clue equal to (or containing) the secret word is struck", async () => {
+    const { result, prompts } = await play({
+      input: { rounds: 1, deck: ["piano"] },
+      // Iris writes the secret word; Milo writes an inflected form of it.
+      script: { Iris: ["Piano"], Milo: ["pianos"], Nadia: ["keys"] },
+      guesserEvents: [{ type: "GUESS", guess: "piano" }],
+    });
+
+    expect(prompts).toEqual(["Clues: keys. What is the secret word?"]);
+    expect(result.output.log[0]).toBe(
+      'Round 1 — secret "piano". Clues: Piano [gives away the secret word], ' +
+        "pianos [gives away the secret word], keys (Nadia).",
+    );
+    expect(result.output.score).toBe(1);
+  });
+
+  test("PASS advances the round, and a mid-guess snapshot round-trips", async () => {
+    const { executor } = createClueGivers({
+      Iris: ["lava", "sting"],
+      Milo: ["crater", "bear"],
+      Nadia: ["Vesuvius", "bee"],
+    });
+    const shared = { executors: { generateText: executor } };
+
+    const firstIdle = await runAgent(justOneMachine, {
+      input: { rounds: 2, deck: ["volcano", "honey"] },
+      ...shared,
+    });
+    expect(firstIdle.status).toBe("idle");
+    if (firstIdle.status !== "idle") throw new Error("expected idle");
+    expect(idlePrompt(firstIdle.snapshot)).toBe(
+      "Clues: lava, crater, Vesuvius. What is the secret word?",
+    );
+
+    // Pass on round 1: no score, and the round advances.
+    const secondIdle = await runAgent(justOneMachine, {
+      snapshot: firstIdle.persistedSnapshot,
+      event: { type: "PASS" },
+      ...shared,
+    });
+    expect(secondIdle.status).toBe("idle");
+    if (secondIdle.status !== "idle") throw new Error("expected idle");
+    expect(secondIdle.snapshot.context.score).toBe(0);
+    expect(idlePrompt(secondIdle.snapshot)).toBe(
+      "Clues: sting, bear, bee. What is the secret word?",
+    );
+
+    // Persist mid-guess as JSON, then resume a fresh run from it.
+    const serialized = JSON.stringify(secondIdle.persistedSnapshot);
+    const resumed = await runAgent(justOneMachine, {
+      snapshot: JSON.parse(serialized),
+      event: { type: "GUESS", guess: "Honey!" },
+      ...shared,
+    });
+
+    expect(resumed.status).toBe("done");
+    if (resumed.status !== "done") throw new Error("expected done");
+    expect(resumed.output.score).toBe(1);
+    expect(resumed.output.log).toEqual([
+      'Round 1 — secret "volcano". Clues: lava (Iris), crater (Milo), Vesuvius (Nadia).',
+      'Passed — the word was "volcano".',
+      'Round 2 — secret "honey". Clues: sting (Iris), bear (Milo), bee (Nadia).',
+      'Guessed "Honey!" — correct.',
+    ]);
+  });
+
+  test("isolation: no clue request ever carries another giver's clue", async () => {
+    const captured: CapturedRequest[] = [];
+    const clues = {
+      Iris: ["lava", "sting"],
+      Milo: ["crater", "bear"],
+      Nadia: ["Vesuvius", "bee"],
+    };
+
+    await play({
+      input: { rounds: 2, deck: ["volcano", "honey"] },
+      script: clues,
+      guesserEvents: [
+        { type: "GUESS", guess: "volcano" },
+        { type: "GUESS", guess: "honey" },
+      ],
+      captured,
+    });
+
+    expect(captured).toHaveLength(6);
+    const allClues = Object.values(clues).flat();
+
+    for (const request of captured) {
+      expect(request.name).toBe("writeClue");
+      // The whole request — system, prompt, messages, everything — is checked:
+      // no clue text from ANY giver (including this one's other round) is in it.
+      for (const clue of allClues) {
+        expect(
+          request.serialized.toLowerCase().includes(clue.toLowerCase()),
+          `request leaked the clue "${clue}": ${request.prompt}`,
+        ).toBe(false);
+      }
+      // What it does carry: the secret word and exactly one persona.
+      expect(request.prompt).toMatch(/^Secret word: (volcano|honey)$/m);
+      const personasNamed = PERSONAS.filter((persona) =>
+        request.prompt?.includes(`You are ${persona.name}.`),
+      );
+      expect(personasNamed).toHaveLength(1);
+    }
+  });
+});

--- a/examples/just-one/index.ts
+++ b/examples/just-one/index.ts
@@ -1,0 +1,564 @@
+/**
+ * Just One — three AI clue-givers write at the same time, in the dark, and the
+ * machine (not the prompt) throws away the clues that collide.
+ *
+ * The cooperative party game: a human guesser must name a secret word from
+ * one-word clues written by the other players. Every clue that matches another
+ * player's clue is struck before the guesser ever sees it — so the players win
+ * by writing clues that are accurate but *not* the obvious one.
+ *
+ * Two properties this example exists to show:
+ *
+ *   1. Isolation is architectural, not promised. The three clue-givers are
+ *      regions of one `type: 'parallel'` state, and each region's request input
+ *      is built by `({ context }) => ({ secretWord, persona })` — two fields,
+ *      neither of which is a sibling's clue. All three inputs are constructed
+ *      when `cluing` is entered, before any request settles, so there is no
+ *      point in the run at which one giver's clue could reach another's prompt.
+ *      Each region writes only its OWN context slot (`clueA` / `clueB` /
+ *      `clueC`) and reads none of the others. A prompt saying "don't peek" is a
+ *      request; this is a fact about the graph, and `index.test.ts` regression-
+ *      tests it by asserting no captured request text contains another giver's
+ *      clue.
+ *
+ *      Theory of mind still lives in the model: each giver is told that two
+ *      other players are writing simultaneously and that duplicates cancel, so
+ *      it must *reason about* what the others will likely write. It just never
+ *      gets to see it.
+ *
+ *   2. The rules are machine-owned. Normalization, the duplicate strike, the
+ *      "clue is the secret word" strike, the "one word only" strike, and the
+ *      all-clues-struck round skip are pure functions applied in the
+ *      `judging` transition. The model cannot talk its way past them, and they
+ *      hold identically whether the clues came from a real model or the
+ *      scripted executors in the tests.
+ *
+ * The guesser's turn is an idle state (no invoke) carrying `meta.interaction`:
+ * the surviving clues in the label, free text routed to `GUESS`, and a `PASS`
+ * button. Resume with
+ * `runAgent(machine, { snapshot: result.persistedSnapshot, event })`.
+ *
+ * Run: OPENAI_API_KEY=... npx tsx examples/just-one/index.ts
+ */
+import { z } from "zod";
+import type { SnapshotFrom } from "xstate";
+import { openai } from "@ai-sdk/openai";
+import { createAiSdkExecutors, defineModels } from "@statelyai/agent/ai-sdk";
+import { createAgentSchemas, getStateMeta, runAgent, setupAgent } from "@statelyai/agent";
+
+/** Concrete, guessable words. Rounds take them in order, so runs are repeatable. */
+export const WORD_DECK = [
+  "piano",
+  "volcano",
+  "honey",
+  "pirate",
+  "cactus",
+  "lighthouse",
+  "penguin",
+  "guitar",
+  "pyramid",
+  "umbrella",
+  "dragon",
+  "telescope",
+] as const;
+
+const personaSchema = z.object({
+  name: z.string(),
+  angle: z.string(),
+});
+type Persona = z.infer<typeof personaSchema>;
+
+/**
+ * Three angles on the same word. Flavor, not enforcement: differing angles make
+ * collisions less likely, but nothing stops two givers from landing on the same
+ * word — that is exactly the case the machine handles.
+ */
+export const PERSONAS = [
+  {
+    name: "Iris",
+    angle: "free-associate — the first vivid image the word brings to mind",
+  },
+  {
+    name: "Milo",
+    angle: "think in categories, materials, and parts of things",
+  },
+  {
+    name: "Nadia",
+    angle: "think of a famous example, place, or story the word belongs to",
+  },
+] as const satisfies readonly Persona[];
+
+const clueDraftSchema = z.object({
+  clue: z.string(),
+  reasoning: z.string(),
+});
+type ClueDraft = z.infer<typeof clueDraftSchema>;
+
+const judgedClueSchema = z.object({
+  author: z.string(),
+  word: z.string(),
+  struck: z.boolean(),
+  reason: z.string(),
+});
+type JudgedClue = z.infer<typeof judgedClueSchema>;
+
+/**
+ * Typed `meta.interaction` hints. Hosts read them off the idle snapshot to
+ * label the prompt, render buttons, and route free chat text to an event.
+ */
+const metaSchema = z.object({
+  interaction: z
+    .object({
+      label: z.string(),
+      events: z
+        .record(
+          z.string(),
+          z.object({
+            label: z.string().optional(),
+            style: z.enum(["primary", "danger", "default"]).optional(),
+          }),
+        )
+        .optional(),
+      textEvent: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const justOneSchemas = createAgentSchemas({
+  meta: metaSchema,
+  context: z.object({
+    deck: z.array(z.string()),
+    roundIndex: z.number(),
+    rounds: z.number(),
+    secretWord: z.string(),
+    /**
+     * One slot per clue-giver. A region writes only its own slot; no region
+     * reads another's. Separate fields (rather than one array) keep the three
+     * concurrent context writes provably disjoint.
+     */
+    clueA: clueDraftSchema.nullable(),
+    clueB: clueDraftSchema.nullable(),
+    clueC: clueDraftSchema.nullable(),
+    /** The judged clues of the current round, struck flags included. */
+    clues: z.array(judgedClueSchema),
+    /** Surviving clue words, interpolated into the idle label. */
+    clueSummary: z.string(),
+    score: z.number(),
+    log: z.array(z.string()),
+  }),
+  input: z.object({
+    rounds: z.number().int().positive().default(3),
+    /** Override the built-in deck (the tests pin the secret words this way). */
+    deck: z.array(z.string()).optional(),
+  }),
+  output: z.object({
+    /** Headline: a readable round-by-round narration of the game. */
+    summary: z.string(),
+    score: z.number(),
+    rounds: z.number(),
+    log: z.array(z.string()),
+  }),
+  events: {
+    /** The guesser's answer, sent by a host as free text. */
+    GUESS: z.object({ guess: z.string() }),
+    PASS: z.object({}),
+  },
+});
+
+const models = defineModels({ clueGiver: openai("gpt-5.4-mini") });
+
+// ─── Rules (pure functions — the machine's, not the prompt's) ───
+
+/** Lowercase, strip accents and punctuation, collapse whitespace. */
+export function normalizeWord(raw: string): string {
+  return raw
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/** Naive de-inflection so "keys" and "key" collide. */
+function singularize(word: string): string {
+  if (word.length > 3 && word.endsWith("es")) return word.slice(0, -2);
+  return word.length > 3 && word.endsWith("s") ? word.slice(0, -1) : word;
+}
+
+/** The comparison key: two clues collide iff their keys are equal. */
+export function clueKey(raw: string): string {
+  return singularize(normalizeWord(raw));
+}
+
+/**
+ * Apply the whole rulebook to one round's drafts. Every strike is decided here,
+ * deterministically, from the drafts plus the secret word:
+ *
+ * - empty draft (a failed request) is struck;
+ * - a clue that is not a single word is struck;
+ * - a clue that is the secret word, or contains it, is struck;
+ * - clues sharing a key with any other clue cancel each other.
+ *
+ * Duplicates are counted across every non-empty clue, including ones already
+ * struck for another reason — a rule violation does not shield a sibling.
+ */
+export function judgeClues(secretWord: string, drafts: (ClueDraft | null)[]): JudgedClue[] {
+  const secretKey = clueKey(secretWord);
+  const entries = drafts.map((draft, index) => ({
+    author: PERSONAS[index]?.name ?? `Player ${index + 1}`,
+    word: draft?.clue.trim() ?? "",
+    normalized: normalizeWord(draft?.clue ?? ""),
+  }));
+
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    if (!entry.normalized) continue;
+    const key = clueKey(entry.word);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  return entries.map(({ author, word, normalized }) => {
+    const key = clueKey(word);
+    if (!normalized) {
+      return { author, word, struck: true, reason: "no clue written" };
+    }
+    if (normalized.includes(" ")) {
+      return { author, word, struck: true, reason: "not a single word" };
+    }
+    if (key === secretKey || key.includes(secretKey)) {
+      return { author, word, struck: true, reason: "gives away the secret word" };
+    }
+    if ((counts.get(key) ?? 0) > 1) {
+      return { author, word, struck: true, reason: "duplicate — cancelled" };
+    }
+    return { author, word, struck: false, reason: "" };
+  });
+}
+
+/** `true` when the guess matches the secret word after normalization. */
+export function isCorrectGuess(guess: string, secretWord: string): boolean {
+  return clueKey(guess) === clueKey(secretWord) && clueKey(secretWord) !== "";
+}
+
+function renderClues(clues: JudgedClue[]): string {
+  return clues
+    .map((clue) =>
+      clue.struck ? `${clue.word || "(blank)"} [${clue.reason}]` : `${clue.word} (${clue.author})`,
+    )
+    .join(", ");
+}
+
+function survivors(clues: JudgedClue[]): JudgedClue[] {
+  return clues.filter((clue) => !clue.struck);
+}
+
+/** Joins the log into readable prose for the machine output. */
+function narrate(context: { log: string[]; score: number; rounds: number }): string {
+  const headline = `Guessed ${context.score} of ${context.rounds} word${
+    context.rounds === 1 ? "" : "s"
+  }.`;
+  const body = context.log.length === 0 ? "No rounds played." : context.log.join("\n");
+  return `${headline}\n\n${body}`;
+}
+
+// ─── Agent ───
+
+const CLUE_SYSTEM_PROMPT = [
+  "You are a clue-giver in Just One, the cooperative word game.",
+  "A human guesser has to name a secret word from the clues. You are writing ONE clue for it.",
+  "Two other players are writing their clue for the SAME word at the SAME time.",
+  "You cannot see their clues and they cannot see yours — nobody writes second.",
+  "Before the guesser sees anything, a referee compares all three clues and CANCELS every clue that matches another player's.",
+  "A cancelled clue is struck out and never shown, so it helps the guesser exactly as much as writing nothing.",
+  "Therefore the best clue is accurate but NOT the single most obvious word: predict what the other two are most likely to write, and approach the secret from an angle they probably will not take. Do not be so obscure that the guesser cannot use it.",
+  "Rules the referee enforces mechanically: exactly one word, no spaces or hyphens; never the secret word itself or an inflection of it; matching clues cancel.",
+  "Reason briefly about what the others will write, then commit to your clue word.",
+].join(" ");
+
+const agentSetup = setupAgent({
+  schemas: justOneSchemas,
+  models,
+  // Deterministic idle detection: the run settles exactly when it is waiting on
+  // the guesser, instead of falling back to the timing heuristic.
+  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  requests: {
+    // ONE request definition, used by all three regions. Its input type is the
+    // isolation guarantee in miniature: `{ secretWord, persona }` and nothing
+    // else — there is no field a sibling's clue could travel in.
+    writeClue: {
+      schemas: {
+        input: z.object({ secretWord: z.string(), persona: personaSchema }),
+        output: clueDraftSchema,
+      },
+      model: "clueGiver",
+      system: CLUE_SYSTEM_PROMPT,
+      prompt: ({ input }) =>
+        [
+          `Secret word: ${input.secretWord}`,
+          `You are ${input.persona.name}. Your angle: ${input.persona.angle}.`,
+          "Write your one-word clue.",
+        ].join("\n"),
+    },
+  },
+});
+
+export const justOneMachine = agentSetup.createMachine({
+  id: "just-one",
+  context: ({ input }) => ({
+    deck: input.deck ?? [...WORD_DECK],
+    roundIndex: 0,
+    rounds: input.rounds,
+    secretWord: "",
+    clueA: null,
+    clueB: null,
+    clueC: null,
+    clues: [],
+    clueSummary: "",
+    score: 0,
+    log: [],
+  }),
+  output: ({ context }) => ({
+    summary: narrate(context),
+    score: context.score,
+    rounds: context.rounds,
+    log: context.log,
+  }),
+  initial: "pickingWord",
+  states: {
+    // Deal the round's secret word and clear last round's slots.
+    pickingWord: {
+      always: ({ context }) => ({
+        target: "cluing",
+        context: {
+          secretWord: context.deck[context.roundIndex % context.deck.length] ?? "",
+          clueA: null,
+          clueB: null,
+          clueC: null,
+          clues: [],
+          clueSummary: "",
+        },
+      }),
+    },
+
+    // Three simultaneous clue-givers. Each region invokes the SAME `writeClue`
+    // request with a different persona, and every input is built from
+    // `{ secretWord, persona }` at region entry — before any sibling request
+    // settles, so no clue can be in scope to leak. Each region writes only its
+    // own slot; `judging` is the first place all three are read together.
+    cluing: {
+      type: "parallel",
+      onDone: { target: "judging" },
+      states: {
+        giverA: {
+          initial: "writing",
+          states: {
+            writing: {
+              invoke: {
+                src: "writeClue",
+                input: ({ context }) => ({
+                  secretWord: context.secretWord,
+                  persona: PERSONAS[0],
+                }),
+                onDone: ({ output }) => ({ target: "written", context: { clueA: output } }),
+                // A failed request is a blank clue: the round goes on, and
+                // `judgeClues` strikes it like any other unusable clue.
+                onError: { target: "written", context: { clueA: null } },
+              },
+            },
+            written: { type: "final" },
+          },
+        },
+        giverB: {
+          initial: "writing",
+          states: {
+            writing: {
+              invoke: {
+                src: "writeClue",
+                input: ({ context }) => ({
+                  secretWord: context.secretWord,
+                  persona: PERSONAS[1],
+                }),
+                onDone: ({ output }) => ({ target: "written", context: { clueB: output } }),
+                onError: { target: "written", context: { clueB: null } },
+              },
+            },
+            written: { type: "final" },
+          },
+        },
+        giverC: {
+          initial: "writing",
+          states: {
+            writing: {
+              invoke: {
+                src: "writeClue",
+                input: ({ context }) => ({
+                  secretWord: context.secretWord,
+                  persona: PERSONAS[2],
+                }),
+                onDone: ({ output }) => ({ target: "written", context: { clueC: output } }),
+                onError: { target: "written", context: { clueC: null } },
+              },
+            },
+            written: { type: "final" },
+          },
+        },
+      },
+    },
+
+    // The rulebook, applied in one pure step. If every clue was struck the
+    // guesser is never shown anything — the round is skipped, as in the real
+    // game — so `guessing` is not even entered.
+    judging: {
+      always: ({ context }) => {
+        const clues = judgeClues(context.secretWord, [context.clueA, context.clueB, context.clueC]);
+        const shown = survivors(clues);
+        const roundLine =
+          `Round ${context.roundIndex + 1} — secret "${context.secretWord}". ` +
+          `Clues: ${renderClues(clues)}.`;
+
+        if (shown.length === 0) {
+          return {
+            target: "roundEnd",
+            context: {
+              clues,
+              clueSummary: "",
+              log: [...context.log, roundLine, "All clues cancelled — round skipped."],
+            },
+          };
+        }
+        return {
+          target: "guessing",
+          context: {
+            clues,
+            clueSummary: shown.map((clue) => clue.word).join(", "),
+            log: [...context.log, roundLine],
+          },
+        };
+      },
+    },
+
+    // No invoke: the run settles idle here and a host resumes it with `GUESS`
+    // (free text) or the `PASS` button.
+    guessing: {
+      tags: ["waiting"],
+      meta: {
+        interaction: {
+          label: "Clues: {clueSummary}. What is the secret word?",
+          events: {
+            GUESS: { label: "Guess", style: "primary" },
+            PASS: { label: "Pass" },
+          },
+          textEvent: "GUESS",
+        },
+      },
+      on: {
+        GUESS: ({ context, event }) => {
+          const correct = isCorrectGuess(event.guess, context.secretWord);
+          return {
+            target: "roundEnd",
+            context: {
+              score: context.score + (correct ? 1 : 0),
+              log: [
+                ...context.log,
+                correct
+                  ? `Guessed "${event.guess.trim()}" — correct.`
+                  : `Guessed "${event.guess.trim()}" — wrong, the word was "${context.secretWord}".`,
+              ],
+            },
+          };
+        },
+        PASS: ({ context }) => ({
+          target: "roundEnd",
+          context: {
+            log: [...context.log, `Passed — the word was "${context.secretWord}".`],
+          },
+        }),
+      },
+    },
+
+    roundEnd: {
+      always: ({ context }) =>
+        context.roundIndex + 1 < context.rounds
+          ? { target: "pickingWord", context: { roundIndex: context.roundIndex + 1 } }
+          : { target: "gameOver" },
+    },
+
+    gameOver: { type: "final" },
+  },
+});
+
+// ─── Host helpers ───
+
+type JustOneSnapshot = SnapshotFrom<typeof justOneMachine>;
+
+/** What a host sends to unblock an idle machine. */
+export type GuesserEvent = { type: "GUESS"; guess: string } | { type: "PASS" };
+
+/** `{key}` placeholders in interaction labels resolve against context. */
+export function resolveInteractionLabel(label: string, context: Record<string, unknown>): string {
+  return label
+    .replace(/\{(\w+)\}/g, (_, key: string) => {
+      const value = context[key];
+      return typeof value === "string" || typeof value === "number" ? String(value) : "";
+    })
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** The label a host shows on an idle guessing turn. */
+export function idlePrompt(snapshot: JustOneSnapshot): string {
+  const interaction = getStateMeta(snapshot).interaction;
+  return resolveInteractionLabel(
+    interaction?.label ?? "What is the secret word?",
+    snapshot.context,
+  );
+}
+
+/** Route free text to the idle state's `textEvent` (or `PASS` for "pass"). */
+export function toGuesserEvent(text: string): GuesserEvent {
+  return text.trim().toLowerCase() === "pass" ? { type: "PASS" } : { type: "GUESS", guess: text };
+}
+
+// ─── Dual-mode entrypoint ───
+
+export async function main() {
+  const shared = { executors: createAiSdkExecutors({ models }) };
+
+  let result = await runAgent(justOneMachine, { input: { rounds: 3 }, ...shared });
+
+  // Every guessing turn settles the run idle. Resume from `persistedSnapshot`.
+  while (result.status === "idle") {
+    const text = await promptLine(`${idlePrompt(result.snapshot)}\n> `);
+    result = await runAgent(justOneMachine, {
+      snapshot: result.persistedSnapshot,
+      event: toGuesserEvent(text),
+      ...shared,
+    });
+  }
+
+  if (result.status !== "done") throw new Error(`Just One did not complete: ${result.status}`);
+  console.log(result.output.summary);
+}
+
+/** Prompt once on stdin and resolve the trimmed reply. */
+async function promptLine(query: string): Promise<string> {
+  const { createInterface } = await import("node:readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return (await rl.question(query)).trim();
+  } finally {
+    rl.close();
+  }
+}
+
+// Run directly (`tsx index.ts`); skipped when a test imports this module.
+if (import.meta.url === new URL(process.argv[1]!, "file:").href) {
+  if (!process.env.OPENAI_API_KEY) {
+    console.error("Set OPENAI_API_KEY to run this example.");
+    process.exit(1);
+  }
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/examples/just-one/index.ts
+++ b/examples/just-one/index.ts
@@ -280,7 +280,7 @@ const agentSetup = setupAgent({
   models,
   // Deterministic idle detection: the run settles exactly when it is waiting on
   // the guesser, instead of falling back to the timing heuristic.
-  isSuspended: (snapshot) => snapshot.hasTag("waiting"),
+  isIdle: (snapshot) => snapshot.hasTag("waiting"),
   requests: {
     // ONE request definition, used by all three regions. Its input type is the
     // isolation guarantee in miniature: `{ secretWord, persona }` and nothing

--- a/examples/just-one/metadata.json
+++ b/examples/just-one/metadata.json
@@ -1,0 +1,24 @@
+{
+  "name": "just-one",
+  "title": "Just One",
+  "kind": "agent-workflow",
+  "origin": {
+    "type": "stately-agent",
+    "source": "Created in this repository",
+    "url": null
+  },
+  "comparison": {
+    "targets": ["LangGraph", "Burr", "CrewAI Flow"],
+    "purpose": "Three clue-givers run as isolated parallel regions whose inputs are built before any sibling settles, and the duplicate-cancelling rule is a pure function in the machine instead of an instruction the agents are asked to coordinate on."
+  },
+  "starters": [
+    {
+      "label": "Quick game (1 round)",
+      "input": { "rounds": 1 }
+    },
+    {
+      "label": "Full game (3 rounds)",
+      "input": { "rounds": 3 }
+    }
+  ]
+}

--- a/examples/seam-scoring/index.test.ts
+++ b/examples/seam-scoring/index.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Keyless: both candidates are scripted, so the addressing, the routing, and
+ * the scorers are testable with no key and no network.
+ */
+import { describe, expect, test } from "vitest";
+import {
+  BAD_DRAFT,
+  GOOD_DRAFT,
+  renderTable,
+  runCandidate,
+  scoreCoverage,
+  scoreLength,
+  scoreTone,
+  scriptedCandidates,
+} from "./index.js";
+
+const candidateFor = (label: string) =>
+  scriptedCandidates().find((c) => c.label === label)!.candidate;
+
+describe("seam scoring", () => {
+  test("the seam is the first draftEmail call, and only it reaches the candidate", async () => {
+    const run = await runCandidate("good", candidateFor("good"));
+
+    expect(run.status).toBe("done");
+    // Exactly one model call is the candidate's, and it is the drafter's —
+    // addressed by its `actors:` key, which the unnamed request takes as `name`.
+    expect(run.candidateCalls).toEqual(["draftEmail"]);
+    // The evaluator ran first, from the script.
+    expect(run.callsBeforeSeam).toBe(1);
+    expect(run.scriptedCalls[0]).toBe("evaluatePrompt");
+    // The seam's own answer is the candidate's draft, not a scripted one.
+    expect(run.draft).toEqual(GOOD_DRAFT);
+    // The slice starts at the seam: no `prompting`/`evaluating` before it.
+    expect(run.statesAfterSeam[0]).toBe("reviewing");
+    expect(run.statesAfterSeam).not.toContain("prompting");
+  });
+
+  test("every other request is served from the script", async () => {
+    const good = await runCandidate("good", candidateFor("good"));
+    const bad = await runCandidate("bad", candidateFor("bad"));
+
+    // The `calls` ledger is the receipt. The candidate replaces the seam's
+    // slot, so the good run scripts the evaluator and nothing else.
+    expect(good.scriptedCalls).toEqual(["evaluatePrompt"]);
+    // The bad draft was sent back, so the revision draft came from the script
+    // too — one candidate call either way.
+    expect(bad.scriptedCalls).toEqual(["evaluatePrompt", "draftEmail"]);
+    expect(bad.candidateCalls).toEqual(["draftEmail"]);
+    // Scripted plain values report no usage: the seam's cost stays undefined.
+    expect(good.seamTokens).toBeUndefined();
+  });
+
+  test("the good candidate outscores the bad one on every scorer", async () => {
+    const good = await runCandidate("good", candidateFor("good"));
+    const bad = await runCandidate("bad", candidateFor("bad"));
+
+    expect(good.total).toBe(1);
+    expect(bad.total).toBeLessThan(good.total);
+    for (const [index, score] of good.scores.entries()) {
+      expect(score.score).toBeGreaterThan(bad.scores[index]!.score);
+    }
+  });
+
+  test("the branch after the seam is a real consequence of it", async () => {
+    const good = await runCandidate("good", candidateFor("good"));
+    const bad = await runCandidate("bad", candidateFor("bad"));
+
+    // The reviewer accepted the good draft and sent it.
+    expect(good.statesAfterSeam).toEqual(["reviewing", "sending", "sent", "done"]);
+    // The bad draft cost a revision round the good one never needed.
+    expect(bad.statesAfterSeam).toContain("drafting");
+    expect(bad.statesAfterSeam.length).toBeGreaterThan(good.statesAfterSeam.length);
+  });
+
+  test("the scorers grade the drafts, not the run", () => {
+    expect(scoreLength(GOOD_DRAFT).score).toBe(1);
+    expect(scoreLength(BAD_DRAFT).score).toBe(0);
+    expect(scoreCoverage(GOOD_DRAFT).score).toBe(1);
+    expect(scoreCoverage(BAD_DRAFT).note).toContain("recipient");
+    expect(scoreTone(GOOD_DRAFT).score).toBe(1);
+    expect(scoreTone(BAD_DRAFT).score).toBe(0);
+    // Whole-word matching: "Ship it" is not a greeting.
+    expect(scoreTone({ ...BAD_DRAFT, body: "Ship it." }).note).toContain("cold");
+  });
+
+  test("the table carries one row per candidate", async () => {
+    const runs = [
+      await runCandidate("good", candidateFor("good")),
+      await runCandidate("bad", candidateFor("bad")),
+    ];
+    const table = renderTable(runs);
+
+    expect(table.split("\n")).toHaveLength(4);
+    expect(table).toContain("coverage");
+    expect(table).toMatch(/good\s+1\.00/);
+  });
+});

--- a/examples/seam-scoring/index.ts
+++ b/examples/seam-scoring/index.ts
@@ -1,0 +1,351 @@
+/**
+ * Seam scoring — regression-test ONE model call of a machine agent, with the
+ * whole machine running around it.
+ *
+ * A machine agent is a chain of model calls. Swapping the prompt behind one of
+ * them and re-running the whole agent scores everything at once: the run got
+ * better or worse, and you cannot say which call moved. `runSeam` addresses one
+ * call, scripts every other one, and hands back what that call answered plus
+ * the branch it caused.
+ *
+ * This example reuses the email drafter (`../email-drafter/agent-logic.ts`)
+ * unmodified — no test double of the machine, no eval-only copy of the flow:
+ *   - The seam is the FIRST `draftEmail` call (`{ request: 'draftEmail' }`):
+ *     prompt + clarifications -> draft. The drafter's requests declare no
+ *     `name`, so each takes its `actors:` registration key as its name — the
+ *     seam and the scripts address requests by that key.
+ *   - Every other call (the prompt evaluator, and any revision draft the run
+ *     goes on to need) is served from `scripts`, so a candidate comparison
+ *     burns one call instead of the whole chain. The run's `calls` ledger is
+ *     the receipt: which answers the script served, and which one was the
+ *     candidate's.
+ *   - A reactive `respond` plays the human at every `awaiting-user` state, and
+ *     asks for changes when the draft it is shown misses the point — so a weak
+ *     candidate is charged for the extra round trip it caused.
+ *   - Three plain scorers (length bound, required-field coverage, tone) grade
+ *     the seam's own answer, and `seamUsage` prices the one live call.
+ *     Scorers stay yours: no framework, no dependency.
+ *
+ * Keyless and offline by default: both candidates are scripted functions. Set
+ * `OPENAI_API_KEY` to add a third row where the seam is a real model call and
+ * everything else stays scripted.
+ *
+ * Run: npx tsx examples/seam-scoring/index.ts
+ */
+import type { EventFromLogic } from "xstate";
+import { runSeam } from "@statelyai/agent";
+import type { AgentRequestExecutor, ScriptedTextEntry, SeamTurn } from "@statelyai/agent";
+import { emailDrafter, models } from "../email-drafter/agent-logic.js";
+
+type DrafterEvent = EventFromLogic<typeof emailDrafter>;
+
+/** The seam's declared output shape, from the drafter's own schema. */
+export interface EmailDraft {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+// ─── The call plan ───
+
+const PROMPT =
+  "Email team@example.com with subject 'Deploy pipeline is twice as fast' telling them the " +
+  "deploy pipeline now runs in half the time.";
+
+/** The prompt evaluator waves this complete prompt through: no clarification round. */
+const COMPLETE_ASSESSMENT = { satisfied: true, missing: [], questions: [] };
+
+/** Consumed and discarded by the seam — the candidate replaces this answer. */
+const SEAM_SLOT: EmailDraft = { to: "", subject: "", body: "" };
+
+/** The revision draft, only reached when a candidate's draft gets sent back. */
+const REVISION: EmailDraft = {
+  to: "team@example.com",
+  subject: "Deploy pipeline is twice as fast",
+  body:
+    "Hi team, the deploy pipeline now runs in half the time. Thanks for the reviews that got " +
+    "us there. Details are in the thread.",
+};
+
+/**
+ * The call plan, keyed by request name — the `actors:` registration key, which
+ * an unnamed `createTextLogic` request takes as its `name` at run time. Plain
+ * values: the run's own `calls` ledger reports which entries were served, so
+ * nothing here needs to record anything.
+ *
+ * The seam consumes its slot too (the candidate REPLACES that answer rather
+ * than skipping it), so the later entries stay lined up with the plan.
+ */
+const SCRIPTS: Record<string, ScriptedTextEntry[]> = {
+  evaluatePrompt: [COMPLETE_ASSESSMENT],
+  draftEmail: [SEAM_SLOT, REVISION],
+};
+
+// ─── Scorers: plain functions, no dependencies ───
+
+/** One scorer's verdict on the seam's own answer. */
+export interface Score {
+  name: string;
+  score: number;
+  note: string;
+}
+
+const MIN_WORDS = 12;
+const MAX_WORDS = 90;
+
+/** A draft nobody reads is as bad as a draft nobody understands. */
+export function scoreLength(draft: EmailDraft | undefined): Score {
+  const words = (draft?.body ?? "").trim().split(/\s+/).filter(Boolean).length;
+  const ok = words >= MIN_WORDS && words <= MAX_WORDS;
+  return { name: "length", score: ok ? 1 : 0, note: `${words} words` };
+}
+
+const REQUIRED_TERMS = ["deploy", "pipeline", "half"];
+
+/**
+ * Whole-word containment. A substring check would score "Ship it" as a warm
+ * greeting because it contains "hi" — the kind of scorer bug that quietly
+ * flatters every candidate.
+ */
+function mentions(text: string, term: string): boolean {
+  return /^\w[\w ]*\w$|^\w$/.test(term)
+    ? new RegExp(`\\b${term}\\b`).test(text)
+    : text.includes(term);
+}
+
+/** Addressed, subject-lined, and actually about the thing that was asked for. */
+export function scoreCoverage(draft: EmailDraft | undefined): Score {
+  const text = `${draft?.subject ?? ""} ${draft?.body ?? ""}`.toLowerCase();
+  const addressed = Boolean(draft?.to?.includes("@"));
+  const titled = Boolean(draft?.subject?.trim());
+  const checks = [addressed, titled, ...REQUIRED_TERMS.map((term) => mentions(text, term))];
+  const missing = [
+    ...(addressed ? [] : ["recipient"]),
+    ...(titled ? [] : ["subject"]),
+    ...REQUIRED_TERMS.filter((term) => !mentions(text, term)),
+  ];
+  return {
+    name: "coverage",
+    score: checks.filter(Boolean).length / checks.length,
+    note: missing.length ? `missing ${missing.join(", ")}` : (draft?.to ?? ""),
+  };
+}
+
+const WARM_TERMS = ["hi", "hello", "thanks", "thank you", "please"];
+const HARSH_TERMS = ["asap", "obviously", "just do", "whatever", "!!"];
+
+/** House tone: greet somebody, do not shout at them. */
+export function scoreTone(draft: EmailDraft | undefined): Score {
+  const body = (draft?.body ?? "").toLowerCase();
+  const warm = WARM_TERMS.some((term) => mentions(body, term));
+  const harsh = HARSH_TERMS.some((term) => mentions(body, term));
+  const shouting = /\b[A-Z]{4,}\b/.test(draft?.body ?? "");
+  const checks = [warm, !harsh, !shouting];
+  return {
+    name: "tone",
+    score: checks.filter(Boolean).length / checks.length,
+    note: [warm ? "warm" : "cold", harsh ? "harsh" : null, shouting ? "shouting" : null]
+      .filter(Boolean)
+      .join(" "),
+  };
+}
+
+/** The three scorers, in table order. */
+export const scorers = [scoreLength, scoreCoverage, scoreTone];
+
+// ─── Candidates: what the seam answers ───
+
+/** A scripted candidate: whatever the seam is asked, it answers this draft. */
+const makeCandidate =
+  (draft: EmailDraft): AgentRequestExecutor =>
+  async () => ({ output: draft });
+
+/** The candidate under test today: on topic, addressed, polite. */
+export const GOOD_DRAFT: EmailDraft = {
+  to: "team@example.com",
+  subject: "Deploy pipeline is twice as fast",
+  body:
+    "Hi team, the deploy pipeline now runs in half the time. Thanks to everyone who reviewed " +
+    "the change. Details are in the thread.",
+};
+
+/** The regression: terse, unaddressed, and shouty. */
+export const BAD_DRAFT: EmailDraft = {
+  to: "",
+  subject: "",
+  body: "DEPLOY IS FASTER NOW. Ship it, obviously.",
+};
+
+// ─── One seam run ───
+
+/** Everything the comparison table needs from one candidate's run. */
+export interface SeamRun {
+  label: string;
+  status: string;
+  /** What the seam call answered. */
+  draft: EmailDraft | undefined;
+  /** Model calls made before the seam. */
+  callsBeforeSeam: number;
+  /** Which calls the script served, in order. With a candidate at the seam,
+   * the seam's slot is consumed but replaced, so it is not listed here. */
+  scriptedCalls: string[];
+  /** Request names the candidate was actually asked for: exactly one. */
+  candidateCalls: string[];
+  /** The seam call's own token cost, when its answer reported usage. */
+  seamTokens: number | undefined;
+  /** States entered from the seam onward — the branch the seam caused. */
+  statesAfterSeam: string[];
+  scores: Score[];
+  total: number;
+}
+
+/**
+ * The simulated user. It answers off the machine's current state, and reads the
+ * draft it is shown: a draft that misses a required term gets sent back once,
+ * which is a real consequence of the seam rather than a scripted one.
+ */
+function respond() {
+  const used = { changes: false };
+  return ({ snapshot, state }: SeamTurn<typeof emailDrafter>): DrafterEvent | null => {
+    switch (state) {
+      case "prompting":
+        return { type: "PROMPT_SUBMITTED", prompt: PROMPT } as DrafterEvent;
+      case "needsMoreInfo":
+        return { type: "DRAFT_ANYWAY" } as DrafterEvent;
+      case "reviewing": {
+        const shown = snapshot.context.draft as EmailDraft | null;
+        if (!used.changes && scoreCoverage(shown ?? undefined).score < 1) {
+          used.changes = true;
+          return {
+            type: "REQUEST_CHANGES",
+            changes: "Address it to team@example.com and keep the tone friendly.",
+          } as DrafterEvent;
+        }
+        return { type: "SEND" } as DrafterEvent;
+      }
+      case "sent":
+        return { type: "END" } as DrafterEvent;
+      default:
+        return null;
+    }
+  };
+}
+
+/** Runs the machine end to end with `candidate` at the seam, and scores it. */
+export async function runCandidate(
+  label: string,
+  candidate: AgentRequestExecutor,
+): Promise<SeamRun> {
+  const run = await runSeam(emailDrafter, {
+    scripts: SCRIPTS,
+    // The first `draftEmail` call: prompt + clarifications -> draft. The
+    // request's `name` is its `actors:` key, so no model-key addressing.
+    seam: { request: "draftEmail" },
+    candidate,
+    respond: respond(),
+  });
+
+  const draft = run.seamOutput as EmailDraft | undefined;
+  const scores = scorers.map((scorer) => scorer(draft));
+
+  return {
+    label,
+    status: run.result.status,
+    draft,
+    callsBeforeSeam: run.callsBeforeSeam,
+    // The ledger is the receipt: everything else stayed scripted.
+    scriptedCalls: run.calls
+      .filter((call) => call.source === "script")
+      .map((call) => (call.seam ? `${call.key} (seam)` : call.key)),
+    candidateCalls: run.calls
+      .filter((call) => call.source === "candidate")
+      .map((call) => call.name ?? call.model),
+    seamTokens: run.seamUsage?.totalTokens,
+    statesAfterSeam: run.after.statePath.map(String),
+    scores,
+    total: scores.reduce((sum, entry) => sum + entry.score, 0) / scores.length,
+  };
+}
+
+/** The scripted candidates, always available and always keyless. */
+export function scriptedCandidates(): Array<{
+  label: string;
+  candidate: AgentRequestExecutor;
+}> {
+  return [
+    { label: "good", candidate: makeCandidate(GOOD_DRAFT) },
+    { label: "bad", candidate: makeCandidate(BAD_DRAFT) },
+  ];
+}
+
+// ─── Reporting ───
+
+const pad = (value: string, width: number) => value.padEnd(width);
+
+/** The comparison table: one row per candidate, one column per scorer. */
+export function renderTable(runs: SeamRun[]): string {
+  const names = scorers.map((_, index) => runs[0]?.scores[index]?.name ?? "?");
+  const header = ["candidate", ...names, "mean", "states after seam"];
+  const rows = runs.map((run) => [
+    run.label,
+    ...run.scores.map((score) => score.score.toFixed(2)),
+    run.total.toFixed(2),
+    run.statesAfterSeam.join(" -> "),
+  ]);
+  const widths = header.map((cell, index) =>
+    Math.max(cell.length, ...rows.map((row) => row[index]!.length)),
+  );
+  const line = (cells: string[]) =>
+    cells
+      .map((cell, index) => pad(cell, widths[index]!))
+      .join("  ")
+      .trimEnd();
+
+  return [line(header), line(widths.map((width) => "-".repeat(width))), ...rows.map(line)].join(
+    "\n",
+  );
+}
+
+async function liveCandidate(): Promise<AgentRequestExecutor> {
+  const { createAiSdkExecutors } = await import("@statelyai/agent/ai-sdk");
+  return createAiSdkExecutors({ models }).generateText;
+}
+
+export async function main() {
+  const live = Boolean(process.env.OPENAI_API_KEY);
+  const candidates = scriptedCandidates();
+  if (live) {
+    candidates.push({ label: "live", candidate: await liveCandidate() });
+  }
+
+  console.log(
+    "[seam-scoring] seam: draftEmail call #0 (prompt + clarifications -> draft) | " +
+      `candidates: ${candidates.map((entry) => entry.label).join(", ")}` +
+      (live ? "" : " (keyless: set OPENAI_API_KEY to add a real-model row)"),
+  );
+
+  const runs: SeamRun[] = [];
+  for (const { label, candidate } of candidates) {
+    runs.push(await runCandidate(label, candidate));
+  }
+
+  console.log(`\n${renderTable(runs)}\n`);
+
+  for (const run of runs) {
+    console.log(
+      `${run.label}: ${run.status} | ${run.candidateCalls.length} candidate call, ` +
+        `${run.scriptedCalls.length} scripted (${run.scriptedCalls.join(", ")})` +
+        (run.seamTokens !== undefined ? ` | seam cost: ${run.seamTokens} tokens` : ""),
+    );
+    for (const score of run.scores) {
+      console.log(`  ${pad(score.name, 9)} ${score.score.toFixed(2)}  ${score.note}`);
+    }
+  }
+}
+
+if (import.meta.url === new URL(process.argv[1]!, "file:").href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/examples/seam-scoring/metadata.json
+++ b/examples/seam-scoring/metadata.json
@@ -1,0 +1,16 @@
+{
+  "name": "seam-scoring",
+  "title": "Seam scoring",
+  "kind": "evaluation",
+  "manual": true,
+  "origin": {
+    "type": "stately-agent",
+    "source": "runSeam over the unmodified email-drafter machine: one addressed model call (emailDrafter #0) runs a candidate while every other request is served from the call plan, scored by plain dependency-free scorers and compared across a good and a bad candidate",
+    "url": null
+  },
+  "comparison": {
+    "targets": ["Braintrust", "LangSmith datasets", "whole-run eval harnesses"],
+    "purpose": "A whole-run eval says the agent got worse; a seam run says which model call got worse, because runSeam scripts every request except the one under test and returns both its answer and the branch it caused."
+  },
+  "starters": []
+}

--- a/examples/snapshot-migration/index.test.ts
+++ b/examples/snapshot-migration/index.test.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "vitest";
+import { assertJsonSerializable, persistSnapshot, runAgent } from "@statelyai/agent";
+import { AgentSnapshotVersionMismatchError } from "@statelyai/agent";
+import {
+  migrateOrderSnapshot,
+  orderApprovalMachine,
+  orderApprovalMachineV1,
+  runSnapshotMigrationExample,
+  V1,
+  V2,
+} from "./index.js";
+
+/** A v1 run paused at its idle gate, persisted as plain JSON. */
+async function persistedV1Snapshot(orderId = "ORD-1", total = 812.5) {
+  const paused = await runAgent(orderApprovalMachineV1, {
+    input: { orderId, total },
+    machineVersion: V1,
+  });
+  if (paused.status !== "idle") {
+    throw new Error(`Expected idle, got '${paused.status}'.`);
+  }
+  return persistSnapshot(paused.snapshot);
+}
+
+test("a v1 idle snapshot is stamped with its machine version and round-trips as JSON", async () => {
+  const persisted = await persistedV1Snapshot();
+  expect((persisted as { value?: unknown }).value).toBe("reviewing");
+  expect((persisted as { agentMeta?: { version?: string } }).agentMeta?.version).toBe(V1);
+  // Nothing in the persisted snapshot is a value JSON would drop or coerce.
+  expect(() => assertJsonSerializable(persisted, "snapshot")).not.toThrow();
+  expect(persistSnapshot(persisted)).toEqual(persisted);
+});
+
+test("resuming the v1 snapshot on v2 throws AgentSnapshotVersionMismatchError with from/to", async () => {
+  const persisted = await persistedV1Snapshot();
+  let caught: unknown;
+  try {
+    await runAgent(orderApprovalMachine, {
+      snapshot: persisted as never,
+      event: { type: "APPROVE" },
+      machineVersion: V2,
+    });
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(AgentSnapshotVersionMismatchError);
+  const mismatch = caught as AgentSnapshotVersionMismatchError;
+  expect(mismatch.from).toBe(V1);
+  expect(mismatch.to).toBe(V2);
+  expect(mismatch.machineId).toBe("order-approval");
+});
+
+test("migrateSnapshot resumes the migrated snapshot and completes with the v2 context", async () => {
+  const result = await runSnapshotMigrationExample({ orderId: "ORD-4417", total: 812.5 });
+  expect(result.stampedVersion).toBe(V1);
+  expect(result.mismatch).toBeInstanceOf(AgentSnapshotVersionMismatchError);
+  expect(result.migrationInfo).toEqual({ from: V1, to: V2 });
+  expect(result.output).toEqual({
+    orderId: "ORD-4417",
+    approved: true,
+    // 812.50 dollars became integer cents, and the new risk rule was applied.
+    amountCents: 81250,
+    currency: "USD",
+    riskLevel: "high",
+  });
+});
+
+test("the migration is a pure function of the old snapshot", async () => {
+  const persisted = await persistedV1Snapshot("ORD-9", 12.34);
+  const before = persistSnapshot(persisted);
+  const migrated = migrateOrderSnapshot(persisted as never) as unknown as {
+    value: unknown;
+    context: Record<string, unknown>;
+  };
+  expect(persisted).toEqual(before); // input untouched
+  expect(migrated.value).toBe("awaitingApproval");
+  expect(migrated.context).toEqual({
+    orderId: "ORD-9",
+    amountCents: 1234,
+    currency: "USD",
+    riskLevel: "low",
+    decision: "pending",
+  });
+});
+
+test("opting out with 'ignore' does not protect you — the stale snapshot fails elsewhere", async () => {
+  const persisted = await persistedV1Snapshot();
+  let caught: unknown;
+  try {
+    await runAgent(orderApprovalMachine, {
+      snapshot: persisted as never,
+      event: { type: "APPROVE" },
+      machineVersion: V2,
+      onVersionMismatch: "ignore",
+    });
+  } catch (error) {
+    caught = error;
+  }
+  // It still fails, just later and with an error that names nothing useful —
+  // which is the argument for the default 'throw'.
+  expect(caught).toBeInstanceOf(Error);
+  expect(caught).not.toBeInstanceOf(AgentSnapshotVersionMismatchError);
+});
+
+test("a v2 snapshot resumes on v2 without any migration", async () => {
+  const paused = await runAgent(orderApprovalMachine, {
+    input: { orderId: "ORD-2", amountCents: 2500 },
+    machineVersion: V2,
+  });
+  if (paused.status !== "idle") {
+    throw new Error(`Expected idle, got '${paused.status}'.`);
+  }
+  const resumed = await runAgent(orderApprovalMachine, {
+    snapshot: persistSnapshot(paused.snapshot),
+    event: { type: "REJECT", reason: "duplicate order" },
+    machineVersion: V2,
+  });
+  expect(resumed.status).toBe("done");
+  if (resumed.status !== "done") return;
+  expect(resumed.output).toEqual({
+    orderId: "ORD-2",
+    approved: false,
+    amountCents: 2500,
+    currency: "USD",
+    riskLevel: "low",
+  });
+});

--- a/examples/snapshot-migration/index.test.ts
+++ b/examples/snapshot-migration/index.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "vitest";
-import { assertJsonSerializable, persistSnapshot, runAgent } from "@statelyai/agent";
+import { assertJsonSerializable, runAgent } from "@statelyai/agent";
 import { AgentSnapshotVersionMismatchError } from "@statelyai/agent";
 import {
   migrateOrderSnapshot,
+  persistSnapshot,
   orderApprovalMachine,
   orderApprovalMachineV1,
   runSnapshotMigrationExample,
@@ -14,7 +15,6 @@ import {
 async function persistedV1Snapshot(orderId = "ORD-1", total = 812.5) {
   const paused = await runAgent(orderApprovalMachineV1, {
     input: { orderId, total },
-    machineVersion: V1,
   });
   if (paused.status !== "idle") {
     throw new Error(`Expected idle, got '${paused.status}'.`);
@@ -38,7 +38,6 @@ test("resuming the v1 snapshot on v2 throws AgentSnapshotVersionMismatchError wi
     await runAgent(orderApprovalMachine, {
       snapshot: persisted as never,
       event: { type: "APPROVE" },
-      machineVersion: V2,
     });
   } catch (error) {
     caught = error;
@@ -90,7 +89,6 @@ test("opting out with 'ignore' does not protect you — the stale snapshot fails
     await runAgent(orderApprovalMachine, {
       snapshot: persisted as never,
       event: { type: "APPROVE" },
-      machineVersion: V2,
       onVersionMismatch: "ignore",
     });
   } catch (error) {
@@ -105,7 +103,6 @@ test("opting out with 'ignore' does not protect you — the stale snapshot fails
 test("a v2 snapshot resumes on v2 without any migration", async () => {
   const paused = await runAgent(orderApprovalMachine, {
     input: { orderId: "ORD-2", amountCents: 2500 },
-    machineVersion: V2,
   });
   if (paused.status !== "idle") {
     throw new Error(`Expected idle, got '${paused.status}'.`);
@@ -113,7 +110,6 @@ test("a v2 snapshot resumes on v2 without any migration", async () => {
   const resumed = await runAgent(orderApprovalMachine, {
     snapshot: persistSnapshot(paused.snapshot),
     event: { type: "REJECT", reason: "duplicate order" },
-    machineVersion: V2,
   });
   expect(resumed.status).toBe("done");
   if (resumed.status !== "done") return;

--- a/examples/snapshot-migration/index.ts
+++ b/examples/snapshot-migration/index.ts
@@ -8,11 +8,11 @@
  * context has the wrong shape.
  *
  * Demonstrates the three pieces `runAgent` gives you for that:
- *   - `machineVersion` — the stamp written onto every settled snapshot's
- *     `agentMeta` (defaults to the machine's own `version`, else
+ *   - the machine's own `version` — the stamp written onto every settled
+ *     snapshot's `agentMeta` (falling back to
  *     `getMachineStructuralHash(machine)`, which changes on any structural
- *     edit). Both machines here set it explicitly, so the boundary is a
- *     deliberate "1.0.0" → "2.0.0" and not an accident of hashing.
+ *     edit). Both machines here declare it, so the boundary is a deliberate
+ *     "1.0.0" → "2.0.0" and not an accident of hashing.
  *   - `onVersionMismatch` — `'throw'` (the default) turns a stale resume into
  *     an `AgentSnapshotVersionMismatchError` carrying `from`/`to`, instead of
  *     restoring garbage. `'warn'`/`'ignore'` opt out.
@@ -28,13 +28,16 @@
  * npx tsx examples/snapshot-migration/index.ts
  */
 import { z } from "zod";
-import {
-  AgentSnapshotVersionMismatchError,
-  persistSnapshot,
-  runAgent,
-  setupAgent,
-} from "@statelyai/agent";
+import { AgentSnapshotVersionMismatchError, runAgent, setupAgent } from "@statelyai/agent";
 import type { Snapshot } from "xstate";
+
+/**
+ * What a durable store does to a settled snapshot: write it as JSON and read it
+ * back. Everything `runAgent` hands you at an idle gate survives the trip.
+ */
+export function persistSnapshot<T>(snapshot: T): T {
+  return JSON.parse(JSON.stringify(snapshot)) as T;
+}
 
 /** The version stamped on snapshots produced by {@link orderApprovalMachineV1}. */
 export const V1 = "1.0.0";
@@ -58,12 +61,13 @@ const v1Setup = setupAgent({
   },
   // The idle gate is declared by the machine, so `runAgent` settles
   // `{ status: 'idle', snapshot }` deterministically rather than by timing.
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-approval"),
 });
 
 /** v1 of the order-approval flow. Kept exported so the old snapshot is real, not hand-written. */
 export const orderApprovalMachineV1 = v1Setup.createMachine({
   id: "order-approval",
+  version: V1,
   context: ({ input }) => ({
     orderId: input.orderId,
     total: input.total,
@@ -134,7 +138,7 @@ const v2Setup = setupAgent({
       })
       .optional(),
   }),
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-approval"),
 });
 
 /** Anything at or above this is `riskLevel: 'high'`. New rule in v2. */
@@ -143,6 +147,7 @@ export const HIGH_RISK_CENTS = 50_000;
 /** v2 of the order-approval flow — the current machine. */
 export const orderApprovalMachine = v2Setup.createMachine({
   id: "order-approval",
+  version: V2,
   context: ({ input }) => ({
     orderId: input.orderId,
     amountCents: input.amountCents,
@@ -258,7 +263,6 @@ export async function runSnapshotMigrationExample(
   // Act 1 — v1 runs to its idle gate and the snapshot is persisted as JSON.
   const paused = await runAgent(orderApprovalMachineV1, {
     input: { orderId, total },
-    machineVersion: V1,
   });
   if (paused.status !== "idle") {
     throw new Error(`Expected v1 to settle idle, got '${paused.status}'.`);
@@ -273,7 +277,6 @@ export async function runSnapshotMigrationExample(
     await runAgent(orderApprovalMachine, {
       snapshot: persisted as never,
       event: { type: "APPROVE" },
-      machineVersion: V2,
     });
   } catch (error) {
     if (!(error instanceof AgentSnapshotVersionMismatchError)) {
@@ -290,7 +293,6 @@ export async function runSnapshotMigrationExample(
   const resumed = await runAgent(orderApprovalMachine, {
     snapshot: persisted as never,
     event: { type: "APPROVE" },
-    machineVersion: V2,
     migrateSnapshot: (snapshot, info) => {
       migrationInfo = info;
       return migrateOrderSnapshot(snapshot);
@@ -311,7 +313,6 @@ export async function main(): Promise<void> {
   console.log("Act 1 — v1 pauses for a human and the snapshot is persisted");
   const paused = await runAgent(orderApprovalMachineV1, {
     input: { orderId, total },
-    machineVersion: V1,
   });
   if (paused.status !== "idle") {
     throw new Error(`Expected v1 to settle idle, got '${paused.status}'.`);
@@ -327,7 +328,6 @@ export async function main(): Promise<void> {
     await runAgent(orderApprovalMachine, {
       snapshot: persisted as never,
       event: { type: "APPROVE" },
-      machineVersion: V2,
       onVersionMismatch: "throw", // the default, spelled out
     });
     console.log("  (unreachable — the stale snapshot was accepted)");
@@ -343,7 +343,6 @@ export async function main(): Promise<void> {
   const resumed = await runAgent(orderApprovalMachine, {
     snapshot: persisted as never,
     event: { type: "APPROVE" },
-    machineVersion: V2,
     migrateSnapshot: (snapshot, info) => {
       const migrated = migrateOrderSnapshot(snapshot);
       console.log(`  migrating '${info.from}' → '${info.to}'`);

--- a/examples/snapshot-migration/index.ts
+++ b/examples/snapshot-migration/index.ts
@@ -1,0 +1,369 @@
+/**
+ * Snapshot migration — resuming a paused run after you shipped a new machine.
+ *
+ * An order-approval flow pauses idle waiting for a human. Between the pause and
+ * the approval, v2 of the machine ships: the idle state is renamed, `total`
+ * becomes `amountCents`, and `currency`/`riskLevel` join the context. The
+ * persisted v1 snapshot is now stale — its state value does not exist and its
+ * context has the wrong shape.
+ *
+ * Demonstrates the three pieces `runAgent` gives you for that:
+ *   - `machineVersion` — the stamp written onto every settled snapshot's
+ *     `agentMeta` (defaults to the machine's own `version`, else
+ *     `getMachineStructuralHash(machine)`, which changes on any structural
+ *     edit). Both machines here set it explicitly, so the boundary is a
+ *     deliberate "1.0.0" → "2.0.0" and not an accident of hashing.
+ *   - `onVersionMismatch` — `'throw'` (the default) turns a stale resume into
+ *     an `AgentSnapshotVersionMismatchError` carrying `from`/`to`, instead of
+ *     restoring garbage. `'warn'`/`'ignore'` opt out.
+ *   - `migrateSnapshot` — a pure `(snapshot, { from, to }) => snapshot` hook
+ *     that runs *instead of* `onVersionMismatch`, so old snapshots are adapted
+ *     at the boundary rather than everywhere downstream.
+ *
+ * Both machines live in this one file on purpose: v1 is what shipped, v2 is
+ * what shipped next, and `migrateOrderSnapshot` is the diff between them
+ * expressed as data.
+ *
+ * No API key needed: nothing here calls a model. Run:
+ * npx tsx examples/snapshot-migration/index.ts
+ */
+import { z } from "zod";
+import {
+  AgentSnapshotVersionMismatchError,
+  persistSnapshot,
+  runAgent,
+  setupAgent,
+} from "@statelyai/agent";
+import type { Snapshot } from "xstate";
+
+/** The version stamped on snapshots produced by {@link orderApprovalMachineV1}. */
+export const V1 = "1.0.0";
+/** The version stamped on snapshots produced by {@link orderApprovalMachine}. */
+export const V2 = "2.0.0";
+
+// ─── v1: what shipped first ───
+
+const v1Setup = setupAgent({
+  context: z.object({
+    orderId: z.string(),
+    // Dollars, as a float. This is the mistake v2 fixes.
+    total: z.number(),
+    decision: z.enum(["pending", "approved", "rejected"]),
+  }),
+  input: z.object({ orderId: z.string(), total: z.number() }),
+  output: z.object({ orderId: z.string(), approved: z.boolean() }),
+  events: {
+    APPROVE: z.object({}),
+    REJECT: z.object({ reason: z.string() }),
+  },
+  // The idle gate is declared by the machine, so `runAgent` settles
+  // `{ status: 'idle', snapshot }` deterministically rather than by timing.
+  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+});
+
+/** v1 of the order-approval flow. Kept exported so the old snapshot is real, not hand-written. */
+export const orderApprovalMachineV1 = v1Setup.createMachine({
+  id: "order-approval",
+  context: ({ input }) => ({
+    orderId: input.orderId,
+    total: input.total,
+    decision: "pending" as const,
+  }),
+  initial: "reviewing",
+  states: {
+    // v2 renames this state, which is what makes a raw v1 snapshot unusable.
+    reviewing: {
+      tags: ["awaiting-approval"],
+      on: {
+        APPROVE: () => ({ target: "settled", context: { decision: "approved" as const } }),
+        REJECT: () => ({ target: "settled", context: { decision: "rejected" as const } }),
+      },
+    },
+    settled: {
+      type: "final",
+      output: ({ context }) => ({
+        orderId: context.orderId,
+        approved: context.decision === "approved",
+      }),
+    },
+  },
+});
+
+// ─── v2: what shipped next ───
+
+const v2Setup = setupAgent({
+  context: z.object({
+    orderId: z.string(),
+    // Renamed and re-scaled: integer cents, never a float.
+    amountCents: z.number().int(),
+    // New in v2.
+    currency: z.string(),
+    riskLevel: z.enum(["low", "high"]),
+    decision: z.enum(["pending", "approved", "rejected"]),
+  }),
+  input: z.object({
+    orderId: z.string(),
+    amountCents: z.number().int(),
+    currency: z.string().optional(),
+  }),
+  output: z.object({
+    orderId: z.string(),
+    approved: z.boolean(),
+    amountCents: z.number().int(),
+    currency: z.string(),
+    riskLevel: z.enum(["low", "high"]),
+  }),
+  events: {
+    APPROVE: z.object({}),
+    REJECT: z.object({ reason: z.string() }),
+  },
+  meta: z.object({
+    interaction: z
+      .object({
+        label: z.string(),
+        events: z
+          .record(
+            z.string(),
+            z.object({
+              label: z.string().optional(),
+              style: z.enum(["primary", "danger", "default"]).optional(),
+            }),
+          )
+          .optional(),
+        textEvent: z.string().optional(),
+      })
+      .optional(),
+  }),
+  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+});
+
+/** Anything at or above this is `riskLevel: 'high'`. New rule in v2. */
+export const HIGH_RISK_CENTS = 50_000;
+
+/** v2 of the order-approval flow — the current machine. */
+export const orderApprovalMachine = v2Setup.createMachine({
+  id: "order-approval",
+  context: ({ input }) => ({
+    orderId: input.orderId,
+    amountCents: input.amountCents,
+    currency: input.currency ?? "USD",
+    riskLevel: input.amountCents >= HIGH_RISK_CENTS ? ("high" as const) : ("low" as const),
+    decision: "pending" as const,
+  }),
+  initial: "awaitingApproval",
+  states: {
+    // Renamed from v1's `reviewing`.
+    awaitingApproval: {
+      tags: ["awaiting-approval"],
+      meta: {
+        interaction: {
+          label: "Approve this order, or reject it with a reason.",
+          events: {
+            APPROVE: { label: "Approve order", style: "primary" },
+            REJECT: { label: "Reject order", style: "danger" },
+          },
+          textEvent: "REJECT",
+        },
+      },
+      on: {
+        APPROVE: () => ({ target: "settled", context: { decision: "approved" as const } }),
+        REJECT: () => ({ target: "settled", context: { decision: "rejected" as const } }),
+      },
+    },
+    settled: {
+      type: "final",
+      output: ({ context }) => ({
+        orderId: context.orderId,
+        approved: context.decision === "approved",
+        amountCents: context.amountCents,
+        currency: context.currency,
+        riskLevel: context.riskLevel,
+      }),
+    },
+  },
+});
+
+// ─── the migration ───
+
+/** The v1 context shape, as it appears inside a persisted v1 snapshot. */
+interface V1Context {
+  orderId: string;
+  total: number;
+  decision: "pending" | "approved" | "rejected";
+}
+
+/**
+ * v1 snapshot → v2 snapshot. Pure: it reads the old shape and returns the new
+ * one, touching nothing else on the snapshot. Two edits, mirroring the two
+ * things v2 changed:
+ *
+ *   1. `value: 'reviewing'` → `'awaitingApproval'` (the renamed state).
+ *   2. `total` (dollars) → `amountCents` (integer cents), plus the new
+ *      `currency` and derived `riskLevel` fields.
+ *
+ * Passed as `runAgent({ migrateSnapshot })`, it runs *instead of*
+ * `onVersionMismatch` and its return value is the snapshot the run resumes
+ * from.
+ */
+export function migrateOrderSnapshot(snapshot: Snapshot<unknown>): Snapshot<unknown> {
+  const old = snapshot as Snapshot<unknown> & { value?: unknown; context?: V1Context };
+  const context = old.context;
+  if (!context) {
+    return snapshot;
+  }
+  const amountCents = Math.round(context.total * 100);
+  return {
+    ...old,
+    value: old.value === "reviewing" ? "awaitingApproval" : old.value,
+    context: {
+      orderId: context.orderId,
+      amountCents,
+      currency: "USD",
+      riskLevel: amountCents >= HIGH_RISK_CENTS ? "high" : "low",
+      decision: context.decision,
+    },
+  } as unknown as Snapshot<unknown>;
+}
+
+// ─── the three acts ───
+
+export interface SnapshotMigrationResult {
+  /** The persisted (JSON-round-tripped) v1 idle snapshot. */
+  persisted: unknown;
+  /** The version stamped on that snapshot's `agentMeta`. */
+  stampedVersion: string | undefined;
+  /** The error v2 threw when handed the v1 snapshot with the default `'throw'`. */
+  mismatch: AgentSnapshotVersionMismatchError;
+  /** The `{ from, to }` pair `migrateSnapshot` was called with. */
+  migrationInfo: { from: string; to: string } | undefined;
+  /** v2's output after the migrated snapshot resumed and was approved. */
+  output: {
+    orderId: string;
+    approved: boolean;
+    amountCents: number;
+    currency: string;
+    riskLevel: "low" | "high";
+  };
+}
+
+/**
+ * Runs the whole story: v1 pauses and is persisted, v2 refuses the stale
+ * snapshot, then v2 accepts it through `migrateSnapshot` and runs to done.
+ */
+export async function runSnapshotMigrationExample(
+  input: { orderId?: string; total?: number } = {},
+): Promise<SnapshotMigrationResult> {
+  const { orderId = "ORD-4417", total = 812.5 } = input;
+
+  // Act 1 — v1 runs to its idle gate and the snapshot is persisted as JSON.
+  const paused = await runAgent(orderApprovalMachineV1, {
+    input: { orderId, total },
+    machineVersion: V1,
+  });
+  if (paused.status !== "idle") {
+    throw new Error(`Expected v1 to settle idle, got '${paused.status}'.`);
+  }
+  const persisted = persistSnapshot(paused.snapshot);
+  const stampedVersion = (persisted as { agentMeta?: { version?: string } }).agentMeta?.version;
+
+  // Act 2 — v2 refuses it. The default `onVersionMismatch: 'throw'` is what
+  // stands between a shipped rename and a silently corrupt resume.
+  let mismatch: AgentSnapshotVersionMismatchError | undefined;
+  try {
+    await runAgent(orderApprovalMachine, {
+      snapshot: persisted as never,
+      event: { type: "APPROVE" },
+      machineVersion: V2,
+    });
+  } catch (error) {
+    if (!(error instanceof AgentSnapshotVersionMismatchError)) {
+      throw error;
+    }
+    mismatch = error;
+  }
+  if (!mismatch) {
+    throw new Error("Expected v2 to reject the v1 snapshot.");
+  }
+
+  // Act 3 — the same snapshot, adapted at the boundary, resumes and completes.
+  let migrationInfo: { from: string; to: string } | undefined;
+  const resumed = await runAgent(orderApprovalMachine, {
+    snapshot: persisted as never,
+    event: { type: "APPROVE" },
+    machineVersion: V2,
+    migrateSnapshot: (snapshot, info) => {
+      migrationInfo = info;
+      return migrateOrderSnapshot(snapshot);
+    },
+  });
+  if (resumed.status !== "done") {
+    throw new Error(`Expected v2 to finish after migrating, got '${resumed.status}'.`);
+  }
+
+  return { persisted, stampedVersion, mismatch, migrationInfo, output: resumed.output };
+}
+
+/** Narrated walkthrough of the three acts. Keyless. */
+export async function main(): Promise<void> {
+  const orderId = "ORD-4417";
+  const total = 812.5;
+
+  console.log("Act 1 — v1 pauses for a human and the snapshot is persisted");
+  const paused = await runAgent(orderApprovalMachineV1, {
+    input: { orderId, total },
+    machineVersion: V1,
+  });
+  if (paused.status !== "idle") {
+    throw new Error(`Expected v1 to settle idle, got '${paused.status}'.`);
+  }
+  const persisted = persistSnapshot(paused.snapshot);
+  const meta = (persisted as { agentMeta?: { version?: string } }).agentMeta;
+  console.log(`  state:   ${JSON.stringify((persisted as { value?: unknown }).value)}`);
+  console.log(`  context: ${JSON.stringify((persisted as { context?: unknown }).context)}`);
+  console.log(`  stamped: agentMeta.version = ${JSON.stringify(meta?.version)}`);
+
+  console.log("\nAct 2 — v2 shipped; resuming the v1 snapshot throws by default");
+  try {
+    await runAgent(orderApprovalMachine, {
+      snapshot: persisted as never,
+      event: { type: "APPROVE" },
+      machineVersion: V2,
+      onVersionMismatch: "throw", // the default, spelled out
+    });
+    console.log("  (unreachable — the stale snapshot was accepted)");
+  } catch (error) {
+    if (!(error instanceof AgentSnapshotVersionMismatchError)) {
+      throw error;
+    }
+    console.log(`  ${error.name}: from '${error.from}' to '${error.to}'`);
+    console.log(`  machineId: ${error.machineId}`);
+  }
+
+  console.log("\nAct 3 — migrateSnapshot adapts it at the boundary, and the run completes");
+  const resumed = await runAgent(orderApprovalMachine, {
+    snapshot: persisted as never,
+    event: { type: "APPROVE" },
+    machineVersion: V2,
+    migrateSnapshot: (snapshot, info) => {
+      const migrated = migrateOrderSnapshot(snapshot);
+      console.log(`  migrating '${info.from}' → '${info.to}'`);
+      console.log(`  before: ${JSON.stringify((snapshot as { context?: unknown }).context)}`);
+      console.log(`  after:  ${JSON.stringify((migrated as { context?: unknown }).context)}`);
+      return migrated;
+    },
+  });
+  if (resumed.status !== "done") {
+    throw new Error(`Expected v2 to finish after migrating, got '${resumed.status}'.`);
+  }
+  console.log(`  output: ${JSON.stringify(resumed.output)}`);
+
+  console.log("\nThe rename was survivable because the snapshot knew which machine wrote it.");
+}
+
+// Run directly (`tsx index.ts`); skipped when a test imports this module.
+if (import.meta.url === new URL(process.argv[1]!, "file:").href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/examples/snapshot-migration/metadata.json
+++ b/examples/snapshot-migration/metadata.json
@@ -1,0 +1,25 @@
+{
+  "name": "snapshot-migration",
+  "title": "Resume a run after shipping a new machine",
+  "kind": "pattern",
+  "machine": "orderApprovalMachine",
+  "origin": {
+    "type": "stately-agent",
+    "source": "Versioned snapshots: machineVersion stamping, onVersionMismatch, and migrateSnapshot across two versions of one order-approval machine",
+    "url": null
+  },
+  "comparison": {
+    "targets": ["LangGraph checkpointer"],
+    "purpose": "A snapshot carries the version of the machine that wrote it, so a paused run resumed on a redeployed machine either throws with from/to or passes through an explicit migrateSnapshot, instead of silently restoring stale state."
+  },
+  "starters": [
+    {
+      "label": "Small order ($25.00)",
+      "input": { "orderId": "ORD-2", "amountCents": 2500, "currency": "USD" }
+    },
+    {
+      "label": "High-risk order ($812.50)",
+      "input": { "orderId": "ORD-4417", "amountCents": 81250, "currency": "USD" }
+    }
+  ]
+}

--- a/examples/snapshot-migration/metadata.json
+++ b/examples/snapshot-migration/metadata.json
@@ -5,7 +5,7 @@
   "machine": "orderApprovalMachine",
   "origin": {
     "type": "stately-agent",
-    "source": "Versioned snapshots: machineVersion stamping, onVersionMismatch, and migrateSnapshot across two versions of one order-approval machine",
+    "source": "Versioned snapshots: machine `version` stamping, onVersionMismatch, and migrateSnapshot across two versions of one order-approval machine",
     "url": null
   },
   "comparison": {

--- a/examples/verification/index.test.ts
+++ b/examples/verification/index.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "vitest";
+import {
+  canReach,
+  explorePaths,
+  lintAgentMachine,
+  matchesTrajectory,
+  runAgent,
+  simulateAgent,
+} from "@statelyai/agent";
+import type { AgentDecisionRequest, ChosenEvent } from "@statelyai/agent";
+import { APPROVAL_THRESHOLD, refundMachine } from "./index.js";
+
+const LARGE = { amount: 500, reason: "Duplicate annual charge" };
+const SMALL = { amount: 40, reason: "Late delivery credit" };
+
+/** A decide executor that plays a fixed script of event types in order. */
+function scriptedDecide(script: string[]) {
+  let i = 0;
+  return async (_request: AgentDecisionRequest): Promise<{ event: ChosenEvent }> => {
+    const type = script[i++] ?? "REFUSE";
+    return { event: { type, reasoning: `scripted ${type}` } };
+  };
+}
+
+describe("verification", () => {
+  test("lint is clean", () => {
+    expect(lintAgentMachine(refundMachine)).toEqual([]);
+  });
+
+  test("canReach proves the violation state unreachable at any amount", async () => {
+    for (const input of [LARGE, SMALL, { amount: APPROVAL_THRESHOLD, reason: "at the limit" }]) {
+      const result = await canReach(refundMachine, "illegallyIssued", { input });
+      expect(result.reachable, `illegallyIssued reachable at $${input.amount}`).toBe(false);
+      expect(result.witness).toBeUndefined();
+    }
+  });
+
+  test("canReach proves 'issued' reachable, and only via the human gate when large", async () => {
+    const large = await canReach(refundMachine, "issued", { input: LARGE });
+    expect(large.reachable).toBe(true);
+    // The only route to a $500 payout runs through approving.
+    expect(large.witness?.map((event) => event.type)).toEqual(["ESCALATE", "APPROVE"]);
+
+    const small = await canReach(refundMachine, "issued", { input: SMALL });
+    expect(small.reachable).toBe(true);
+    expect(small.witness?.map((event) => event.type)).toEqual(["ISSUE"]);
+  });
+
+  test("the violation stated as a snapshot predicate needs no sentinel state", async () => {
+    type Ctx = { amount: number; approved: boolean };
+    const violation = await canReach(
+      refundMachine,
+      (snapshot) =>
+        snapshot.matches("issued") &&
+        (snapshot.context as Ctx).amount > APPROVAL_THRESHOLD &&
+        !(snapshot.context as Ctx).approved,
+      { input: LARGE },
+    );
+    expect(violation.reachable).toBe(false);
+
+    // The predicate's legal counterpart: issued WITH approval on record.
+    const legal = await canReach(
+      refundMachine,
+      (snapshot) => snapshot.matches("issued") && (snapshot.context as Ctx).approved,
+      { input: LARGE },
+    );
+    expect(legal.reachable).toBe(true);
+    expect(legal.witness?.map((event) => event.type)).toEqual(["ESCALATE", "APPROVE"]);
+  });
+
+  test("explorePaths prunes the guarded ISSUE above the threshold, not below", async () => {
+    const large = await explorePaths(refundMachine, { input: LARGE });
+    expect(large.prunedByGuard).toBe(1);
+    expect(large.terminals.every((terminal) => terminal.status === "done")).toBe(true);
+    expect(large.terminals.map((terminal) => terminal.state).sort()).toEqual([
+      "issued",
+      "refused",
+      "rejected",
+    ]);
+    // No path anywhere in the enumeration lands on the violation state.
+    expect(large.reachedStates).not.toContain("illegallyIssued");
+
+    const small = await explorePaths(refundMachine, { input: SMALL });
+    expect(small.prunedByGuard).toBe(0);
+    expect(small.terminals.filter((terminal) => terminal.state === "issued")).toHaveLength(2);
+  });
+
+  test("simulateAgent: an adversarial ISSUE exhausts into refused, the same choice passes below the limit", async () => {
+    const script = { decisions: { "agent.decide": [{ type: "ISSUE", reasoning: "pay it" }] } };
+
+    const adversarial = await simulateAgent(refundMachine, { input: LARGE, script });
+    // The guard rejects ISSUE; the queue is retried like a live run re-asks
+    // the model, exhausts, and the error routes via onError to `refused`.
+    expect(adversarial.status).toBe("done");
+    expect(adversarial.snapshot.value).toBe("refused");
+    expect(adversarial.trail.map((entry) => entry.state)).toEqual(["classifying", "refused"]);
+    expect(adversarial.trail.at(-1)?.rejectedEvents).toEqual([
+      { type: "ISSUE", reasoning: "pay it" },
+    ]);
+
+    const legal = await simulateAgent(refundMachine, { input: SMALL, script });
+    expect(legal.status).toBe("done");
+    expect(legal.snapshot.value).toBe("issued");
+  });
+
+  test("simulateAgent: scripted external APPROVE crosses the human gate to issued", async () => {
+    const result = await simulateAgent(refundMachine, {
+      input: LARGE,
+      script: {
+        decisions: { "agent.decide": [{ type: "ESCALATE", reasoning: "over the limit" }] },
+        events: [{ type: "APPROVE", approver: "ops" }],
+      },
+    });
+
+    expect(result.status).toBe("done");
+    expect(result.snapshot.value).toBe("issued");
+    expect(result.snapshot.context.approved).toBe(true);
+    expect(result.trail.map((entry) => entry.state)).toEqual([
+      "classifying",
+      "approving",
+      "issued",
+    ]);
+    expect(result.trail.at(-1)).toEqual(
+      expect.objectContaining({
+        appliedEvent: expect.objectContaining({ type: "APPROVE" }),
+        external: true,
+      }),
+    );
+  });
+
+  test("a live run rejects the adversarial choice by guard and still completes legally", async () => {
+    const requests: AgentDecisionRequest[] = [];
+    const decide = async (request: AgentDecisionRequest): Promise<{ event: ChosenEvent }> => {
+      requests.push(request);
+      // First attempt cheats; the retry escalates.
+      const type = requests.length === 1 ? "ISSUE" : "ESCALATE";
+      return { event: { type, reasoning: `scripted ${type}` } };
+    };
+
+    const idle = await runAgent(refundMachine, { input: LARGE, executors: { decide } });
+    expect(idle.status).toBe("idle");
+    if (idle.status !== "idle") throw new Error("expected idle");
+    expect(idle.snapshot.value).toBe("approving");
+    expect(requests[1]!.attempts.at(-1)!.failure).toBe("rejected-by-guard");
+
+    // The human approves; only now can the payout happen.
+    const done = await runAgent(refundMachine, {
+      snapshot: idle.snapshot,
+      event: { type: "APPROVE", approver: "ops" },
+      executors: { decide },
+    });
+    expect(done.status).toBe("done");
+    if (done.status !== "done") throw new Error("expected done");
+    expect(done.output.outcome).toBe("issued");
+    expect(done.output.approved).toBe(true);
+  });
+
+  test("a small refund runs straight through without a human", async () => {
+    const result = await runAgent(refundMachine, {
+      input: SMALL,
+      executors: { decide: scriptedDecide(["ISSUE"]) },
+    });
+    expect(result.status).toBe("done");
+    if (result.status !== "done") throw new Error("expected done");
+    expect(result.output.outcome).toBe("issued");
+    expect(result.output.approved).toBe(false);
+  });
+
+  test("matchesTrajectory scores the simulated state paths, hit and miss", async () => {
+    const script = { decisions: { "agent.decide": [{ type: "ISSUE", reasoning: "pay it" }] } };
+    const legal = await simulateAgent(refundMachine, { input: SMALL, script });
+    const adversarial = await simulateAgent(refundMachine, { input: LARGE, script });
+
+    // The trail already begins with the initial state — a complete state path.
+    const pathOf = (result: { trail: { state: unknown }[] }) =>
+      result.trail.map((entry) => entry.state);
+
+    const hit = matchesTrajectory(pathOf(legal), ["classifying", "issued"]);
+    expect(hit.matched).toBe(true);
+    expect(hit.score).toBe(1);
+
+    const miss = matchesTrajectory(pathOf(adversarial), ["classifying", "issued"]);
+    expect(miss.matched).toBe(false);
+    expect(miss.firstMiss?.index).toBe(1);
+    expect(miss.firstMiss?.expected).toBe("issued");
+  });
+});

--- a/examples/verification/index.ts
+++ b/examples/verification/index.ts
@@ -106,7 +106,7 @@ const agentSetup = setupAgent({
   models,
   // The gate is an idle state: runAgent settles `idle` there and waits for a
   // human event rather than hanging.
-  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+  isIdle: (snapshot) => snapshot.hasTag("awaiting-approval"),
 });
 
 const CLASSIFY_SYSTEM_PROMPT =

--- a/examples/verification/index.ts
+++ b/examples/verification/index.ts
@@ -1,0 +1,399 @@
+/**
+ * Verification — proving that invalid agent actions are impossible.
+ *
+ * A refund-approval agent with one business rule: a refund over $100 can never
+ * be issued without passing through an explicit human `approving` gate. Prompts
+ * cannot promise that; a guard can, and the verification suite proves it
+ * without a single model call.
+ *
+ * Demonstrates the whole keyless suite over one small machine:
+ *   - `lintAgentMachine` — static structural checks (dead states, decisions
+ *     whose chosen event can never be delivered, output-contract gaps).
+ *   - `canReach` — the reachability argument, both directions: `issued` IS
+ *     reachable (with a witness path), and the violation sentinel
+ *     `illegallyIssued` is NOT, for any amount. The same violation is also
+ *     checked as a snapshot predicate — no sentinel state required.
+ *   - `explorePaths` — every decision and human branch enumerated to a bounded
+ *     depth, with guard-rejected candidates counted rather than walked.
+ *   - `simulateAgent` — scripted playthroughs with live-run parity: an
+ *     adversarial "model" that insists on issuing a $500 refund outright has
+ *     its guard-rejected decision retried and exhausted, landing in `refused`
+ *     through the invoke's `onError` — exactly as a live run would. A second
+ *     script escalates and then crosses the human gate with an external
+ *     APPROVE event from the script's `events` queue.
+ *   - `matchesTrajectory` — the simulated state path scored against an expected
+ *     one, hit and miss.
+ *
+ * The violation is encoded as a state, not a runtime assertion: `issuing` has
+ * an `always` monitor that targets `illegallyIssued` whenever it is entered
+ * over the threshold without approval. `canReach` proving that state
+ * unreachable IS the safety proof. (Static lint cannot make this call — the
+ * monitor is a dynamic transition, so lint conservatively treats the sentinel
+ * as reachable. Semantic exploration is what settles it.)
+ *
+ * No API key needed: nothing here calls a model. Run:
+ * npx tsx examples/verification/index.ts
+ */
+import { z } from "zod";
+import { openai } from "@ai-sdk/openai";
+import {
+  canReach,
+  createAgentSchemas,
+  explorePaths,
+  lintAgentMachine,
+  matchesTrajectory,
+  setupAgent,
+  simulateAgent,
+  type AgentPathReport,
+  type SimulateAgentResult,
+} from "@statelyai/agent";
+import { defineModels } from "@statelyai/agent/ai-sdk";
+
+// Declared so the machine is playable against a real model; the report below
+// never calls it.
+const models = defineModels({
+  reviewer: openai("gpt-5.4-mini"),
+});
+
+/** The business rule, in one number. Refunds above this need a human. */
+export const APPROVAL_THRESHOLD = 100;
+
+export const verificationSchemas = createAgentSchemas({
+  context: z.object({
+    amount: z.number(),
+    reason: z.string(),
+    // Set only by the human gate's APPROVE. Nothing else can write it.
+    approved: z.boolean(),
+  }),
+  input: z.object({
+    amount: z.number(),
+    reason: z.string().default("Duplicate charge"),
+  }),
+  output: z.object({
+    outcome: z.enum(["issued", "refused", "rejected", "illegal"]),
+    amount: z.number(),
+    approved: z.boolean(),
+    summary: z.string(),
+  }),
+  meta: z.object({
+    interaction: z
+      .object({
+        label: z.string(),
+        events: z
+          .record(
+            z.string(),
+            z.object({
+              label: z.string().optional(),
+              style: z.enum(["primary", "danger", "default"]).optional(),
+            }),
+          )
+          .optional(),
+        textEvent: z.string().optional(),
+      })
+      .optional(),
+  }),
+  events: {
+    ISSUE: z.object({ reasoning: z.string() }),
+    ESCALATE: z.object({ reasoning: z.string() }),
+    REFUSE: z.object({ reasoning: z.string() }),
+    APPROVE: z.object({ approver: z.string().default("ops") }),
+    REJECT: z.object({ reason: z.string().default("Not eligible") }),
+  },
+});
+
+const agentSetup = setupAgent({
+  schemas: verificationSchemas,
+  models,
+  // The gate is an idle state: runAgent settles `idle` there and waits for a
+  // human event rather than hanging.
+  isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+});
+
+const CLASSIFY_SYSTEM_PROMPT =
+  "You triage refund requests. Choose exactly one event: ISSUE to pay it out, " +
+  "ESCALATE to send it to a human approver, or REFUSE to decline it.";
+
+export const refundMachine = agentSetup.createMachine({
+  id: "refund-approval",
+  context: ({ input }) => ({
+    amount: input.amount,
+    reason: input.reason,
+    approved: false,
+  }),
+  initial: "classifying",
+  states: {
+    classifying: {
+      invoke: {
+        src: "agent.decide",
+        input: ({ context }) => ({
+          model: "reviewer",
+          system: CLASSIFY_SYSTEM_PROMPT,
+          prompt:
+            `Refund request: ${context.reason}\nAmount: $${context.amount}\n` +
+            `Refunds over $${APPROVAL_THRESHOLD} require human approval.`,
+          allowedEvents: ["ISSUE", "ESCALATE", "REFUSE"],
+          maxRetries: 3,
+        }),
+        onError: { target: "refused" },
+      },
+      on: {
+        // The rule, as a v6 function transition: over the threshold without an
+        // approval on record, ISSUE returns `undefined` and is not a legal
+        // transition at all. `resolveDecision` rejects the choice
+        // (`failure: 'rejected-by-guard'`) and asks again; `explorePaths`
+        // counts it in `prunedByGuard` instead of walking it.
+        ISSUE: ({ context }) =>
+          context.amount > APPROVAL_THRESHOLD && !context.approved
+            ? undefined
+            : { target: "issuing" },
+        ESCALATE: { target: "approving" },
+        REFUSE: { target: "refused" },
+      },
+    },
+    // Idle human gate. No invoke, so the run settles here; `meta.interaction`
+    // tells a host what to render.
+    approving: {
+      tags: ["awaiting-approval"],
+      meta: {
+        interaction: {
+          label: "This refund is over the auto-issue limit. Approve or reject it.",
+          events: {
+            APPROVE: { label: "Approve refund", style: "primary" },
+            REJECT: { label: "Reject refund", style: "danger" },
+          },
+          textEvent: "REJECT",
+        },
+      },
+      on: {
+        // The only writer of `approved`.
+        APPROVE: () => ({ target: "issuing", context: { approved: true } }),
+        REJECT: { target: "rejected" },
+      },
+    },
+    // The monitor. Every route into payout passes through here, so the
+    // invariant is checked in one place: entering over the threshold without
+    // approval means the guard leaked, and the run lands in a state that exists
+    // only to be proven unreachable.
+    issuing: {
+      always: ({ context }: { context: { amount: number; approved: boolean } }) =>
+        context.amount > APPROVAL_THRESHOLD && !context.approved
+          ? { target: "illegallyIssued" }
+          : { target: "issued" },
+    },
+    issued: {
+      type: "final",
+      output: ({ context }) => ({
+        outcome: "issued" as const,
+        amount: context.amount,
+        approved: context.approved,
+        summary: context.approved
+          ? `Issued $${context.amount} after human approval.`
+          : `Issued $${context.amount} automatically (at or under the $${APPROVAL_THRESHOLD} limit).`,
+      }),
+    },
+    refused: {
+      type: "final",
+      output: ({ context }) => ({
+        outcome: "refused" as const,
+        amount: context.amount,
+        approved: context.approved,
+        summary: `Declined the $${context.amount} refund.`,
+      }),
+    },
+    rejected: {
+      type: "final",
+      output: ({ context }) => ({
+        outcome: "rejected" as const,
+        amount: context.amount,
+        approved: context.approved,
+        summary: `A human rejected the $${context.amount} refund.`,
+      }),
+    },
+    // Unreachable by construction; `canReach` is what turns "by construction"
+    // into a checked claim.
+    illegallyIssued: {
+      type: "final",
+      output: ({ context }) => ({
+        outcome: "illegal" as const,
+        amount: context.amount,
+        approved: context.approved,
+        summary: `INVARIANT VIOLATED: issued $${context.amount} without approval.`,
+      }),
+    },
+  },
+});
+
+// ─── The verification report ───
+
+const LARGE = { amount: 500, reason: "Duplicate annual charge" };
+const SMALL = { amount: 40, reason: "Late delivery credit" };
+
+const check = (ok: boolean) => (ok ? "✓" : "✗");
+
+function section(title: string): void {
+  console.log(`\n${title}\n${"─".repeat(title.length)}`);
+}
+
+/** `[ISSUE → ESCALATE]`, or `(none)` for an empty witness. */
+function formatPath(events: readonly { type: string }[]): string {
+  return events.length === 0 ? "(none)" : `[${events.map((event) => event.type).join(" → ")}]`;
+}
+
+/** `done issued ×2` per distinct terminal, sorted for a stable report. */
+function summarizeTerminals(report: AgentPathReport): string[] {
+  const counts = new Map<string, number>();
+  for (const terminal of report.terminals) {
+    const key = `${terminal.status} ${JSON.stringify(terminal.state)}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort().map(([key, count]) => `${key} ×${count}`);
+}
+
+/** One labelled playthrough: status, resting state, then event → state per step. */
+function printTrail(label: string, result: SimulateAgentResult): void {
+  console.log(`${label}: ${result.status} at ${JSON.stringify(result.snapshot.value)}`);
+  for (const entry of result.trail) {
+    const applied = entry.appliedEvent
+      ? `${entry.appliedEvent.type}${entry.external ? " (external)" : ""} → `
+      : "";
+    const rejected = entry.rejectedEvents?.length
+      ? ` [rejected: ${entry.rejectedEvents.map((event) => event.type).join(", ")}]`
+      : "";
+    console.log(`  ${applied}${JSON.stringify(entry.state)}${rejected}`);
+  }
+}
+
+export async function main() {
+  console.log(`Verification report — ${refundMachine.id}`);
+  console.log(`Rule: a refund over $${APPROVAL_THRESHOLD} may not be issued without approval.`);
+
+  // 1. Lint — static structure, no execution.
+  section("1. Lint");
+  const diagnostics = lintAgentMachine(refundMachine);
+  const errors = diagnostics.filter((diagnostic) => diagnostic.severity === "error");
+  console.log(
+    `${check(errors.length === 0)} ${diagnostics.length} diagnostic(s), ${errors.length} error(s)`,
+  );
+  for (const diagnostic of diagnostics) {
+    console.log(`  ${diagnostic.severity}  ${diagnostic.code}  ${diagnostic.path}`);
+  }
+  // A finding reads like:
+  //   error  decide-without-events  classifying
+  //   State 'classifying' invokes decision source 'agent.decide', but neither
+  //   it nor any ancestor handles any event (no 'on:') ...
+  console.log("  (lint is structural: it cannot decide the $100 rule — that is step 2)");
+
+  // 2. Reachability — the safety argument, both directions.
+  section("2. Reachability");
+  const goodPath = await canReach(refundMachine, "issued", { input: LARGE });
+  console.log(
+    `${check(goodPath.reachable)} 'issued' IS reachable at $${LARGE.amount}: ${formatPath(goodPath.witness ?? [])}`,
+  );
+
+  // The violation is a state (`issuing`'s always-monitor targets it), so
+  // "cannot happen" is a reachability query rather than a runtime assertion.
+  for (const input of [LARGE, SMALL]) {
+    const violation = await canReach(refundMachine, "illegallyIssued", { input });
+    console.log(
+      `${check(!violation.reachable)} 'illegallyIssued' is UNREACHABLE at $${input.amount}` +
+        (violation.reachable ? ` — witness ${formatPath(violation.witness ?? [])}` : ""),
+    );
+  }
+
+  // The sentinel state is optional: the same violation stated as a snapshot
+  // predicate — "issued, over the threshold, without approval" — needs no
+  // extra state in the machine at all.
+  const predicateViolation = await canReach(
+    refundMachine,
+    (snapshot) =>
+      snapshot.matches("issued") &&
+      (snapshot.context as { amount: number; approved: boolean }).amount > APPROVAL_THRESHOLD &&
+      !(snapshot.context as { amount: number; approved: boolean }).approved,
+    { input: LARGE },
+  );
+  console.log(
+    `${check(!predicateViolation.reachable)} the same violation, as a snapshot predicate: UNREACHABLE`,
+  );
+
+  // 3. Path enumeration — every branch, terminal by terminal.
+  section("3. Paths");
+  for (const input of [LARGE, SMALL]) {
+    const report = await explorePaths(refundMachine, { input });
+    console.log(
+      `$${input.amount}: ${report.pathsExplored} path(s), ${report.prunedByGuard} pruned by guard`,
+    );
+    for (const line of summarizeTerminals(report)) {
+      console.log(`  ${line}`);
+    }
+    if (report.prunedByGuard > 0) {
+      console.log("  (the pruned branch is ISSUE — the guard, counted not walked)");
+    }
+  }
+
+  // 4. Scripted simulations — the same ISSUE choice, above and below the line.
+  section("4. Simulation");
+  // Adversarial: a "model" that goes straight for a $500 payout. The guard
+  // makes ISSUE an illegal transition, so simulateAgent retries the decision
+  // exactly as a live run re-asks the model; a queue that only ever says ISSUE
+  // exhausts the attempt budget, and the exhaustion error routes through the
+  // invoke's `onError` to `refused` — which is the point: it never touches
+  // `issuing`.
+  const adversarial = await simulateAgent(refundMachine, {
+    input: LARGE,
+    script: { decisions: { "agent.decide": [{ type: "ISSUE", reasoning: "just pay it" }] } },
+  });
+  printTrail(`adversarial ($${LARGE.amount})`, adversarial);
+  const blocked = adversarial.status === "done" && adversarial.snapshot.matches("refused");
+  console.log(`${check(blocked)} ISSUE was rejected until exhaustion: refused, no payout`);
+
+  // Legal: the identical script under the threshold runs clean to `issued`.
+  const legal = await simulateAgent(refundMachine, {
+    input: SMALL,
+    script: { decisions: { "agent.decide": [{ type: "ISSUE", reasoning: "small, auto-issue" }] } },
+  });
+  printTrail(`legal ($${SMALL.amount})`, legal);
+  console.log(
+    `${check(legal.status === "done" && legal.snapshot.matches("issued"))} the same choice is allowed below the limit`,
+  );
+
+  // The legitimate large-refund route: ESCALATE, then the human gate crossed
+  // by an external APPROVE from the script's `events` queue — a simulation of
+  // what a live host does with `actor.send(...)`.
+  const escalated = await simulateAgent(refundMachine, {
+    input: LARGE,
+    script: {
+      decisions: { "agent.decide": [{ type: "ESCALATE", reasoning: "over the limit" }] },
+      events: [{ type: "APPROVE", approver: "ops" }],
+    },
+  });
+  printTrail(`escalated ($${LARGE.amount})`, escalated);
+  console.log(
+    `${check(escalated.status === "done" && escalated.snapshot.matches("issued"))} the human gate, crossed in simulation`,
+  );
+
+  // 5. Trajectory matching — score the runs' state paths. The trail begins
+  // with the initial state, so it is a complete state path as-is.
+  section("5. Trajectory");
+  const legalPath = legal.trail.map((entry) => entry.state);
+  const hit = matchesTrajectory(legalPath, ["classifying", "issued"]);
+  console.log(
+    `${check(hit.matched)} legal run matches ['classifying', 'issued'] (score ${hit.score})`,
+  );
+  const adversarialPath = adversarial.trail.map((entry) => entry.state);
+  const miss = matchesTrajectory(adversarialPath, ["classifying", "issued"]);
+  console.log(
+    `${check(!miss.matched)} adversarial run does NOT match ['classifying', 'issued'] — ` +
+      `first miss at index ${miss.firstMiss?.index} (score ${miss.score.toFixed(2)})`,
+  );
+
+  console.log("\nInvalid actions are not discouraged here; they are unreachable.");
+}
+
+// Run directly (`tsx index.ts`); skipped when a test imports this module. No
+// API-key check: the whole report is keyless and offline.
+if (import.meta.url === new URL(process.argv[1]!, "file:").href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/examples/verification/metadata.json
+++ b/examples/verification/metadata.json
@@ -1,0 +1,28 @@
+{
+  "name": "verification",
+  "title": "Verified agent machine",
+  "kind": "evaluation",
+  "origin": {
+    "type": "stately-agent",
+    "source": "Flagship showcase for the keyless verification suite (lintAgentMachine, canReach, explorePaths, simulateAgent, matchesTrajectory) over a refund-approval machine",
+    "url": null
+  },
+  "comparison": {
+    "targets": ["LangGraph", "Burr", "prompt-level guardrails"],
+    "purpose": "A prompt can ask a model not to issue a large refund without approval; a guard makes it an illegal transition, and canReach proves the violation state unreachable across every branch without one model call."
+  },
+  "starters": [
+    {
+      "label": "Small refund ($40)",
+      "input": { "amount": 40, "reason": "Late delivery credit" }
+    },
+    {
+      "label": "Large refund ($500)",
+      "input": { "amount": 500, "reason": "Duplicate annual charge" }
+    },
+    {
+      "label": "Right at the limit ($100)",
+      "input": { "amount": 100, "reason": "Damaged item" }
+    }
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,14 @@ export type {
   TrajectoryMiss,
 } from "./trajectory.js";
 export { runSeam } from "./seam.js";
-export type { RunSeamOptions, RunSeamResult, SeamRef, SeamSlice, SeamTurn } from "./seam.js";
+export type {
+  RunSeamOptions,
+  RunSeamResult,
+  SeamCall,
+  SeamRef,
+  SeamSlice,
+  SeamTurn,
+} from "./seam.js";
 export { createScriptedExecutors } from "./scripted-executors.js";
 export type {
   ScriptedDecisionEntry,

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ export { provideExecutors } from "./provide-executors.js";
 export type { ProvideExecutorsOptions } from "./provide-executors.js";
 export {
   AgentLintError,
+  assertAgentMachine,
   canReach,
   explorePaths,
   lintAgentMachine,
@@ -112,6 +113,7 @@ export type {
   AgentLintSeverity,
   AgentPathReport,
   AgentPathTerminal,
+  AssertAgentMachineOptions,
   CanReachResult,
   ExplorePathsOptions,
   LintAgentMachineOptions,

--- a/src/run-agent.ts
+++ b/src/run-agent.ts
@@ -42,9 +42,11 @@ export type { AgentStateRequest } from "./internal/state-request-pass.js";
 import { getAcceptedEvents, type AgentSchemas } from "./events.js";
 import {
   AGENT_USAGE_TOKEN_FIELDS,
+  GENERATE_TEXT_ACTOR,
   getCallUsage,
   isTextLogic,
   normalizeGeneratorResult,
+  STREAM_TEXT_ACTOR,
   USER_INPUT_ACTOR,
   type AgentCallUsage,
   type AgentUsage,
@@ -1384,9 +1386,22 @@ function invokingActorOf(
  * identical event shapes by construction. @internal
  */
 function bindTextLogic(logic: TextLogic, runCtx: RunAgentBindContext): TextLogic {
-  return logic.withExecutor(async ({ request, self: selfArg, signal }) => {
+  return logic.withExecutor(async ({ request: rawRequest, self: selfArg, signal }) => {
     const self = selfArg as BoundActorSelf | undefined;
     const { id, src } = selfIdAndSrc(self);
+    // A request authored with no `name` (bare `createTextLogic({ model })`)
+    // takes its `actors:` registration key: the invoke `src` IS the
+    // developer-facing handle, so name-addressed surfaces (runSeam's
+    // `{ request }`, script routing, host mocks) work without a `name` in the
+    // config. The `agent.*` builtins keep their documented nameless requests —
+    // their `src` is the builtin id, not a handle the author chose.
+    const request: AgentTextRequest =
+      rawRequest.name === undefined &&
+      src !== "" &&
+      src !== GENERATE_TEXT_ACTOR &&
+      src !== STREAM_TEXT_ACTOR
+        ? { ...rawRequest, name: src }
+        : rawRequest;
     const executor = logic.mode === "stream" ? runCtx.streamText : runCtx.generateText;
     if (!executor) {
       throw new Error(

--- a/src/seam.ts
+++ b/src/seam.ts
@@ -28,14 +28,16 @@ import type {
 } from "xstate";
 import { AgentError } from "./errors.js";
 import type { AgentLogEntry } from "./event-log-store.js";
-import { normalizeGeneratorResult } from "./text-logic.js";
+import { getCallUsage, normalizeGeneratorResult } from "./text-logic.js";
 import { runAgent } from "./run-agent.js";
 import type { RunAgentOptions, RunAgentResult } from "./run-agent.js";
 import { isRecord } from "./internal/is-record.js";
 import { describeText, emitScriptedChunk, resolveScriptedTextEntry } from "./scripted-executors.js";
 import type { ScriptedTextEntry } from "./scripted-executors.js";
 import type {
+  AgentCallUsage,
   AgentExecutorTextRequest,
+  AgentRequestExecutor,
   AgentRequestExecutorInfo,
   AgentRequestExecutorResult,
   AgentRequestExecutors,
@@ -79,6 +81,27 @@ export interface SeamTurn<TMachine extends AnyStateMachine> {
   result: RunAgentResult<TMachine>;
 }
 
+/**
+ * One text call in a {@link runSeam} run's ledger, in call order — the receipt
+ * that says which answers came from the script and which one came from the
+ * candidate, so "everything else stayed scripted" is a plain assertion on
+ * {@link RunSeamResult.calls} rather than a recording function wrapped around
+ * every script entry. Text calls only: `decide` and other base executors are
+ * not routed by the seam and do not appear.
+ */
+export interface SeamCall {
+  /** The request's `name`, when it has one. */
+  name?: string;
+  /** The request's model key. */
+  model: string;
+  /** The `scripts` queue key that routed this call. */
+  key: string;
+  /** Where the answer came from: the script, or the seam's `candidate`. */
+  source: "script" | "candidate";
+  /** True for the seam call itself — scripted or candidate. */
+  seam: boolean;
+}
+
 /** One side of the seam: a trajectory pair ready for `matchesTrajectory`. */
 export interface SeamSlice {
   /** State values entered on this side of the seam, in order. */
@@ -116,7 +139,7 @@ export interface RunSeamOptions<TMachine extends AnyStateMachine> {
    * request-shaped. Omit to run the seam scripted too: the whole seam run is
    * then keyless and deterministic.
    */
-  candidate?: AgentRequestExecutors["generateText"];
+  candidate?: AgentRequestExecutor;
   /**
    * The simulated user. Called at every idle pause; return the event to send,
    * or `null`/`undefined` to stop the run there. Omitted, the run stops at the
@@ -146,8 +169,17 @@ export interface RunSeamResult<TMachine extends AnyStateMachine> {
   result: RunAgentResult<TMachine>;
   /** What the seam call returned, or `undefined` when the run never reached it. */
   seamOutput: unknown;
+  /**
+   * The seam call's own reported token usage — the cost of the one live call
+   * when a `candidate` is a real model. `undefined` when the run never reached
+   * the seam or its answer reported no usage (scripted entries report usage
+   * only via the `{ output, usage }` envelope).
+   */
+  seamUsage?: AgentCallUsage;
   /** Model calls made before the seam, or `-1` when the run never reached it. */
   callsBeforeSeam: number;
+  /** The run's text calls in order: what was served, and by whom. */
+  calls: SeamCall[];
   /** Everything up to the seam's own effect completion. */
   before: SeamSlice;
   /**
@@ -158,7 +190,7 @@ export interface RunSeamResult<TMachine extends AnyStateMachine> {
 }
 
 /** Whatever a host executor may return — our envelope, or a raw AI SDK result. */
-type ExecutorReturn = Awaited<ReturnType<NonNullable<AgentRequestExecutors["generateText"]>>>;
+type ExecutorReturn = Awaited<ReturnType<AgentRequestExecutor>>;
 
 /**
  * The seam's own answer, for scoring. Our `{ output }` envelope is read
@@ -226,6 +258,8 @@ export async function runSeam<TMachine extends AnyStateMachine>(
   let calls = 0;
   let seamMatches = 0;
   let seamOutput: unknown;
+  let seamUsage: AgentCallUsage | undefined;
+  const callLog: SeamCall[] = [];
   let seamReached = false;
   let callsBeforeSeam = -1;
   let seamStateAt = 0;
@@ -275,6 +309,15 @@ export async function runSeam<TMachine extends AnyStateMachine>(
     const callIndex = calls++;
     const keyMatches = request.name === seam.request;
     const isSeam = keyMatches && seamMatches++ === (seam.occurrence ?? 0);
+    const ledger = (source: SeamCall["source"]): void => {
+      callLog.push({
+        ...(request.name !== undefined ? { name: request.name } : {}),
+        model: request.model,
+        key: queueKeyOf(request),
+        source,
+        seam: isSeam,
+      });
+    };
 
     if (isSeam && candidate) {
       // The script is the whole call plan, so the seam consumes its slot too:
@@ -288,10 +331,13 @@ export async function runSeam<TMachine extends AnyStateMachine>(
 
       const result = await candidate(request as AgentExecutorTextRequest, info);
       seamOutput = await seamOutputOf(result, request);
+      seamUsage = getCallUsage(result);
+      ledger("candidate");
       return result;
     }
 
     const scripted = await scriptedAnswer(request, info);
+    ledger("script");
     if (!isSeam) {
       return scripted;
     }
@@ -301,6 +347,7 @@ export async function runSeam<TMachine extends AnyStateMachine>(
     seamStateAt = statePath.length;
     seamEventAt = liveEvents;
     seamOutput = scripted.output;
+    seamUsage = scripted.usage;
     return scripted;
   };
 
@@ -381,7 +428,9 @@ export async function runSeam<TMachine extends AnyStateMachine>(
   return {
     result,
     seamOutput,
+    ...(seamUsage !== undefined ? { seamUsage } : {}),
     callsBeforeSeam,
+    calls: callLog,
     before: { statePath: statePath.slice(0, splitStateAt), events: events.slice(0, splitAt) },
     after: { statePath: statePath.slice(splitStateAt), events: events.slice(splitAt) },
   };

--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -780,7 +780,7 @@ describe("canReach — predicate targets", () => {
         APPROVE: z.object({}),
         REJECT: z.object({}),
       },
-      isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+      isIdle: (snapshot) => snapshot.hasTag("awaiting-approval"),
     });
     return agent.createMachine({
       context: ({ input }) => ({ amount: input.amount, approved: false }),

--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -6,13 +6,16 @@ import {
   createTextLogic,
   explorePaths,
   lintAgentMachine,
+  runAgent,
   setupAgent,
   simulateAgent,
   type AgentLintDiagnostic,
+  type ChosenEvent,
   type AgentWorkflowConfig,
   type SchemaCompiler,
   type StandardSchemaV1,
 } from "./index.js";
+import { createDecisionLogic } from "./decision.js";
 import * as examples from "../examples/index.js";
 import {
   humanInTheLoopMachine,
@@ -68,6 +71,41 @@ function createRefundMachine() {
       },
       refunded: { type: "final", output: () => ({ refunded: true }) },
       denied: { type: "final", output: () => ({ refunded: false }) },
+    },
+  });
+}
+
+// A classifier whose guarded ISSUE is illegal over $100 and whose decision
+// invoke routes exhaustion to `refused` via onError — the adversarial-model
+// shape used by the retry-parity tests below.
+function createGuardedIssueMachine() {
+  const agent = setupAgent({
+    context: z.object({ amount: z.number() }),
+    input: z.object({ amount: z.number() }),
+    events: { ISSUE: z.object({}), REFUSE: z.object({}) },
+  });
+  return agent.createMachine({
+    context: ({ input }) => input,
+    initial: "classifying",
+    states: {
+      classifying: {
+        invoke: {
+          id: "decide",
+          src: "agent.decide",
+          input: () => ({
+            model: "quick",
+            prompt: "Issue or refuse?",
+            allowedEvents: ["ISSUE", "REFUSE"] as const,
+          }),
+          onError: { target: "refused" },
+        },
+        on: {
+          ISSUE: ({ context }) => (context.amount > 100 ? undefined : { target: "issued" }),
+          REFUSE: { target: "refused" },
+        },
+      },
+      issued: { type: "final" },
+      refused: { type: "final" },
     },
   });
 }
@@ -443,9 +481,8 @@ describe("lintAgentMachine — each check fires on a crafted bad machine", () =>
 
 describe("simulateAgent — keyless deterministic playthrough", () => {
   // Player turns in twenty-questions are idle states resumed by external
-  // events, and `SimulationScript` has no channel for delivering those, so a
-  // scripted playthrough settles at the first player turn. `canReach` covers
-  // the rest of the path (it forks on externally-accepted events).
+  // events. With no `events` scripted, a playthrough settles at the first
+  // player turn; the `events` queue (tested below) crosses such gates.
   test("drives twenty-questions through scripted decisions to the first player turn", async () => {
     const result = await simulateAgent(twentyQuestionsMachine, {
       input: { questionsRemaining: 1 },
@@ -504,6 +541,317 @@ describe("simulateAgent — keyless deterministic playthrough", () => {
       }),
     ).rejects.toThrow(/script ran dry on a pending decision request for src 'agent\.decide'/);
   });
+
+  test("the trail starts with the initial state (a complete state path)", async () => {
+    const result = await simulateAgent(createRefundMachine(), {
+      input: { request: "small refund", amount: 50 },
+      script: { decisions: { "agent.decide": [{ type: "AUTO_APPROVE" }] } },
+    });
+
+    expect(result.status).toBe("done");
+    expect(result.trail[0]).toEqual({ state: "deciding" });
+    // No hand-prepending needed to compare trajectories.
+    expect(result.trail.map((entry) => entry.state)).toEqual(["deciding", "refunded"]);
+  });
+});
+
+describe("simulateAgent — live-run decision retry semantics", () => {
+  test("a guard-rejected scripted decision retries with the next queued one", async () => {
+    // AUTO_APPROVE is guard-rejected at $5000; a live run re-asks the model,
+    // so the simulation consumes the next scripted decision for the same src.
+    const result = await simulateAgent(createRefundMachine(), {
+      input: { request: "big refund", amount: 5000 },
+      script: {
+        decisions: {
+          "agent.decide": [
+            { type: "AUTO_APPROVE" },
+            { type: "NEEDS_REVIEW", reason: "over limit" },
+          ],
+        },
+      },
+    });
+
+    expect(result.status).toBe("idle");
+    expect(result.snapshot.value).toBe("awaitingHuman");
+    expect(result.trail).toContainEqual({
+      state: "awaitingHuman",
+      appliedEvent: { type: "NEEDS_REVIEW", reason: "over limit" },
+      rejectedEvents: [{ type: "AUTO_APPROVE" }],
+    });
+  });
+
+  test("an unknown scripted event type is rejected and retried, like live validation", async () => {
+    // Comes free from delegating to resolveDecision: the typo'd type is not
+    // among the request's candidate events, so it fails 'unknown-event' and
+    // the next queued decision is tried — a live run behaves identically.
+    const result = await simulateAgent(createRefundMachine(), {
+      input: { request: "small refund", amount: 50 },
+      script: {
+        decisions: { "agent.decide": [{ type: "AUTO_APPROVE_TYPO" }, { type: "AUTO_APPROVE" }] },
+      },
+    });
+
+    expect(result.status).toBe("done");
+    expect(result.snapshot.value).toBe("refunded");
+    expect(result.trail).toContainEqual(
+      expect.objectContaining({
+        appliedEvent: { type: "AUTO_APPROVE" },
+        rejectedEvents: [{ type: "AUTO_APPROVE_TYPO" }],
+      }),
+    );
+  });
+
+  test("an all-rejected queue routes decision exhaustion through the invoke's onError", async () => {
+    // The adversarial "model" only ever tries the guarded ISSUE. Live, the
+    // decision exhausts and its error routes via onError; the simulation
+    // agrees rather than parking idle.
+    const result = await simulateAgent(createGuardedIssueMachine(), {
+      input: { amount: 5000 },
+      script: { decisions: { "agent.decide": [{ type: "ISSUE" }] } },
+    });
+
+    expect(result.status).toBe("done");
+    expect(result.snapshot.value).toBe("refused");
+    expect(result.trail).toContainEqual({
+      state: "refused",
+      rejectedEvents: [{ type: "ISSUE" }],
+    });
+  });
+
+  test("an all-rejected queue with no onError throws AgentDecisionExhaustedError", async () => {
+    // The last queued decision repeats for the remaining retries (a scripted
+    // model that insists), so the default budget of 3 attempts is spent — the
+    // same count a live adversarial model would produce.
+    await expect(
+      simulateAgent(createRefundMachine(), {
+        input: { request: "big refund", amount: 5000 },
+        script: { decisions: { "agent.decide": [{ type: "AUTO_APPROVE" }] } },
+      }),
+    ).rejects.toThrow(/Decision exhausted after 3 attempts.*guard rejected/);
+  });
+
+  test("a direct-object decision logic's own maxRetries caps scripted attempts", async () => {
+    // maxRetries: 0 → exactly one attempt. The logic rides on the invoke
+    // itself (no string src, nothing registered), so the budget must come from
+    // the spawn metadata — and the script queue is keyed by the invoke id.
+    const choose = createDecisionLogic({
+      model: "quick",
+      prompt: "Go or stop?",
+      allowedEvents: ["GO", "STOP"],
+      maxRetries: 0,
+    });
+    const agent = setupAgent({
+      context: z.object({}),
+      events: { GO: z.object({}), STOP: z.object({}) },
+    });
+    const machine = agent.createMachine({
+      context: () => ({}),
+      initial: "a",
+      states: {
+        a: {
+          invoke: { id: "choose", src: choose },
+          on: {
+            GO: () => undefined, // always guard-rejected
+            STOP: { target: "done" },
+          },
+        },
+        done: { type: "final" },
+      },
+    });
+
+    await expect(
+      simulateAgent(machine, {
+        script: { decisions: { choose: [{ type: "GO" }] } },
+      }),
+    ).rejects.toThrow(/Decision exhausted after 1 attempt\b/);
+  });
+});
+
+describe("simulateAgent — scripted external events cross human gates", () => {
+  test("the `events` queue resumes an idle wait, all the way to done", async () => {
+    const result = await simulateAgent(createRefundMachine(), {
+      input: { request: "big refund", amount: 5000 },
+      script: {
+        decisions: { "agent.decide": [{ type: "NEEDS_REVIEW", reason: "over limit" }] },
+        events: [{ type: "APPROVE" }],
+      },
+    });
+
+    expect(result.status).toBe("done");
+    expect(result.snapshot.value).toBe("refunded");
+    expect(result.trail).toContainEqual({
+      state: "refunded",
+      appliedEvent: { type: "APPROVE" },
+      external: true,
+    });
+    expect(result.trail.map((entry) => entry.state)).toEqual([
+      "deciding",
+      "awaitingHuman",
+      "refunded",
+    ]);
+  });
+
+  test("an external event the state cannot take throws instead of vanishing", async () => {
+    await expect(
+      simulateAgent(createRefundMachine(), {
+        input: { request: "big refund", amount: 5000 },
+        script: {
+          decisions: { "agent.decide": [{ type: "NEEDS_REVIEW", reason: "over limit" }] },
+          events: [{ type: "AUTO_APPROVE" }], // not handled at the human gate
+        },
+      }),
+    ).rejects.toThrow(/external event 'AUTO_APPROVE' cannot be taken in state "awaitingHuman"/);
+  });
+});
+
+describe("simulateAgent ↔ runAgent — the same script produces the same outcome", () => {
+  // The live-run counterpart of a simulation script: a `decide` executor that
+  // dequeues one scripted decision per attempt and repeats the last one when
+  // the queue runs dry mid-retry — simulateAgent's exact convention, including
+  // its scope: the repeat only spans one request's retries (`request.attempts`
+  // is empty on a fresh request, where a dry queue is an error instead).
+  const scriptedDecide = (queue: ChosenEvent[]) => {
+    const remaining = [...queue];
+    let last: ChosenEvent | undefined;
+    return async (request: { attempts: readonly unknown[] }) => {
+      if (request.attempts.length === 0) {
+        last = undefined;
+      }
+      last = remaining.shift() ?? last;
+      if (!last) {
+        throw new Error("scripted decide: queue is empty");
+      }
+      return { event: last };
+    };
+  };
+
+  test("guard-rejected then accepted: both surfaces settle idle at the human gate", async () => {
+    const decisions: ChosenEvent[] = [
+      { type: "AUTO_APPROVE" },
+      { type: "NEEDS_REVIEW", reason: "over limit" },
+    ];
+    const input = { request: "big refund", amount: 5000 };
+
+    const simulated = await simulateAgent(createRefundMachine(), {
+      input,
+      script: { decisions: { "agent.decide": decisions } },
+    });
+    const live = await runAgent(createRefundMachine(), {
+      input,
+      executors: { decide: scriptedDecide(decisions) },
+    });
+
+    expect(simulated.status).toBe("idle");
+    expect(live.status).toBe("idle");
+    expect(live.snapshot.value).toEqual(simulated.snapshot.value); // 'awaitingHuman'
+  });
+
+  test("adversarial exhaustion: both surfaces route through onError to 'refused'", async () => {
+    const decisions: ChosenEvent[] = [{ type: "ISSUE" }];
+    const input = { amount: 5000 };
+
+    const simulated = await simulateAgent(createGuardedIssueMachine(), {
+      input,
+      script: { decisions: { "agent.decide": decisions } },
+    });
+    const live = await runAgent(createGuardedIssueMachine(), {
+      input,
+      executors: { decide: scriptedDecide(decisions) },
+    });
+
+    expect(simulated.status).toBe("done");
+    expect(live.status).toBe("done");
+    expect(live.snapshot.value).toEqual(simulated.snapshot.value); // 'refused'
+  });
+});
+
+describe("canReach — predicate targets", () => {
+  // A refund flow whose `approved` flag is written ONLY by the human gate's
+  // APPROVE — so "issued over the limit without approval" is a genuine
+  // state+context property that changes along paths, not a constant of the
+  // input.
+  function createApprovalMachine() {
+    const agent = setupAgent({
+      context: z.object({ amount: z.number(), approved: z.boolean() }),
+      input: z.object({ amount: z.number() }),
+      events: {
+        ISSUE: z.object({}),
+        ESCALATE: z.object({}),
+        APPROVE: z.object({}),
+        REJECT: z.object({}),
+      },
+      isSuspended: (snapshot) => snapshot.hasTag("awaiting-approval"),
+    });
+    return agent.createMachine({
+      context: ({ input }) => ({ amount: input.amount, approved: false }),
+      initial: "classifying",
+      states: {
+        classifying: {
+          invoke: {
+            id: "decide",
+            src: "agent.decide",
+            input: () => ({
+              model: "quick",
+              prompt: "Issue or escalate?",
+              allowedEvents: ["ISSUE", "ESCALATE"] as const,
+            }),
+          },
+          on: {
+            ISSUE: ({ context }) =>
+              context.amount > 100 && !context.approved ? undefined : { target: "issued" },
+            ESCALATE: { target: "approving" },
+          },
+        },
+        approving: {
+          tags: ["awaiting-approval"],
+          on: {
+            // The only writer of `approved`.
+            APPROVE: () => ({ target: "issued", context: { approved: true } }),
+            REJECT: { target: "rejected" },
+          },
+        },
+        issued: { type: "final" },
+        rejected: { type: "final" },
+      },
+    });
+  }
+
+  test("a snapshot predicate can express a violation property without a sentinel state", async () => {
+    type Ctx = { amount: number; approved: boolean };
+
+    // The safety property: over the limit, `issued` is never entered without
+    // `approved` — a predicate over context that only APPROVE can flip, so
+    // this is decided by exploration, not by the input alone.
+    const violation = await canReach(
+      createApprovalMachine(),
+      (snapshot) =>
+        snapshot.matches("issued") &&
+        (snapshot.context as Ctx).amount > 100 &&
+        !(snapshot.context as Ctx).approved,
+      { input: { amount: 5000 } },
+    );
+    expect(violation.reachable).toBe(false);
+
+    // The same terminal state IS reachable with approval on record — the
+    // witness must pass through the human gate.
+    const legal = await canReach(
+      createApprovalMachine(),
+      (snapshot) => snapshot.matches("issued") && (snapshot.context as Ctx).approved,
+      { input: { amount: 5000 } },
+    );
+    expect(legal.reachable).toBe(true);
+    expect(legal.witness?.map((event) => event.type)).toEqual(["ESCALATE", "APPROVE"]);
+
+    // Below the limit, the direct ISSUE is legal and the violation predicate
+    // (approved never set) still has no witness.
+    const small = await canReach(
+      createApprovalMachine(),
+      (snapshot) => snapshot.matches("issued") && !(snapshot.context as Ctx).approved,
+      { input: { amount: 40 } },
+    );
+    expect(small.reachable).toBe(true);
+    expect(small.witness?.map((event) => event.type)).toEqual(["ISSUE"]);
+  });
 });
 
 describe("explorePaths — enumerates decision + human branches", () => {
@@ -547,6 +895,46 @@ describe("canReach — reachability with a witness path", () => {
     });
     expect(result.reachable).toBe(false);
     expect(result.witness).toBeUndefined();
+  });
+
+  test("finds a state passed through mid-chain between two text requests", async () => {
+    // `middle` is entered and immediately left while exploration resolves the
+    // chained text requests — the target check must run on every intermediate
+    // snapshot, not only where a path settles.
+    const agent = setupAgent({ context: z.object({}) });
+    const machine = agent.createMachine({
+      context: () => ({}),
+      initial: "first",
+      states: {
+        first: {
+          invoke: {
+            id: "t1",
+            src: "agent.generateText",
+            input: () => ({ model: "quick", prompt: "one" }),
+            onDone: { target: "middle" },
+          },
+        },
+        middle: {
+          invoke: {
+            id: "t2",
+            src: "agent.generateText",
+            input: () => ({ model: "quick", prompt: "two" }),
+            onDone: { target: "last" },
+          },
+        },
+        last: { type: "final" },
+      },
+    });
+    const text = { "agent.generateText": "canned" };
+
+    const byPath = await canReach(machine, "middle", { text });
+    expect(byPath.reachable).toBe(true);
+    expect(byPath.witness).toEqual([]);
+
+    const byPredicate = await canReach(machine, (snapshot) => snapshot.matches("middle"), {
+      text,
+    });
+    expect(byPredicate.reachable).toBe(true);
   });
 });
 

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1063,10 +1063,14 @@ async function applyScriptedDecision(
 
   let chosen: ChosenEvent;
   try {
-    chosen = await resolveDecision(request, decide, {
-      maxRetries,
-      canTake: (event) => (step.snapshot as AnyMachineSnapshot).can(event as never),
-    });
+    chosen = await resolveDecision(
+      request,
+      { decide },
+      {
+        maxRetries,
+        canTake: (event) => (step.snapshot as AnyMachineSnapshot).can(event as never),
+      },
+    );
   } catch (error) {
     if (!(error instanceof AgentDecisionExhaustedError)) {
       throw error;

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -10,7 +10,7 @@
  * - {@link explorePaths} — enumerates decision/external branches to a bounded
  *   depth and reports reached states and terminal outcomes.
  * - {@link canReach} — a thin wrapper over {@link explorePaths} answering
- *   "can this state be reached?" with a witness path.
+ *   "can this state (or snapshot predicate) be reached?" with a witness path.
  *
  * @module
  */
@@ -19,7 +19,7 @@ import type { ChosenEvent } from "./types.js";
 import { AgentError } from "./errors.js";
 import { getJsonSchemaSync } from "./utils.js";
 import { getAcceptedEvents } from "./events.js";
-import { isDecisionLogic } from "./decision.js";
+import { AgentDecisionExhaustedError, isDecisionLogic, resolveDecision } from "./decision.js";
 import { isTextLogic } from "./text-logic.js";
 import {
   executorBoundLogics,
@@ -721,8 +721,8 @@ export function lintAgentMachine(
 }
 
 /**
- * Thrown by `lintAgentMachine(machine, { throw: true })` when lint finds
- * failing diagnostics.
+ * Thrown by `lintAgentMachine(machine, { throw: true })` (and its
+ * {@link assertAgentMachine} alias) when lint finds failing diagnostics.
  * `diagnostics` holds the findings; the message lists them one per finding,
  * so a test runner's failure output reads like the CLI's lint report.
  */
@@ -742,6 +742,33 @@ export class AgentLintError extends AgentError {
   }
 }
 
+/** Options for {@link assertAgentMachine}. */
+export interface AssertAgentMachineOptions extends LintAgentMachineOptions {
+  /** Also fail on warning-severity findings. Default: errors only. */
+  warnings?: boolean;
+}
+
+/**
+ * Asserts a machine passes {@link lintAgentMachine}: returns silently when
+ * clean, throws {@link AgentLintError} (with the findings on `.diagnostics`)
+ * otherwise — sugar for `lintAgentMachine(machine, { ...options, throw: true })`.
+ * Fails on error-severity findings; set `warnings: true` to fail on warnings
+ * too. The one-liner for tests and generation loops:
+ *
+ * @example
+ * ```ts
+ * test('agent machine is structurally sound', () => {
+ *   assertAgentMachine(machine);
+ * });
+ * ```
+ */
+export function assertAgentMachine(
+  machine: AnyStateMachine,
+  options: AssertAgentMachineOptions = {},
+): void {
+  lintAgentMachine(machine, { ...options, throw: true });
+}
+
 // ─── Simulation ───
 
 /**
@@ -751,26 +778,50 @@ export class AgentLintError extends AgentError {
  * - `text` — output values for text requests, keyed by request src (the
  *   `setupAgent({ requests })` key, or `agent.generateText`/`agent.streamText`).
  * - `decisions` — the {@link ChosenEvent} to apply for a decision request,
- *   keyed by decision src (usually `agent.decide`).
+ *   keyed by decision src (usually `agent.decide`). An invoke whose src is an
+ *   inline logic object has only an auto-generated src, so its queue may be
+ *   keyed by the invoke's `id` instead.
  * - `invokes` — output values for scripted invokes (any actor whose output must
  *   be canned), keyed by src.
  * - `userInput` — a flat FIFO queue of answers for `agent.userInput`, the
  *   shorthand for `invokes: { 'agent.userInput': [...] }`. Entries here are
  *   consumed before that src's `invokes` queue.
+ * - `events` — a flat FIFO queue of external (human/host-sent) events. When the
+ *   machine settles idle with no pending request or invoke — a human gate — the
+ *   next queued event is applied, so a simulation can cross states that a live
+ *   run crosses via `actor.send(...)`. An event the current state cannot take
+ *   (no handler, or guard-rejected) throws rather than silently vanishing.
  */
 export interface SimulationScript {
   text?: Record<string, unknown[]>;
   decisions?: Record<string, ChosenEvent[]>;
   invokes?: Record<string, unknown[]>;
   userInput?: unknown[];
+  events?: ChosenEvent[];
 }
 
-/** One entry in a {@link SimulateAgentResult.trail}: the state after this step, plus what drove the step. */
+/**
+ * One entry in a {@link SimulateAgentResult.trail}: the state after this step,
+ * plus what drove the step. The first entry is always the machine's initial
+ * state, with no `appliedEvent`/`resolvedRequest` — so `trail.map((e) =>
+ * e.state)` is the complete state path, directly comparable with
+ * `matchesTrajectory` without prepending the initial state by hand.
+ */
 export interface SimulationTrailEntry {
   /** The machine state value after applying this step. */
   state: unknown;
-  /** The chosen event applied (for a decision request). */
+  /** The chosen event applied (for a decision request), or the external event applied (when `external`). */
   appliedEvent?: ChosenEvent;
+  /** True when `appliedEvent` came from the script's `events` queue (an external/user event), not a decision. */
+  external?: boolean;
+  /**
+   * Scripted decisions that failed validation (unknown event, invalid payload,
+   * or guard-rejected — live-run retry parity, see {@link simulateAgent})
+   * before this step settled. Present with an `appliedEvent` when a later
+   * scripted attempt succeeded, or alone when every attempt failed and the
+   * exhaustion error was routed through the decision invoke's `onError`.
+   */
+  rejectedEvents?: ChosenEvent[];
   /** The resolved request (for a text/userInput invoke): its kind and src. */
   resolvedRequest?: { kind: "text" | "userInput"; src: string; id: string };
 }
@@ -827,6 +878,21 @@ function takeFromQueue<T>(
  * the real transition logic. Returns the terminal `status`, final `snapshot`,
  * and a `trail` of every step taken.
  *
+ * Decisions run through the live run's own validation/retry core,
+ * {@link resolveDecision}, with the script standing in for the model: each
+ * attempt consumes the next queued {@link ChosenEvent} for that src, so an
+ * unknown, payload-invalid, or guard-rejected event is NOT silently swallowed
+ * — the next queued decision is tried, exactly as a live run re-asks the
+ * model. The decision logic's `maxRetries` caps attempts as it would live;
+ * when retries continue past the end of the queue, the last queued decision
+ * repeats (a scripted model that insists). The repeat applies only within one
+ * decision request's retries — each new decision request must have its own
+ * queued entry, or the dry-script error throws as usual. Exhausting all
+ * attempts delivers
+ * the resulting {@link AgentDecisionExhaustedError} to the machine as the
+ * decision invoke's error (so an `onError` transition observes it, as it
+ * would live); with no `onError` to catch it, it is thrown.
+ *
  * Throws a descriptive error when the script runs dry mid-request, naming the
  * pending request's kind, src, and id so the missing scripted response is
  * obvious.
@@ -835,7 +901,10 @@ function takeFromQueue<T>(
  * ```ts
  * const { status, snapshot } = simulateAgent(machine, {
  *   input: { topic: 'state machines' },
- *   script: { decisions: { 'agent.decide': [{ type: 'END' }] } },
+ *   script: {
+ *     decisions: { 'agent.decide': [{ type: 'ESCALATE' }] },
+ *     events: [{ type: 'APPROVE' }], // crosses the human gate
+ *   },
  * });
  * ```
  */
@@ -850,6 +919,7 @@ export async function simulateAgent(
     text: mapValues(options.script.text ?? {}, (arr) => [...arr]),
     decisions: mapValues(options.script.decisions ?? {}, (arr) => [...arr]),
     invokes: mapValues(options.script.invokes ?? {}, (arr) => [...arr]),
+    events: [...(options.script.events ?? [])],
   };
   if (options.script.userInput?.length) {
     // `userInput` is the shorthand queue for the `agent.userInput` src, and is
@@ -861,7 +931,8 @@ export async function simulateAgent(
   }
 
   let step = initialAgentStep(machine, options.input);
-  const trail: SimulationTrailEntry[] = [];
+  // The trail starts with the initial state, so it is a complete state path.
+  const trail: SimulationTrailEntry[] = [{ state: step.snapshot.value }];
 
   for (let i = 0; i < maxSteps; i++) {
     if (step.done) {
@@ -872,15 +943,27 @@ export async function simulateAgent(
     if (request) {
       if (request.kind === "decision") {
         // A decision request carries no `src` of its own — correlate it to its
-        // invoke src (usually `agent.decide`) via the step's spawn actions.
-        const srcById = new Map(pendingInvokes(step).map((invoke) => [invoke.id, invoke.src]));
-        const decisionSrc = srcById.get(request.id) ?? request.id;
-        const taken = takeFromQueue(script.decisions, decisionSrc);
-        if (!taken.found) {
-          throw scriptDryError("decision", decisionSrc, request.id, request);
-        }
-        step = transitionAgentStep(machine, step, taken.value as never);
-        trail.push({ state: step.snapshot.value, appliedEvent: taken.value });
+        // invoke (usually `agent.decide`) via the step's spawn actions. A
+        // direct-object src lowers to an auto-generated src string
+        // (`xstate.invoke.…`) nobody would key a script by, so the invoke id
+        // works as the queue key too; the logic rides along for maxRetries.
+        const invokeMeta = findInvokeMetadata(step, request.id);
+        const src = invokeMeta?.src ?? request.id;
+        const decisionSrc =
+          src in (script.decisions ?? {})
+            ? src
+            : request.id in (script.decisions ?? {})
+              ? request.id
+              : src;
+        step = await applyScriptedDecision(
+          machine,
+          step,
+          request,
+          decisionSrc,
+          invokeMeta?.logic,
+          script,
+          trail,
+        );
         continue;
       }
       // Text request.
@@ -912,11 +995,146 @@ export async function simulateAgent(
       continue;
     }
 
-    // Nothing pending and not done: an intentional wait for an external event.
+    // Nothing pending and not done: an idle wait for an external event. Apply
+    // the next scripted external event if there is one (the simulation
+    // equivalent of a human's `actor.send(...)`), else settle idle.
+    const external = script.events!;
+    if (external.length > 0) {
+      const event = external.shift() as ChosenEvent;
+      if (!(step.snapshot as AnyMachineSnapshot).can(event as never)) {
+        throw new Error(
+          `simulateAgent: scripted external event '${event.type}' cannot be taken in state ` +
+            `${JSON.stringify(step.snapshot.value)} (no handler, or its guard rejected it). ` +
+            `A live run's send would be silently dropped here; fix the script's \`events\` queue.`,
+        );
+      }
+      step = transitionAgentStep(machine, step, event as never);
+      trail.push({ state: step.snapshot.value, appliedEvent: event, external: true });
+      continue;
+    }
     return { status: "idle", snapshot: step.snapshot, trail };
   }
 
   return { status: "exhausted", snapshot: step.snapshot, trail };
+}
+
+// Resolves one decision request by running the live run's own validation/retry
+// core, resolveDecision, with a scripted `decide` executor standing in for the
+// model — so unknown-event, invalid-payload, and rejected-by-guard semantics
+// (and the maxRetries budget) are the real ones, not a mirror that can drift.
+// Each attempt dequeues the next scripted decision; when retries continue past
+// the end of the queue, the last queued decision repeats (a scripted model
+// that insists). A queue that is empty on the FIRST ask throws the dry-script
+// error. Exhaustion is delivered to the machine as the invoke's error event so
+// `onError` can observe it (as live), and thrown when nothing handles it.
+async function applyScriptedDecision(
+  machine: AnyStateMachine,
+  step: AgentStep,
+  request: AgentStepRequest & { kind: "decision" },
+  decisionSrc: string,
+  invokeLogic: unknown,
+  script: SimulationScript,
+  trail: SimulationTrailEntry[],
+): Promise<AgentStep> {
+  // The scripted decisions actually dequeued for this request (synthetic
+  // repeats excluded) — failed ones surface on the trail as `rejectedEvents`.
+  const dequeued: ChosenEvent[] = [];
+  const decide = async (): Promise<{ event: ChosenEvent }> => {
+    const taken = takeFromQueue(script.decisions, decisionSrc);
+    if (taken.found) {
+      dequeued.push(taken.value);
+      return { event: taken.value };
+    }
+    if (dequeued.length === 0) {
+      throw scriptDryError("decision", decisionSrc, request.id, request);
+    }
+    return { event: dequeued[dequeued.length - 1] as ChosenEvent };
+  };
+
+  // Mirror bindDecisionLogic (the runAgent path): the attempt budget is the
+  // decision logic's maxRetries. The invoke's own logic wins (covers
+  // direct-object srcs), then the registered actors, then `sources.actors`
+  // (which survives `machine.provide(...)`, whose product the registry may
+  // not know).
+  const logic = isDecisionLogic(invokeLogic)
+    ? invokeLogic
+    : resolveRegisteredDecisionLogic(machine, decisionSrc);
+  const maxRetries = logic?.maxRetries;
+
+  let chosen: ChosenEvent;
+  try {
+    chosen = await resolveDecision(request, decide, {
+      maxRetries,
+      canTake: (event) => (step.snapshot as AnyMachineSnapshot).can(event as never),
+    });
+  } catch (error) {
+    if (!(error instanceof AgentDecisionExhaustedError)) {
+      throw error;
+    }
+    const errorEvent = {
+      type: "xstate.error.actor",
+      actorId: request.id,
+      ...sessionIdOf(step.snapshot, request.id),
+      error,
+    };
+    const next = transitionAgentStep(machine, step, errorEvent as never);
+    if ((next.snapshot as { status?: unknown }).status === "error") {
+      // No onError anywhere caught it — same as a live run failing.
+      throw error;
+    }
+    trail.push({ state: next.snapshot.value, rejectedEvents: dequeued });
+    return next;
+  }
+
+  const next = transitionAgentStep(machine, step, chosen as never);
+  // Success comes from the last dequeued decision; everything before it failed.
+  const rejected = dequeued.slice(0, -1);
+  trail.push({
+    state: next.snapshot.value,
+    appliedEvent: chosen,
+    ...(rejected.length > 0 ? { rejectedEvents: rejected } : {}),
+  });
+  return next;
+}
+
+// The spawn-action metadata for the invoke with this id: its string src (when
+// it has one) and its inline logic (when the src is a direct logic object).
+function findInvokeMetadata(
+  step: AgentStep,
+  id: string,
+): { src?: string; logic?: unknown } | undefined {
+  for (const action of step.actions) {
+    const metadata = getInvokeEffectMetadata(action);
+    if (metadata?.id !== id) {
+      continue;
+    }
+    return {
+      ...(typeof metadata.src === "string" ? { src: metadata.src } : {}),
+      logic: metadata.logic ?? (typeof metadata.src === "object" ? metadata.src : undefined),
+    };
+  }
+  return undefined;
+}
+
+// The DecisionLogic registered for a src, checking the machine's registered
+// setupAgent actors first and falling back to `machine.sources.actors` (the
+// same chain lintAgentMachine uses, so `.provide(...)` products resolve too).
+function resolveRegisteredDecisionLogic(
+  machine: AnyStateMachine,
+  src: string,
+): { maxRetries: number } | undefined {
+  const candidate =
+    (getRegisteredAgentExecutionOptions(machine).actors as Record<string, unknown> | undefined)?.[
+      src
+    ] ?? (machine as { sources?: { actors?: Record<string, unknown> } }).sources?.actors?.[src];
+  return isDecisionLogic(candidate) ? candidate : undefined;
+}
+
+// The invoked child's session identity, needed on a minted error event so
+// xstate's transition doesn't discard it as stale.
+function sessionIdOf(snapshot: AnyMachineSnapshot, id: string): { sessionId?: string } {
+  const child = (snapshot.children as Record<string, { sessionId?: unknown }>)[id];
+  return typeof child?.sessionId === "string" ? { sessionId: child.sessionId } : {};
 }
 
 function mapValues<T, U>(obj: Record<string, T>, fn: (value: T) => U): Record<string, U> {
@@ -1042,10 +1260,16 @@ async function explore(
   // Advance a step deterministically through any non-branching text/userInput
   // invokes until it is done, idle-with-external-events, at a decision, or
   // blocked on a missing canned output. Returns the settled step plus a note.
-  const advance = (step: AgentStep): { step: AgentStep; blockedSrc?: string } => {
+  // `stopWhen` is checked on EVERY snapshot along the way — including the
+  // intermediate ones this advance resolves straight through — so a predicate
+  // canReach target that only holds mid-chain is still found (`hit`).
+  const advance = (step: AgentStep): { step: AgentStep; blockedSrc?: string; hit?: boolean } => {
     let current = step;
     // Bounded loop: each iteration resolves one text/userInput invoke.
     for (let i = 0; i < MAX_ADVANCE_STEPS; i++) {
+      if (stopWhen?.(current.snapshot)) {
+        return { step: current, hit: true };
+      }
       if (current.done) {
         return { step: current };
       }
@@ -1085,8 +1309,8 @@ async function explore(
       return;
     }
 
-    const { step: settled, blockedSrc } = advance(step);
-    if (stopWhen?.(settled.snapshot)) {
+    const { step: settled, blockedSrc, hit } = advance(step);
+    if (hit) {
       witness = path;
       return;
     }
@@ -1200,8 +1424,11 @@ export interface CanReachResult {
 }
 
 /**
- * Answers "can the machine reach `statePath`?" by exploring its branches (a
- * thin wrapper over {@link explorePaths}). Returns
+ * Answers "can the machine reach this?" by exploring its branches (a thin
+ * wrapper over {@link explorePaths}). The target is either a state path string
+ * (`snapshot.matches(...)` semantics) or a snapshot predicate — the predicate
+ * form checks any property (a context invariant, a tag, a state+context
+ * combination) without reifying a sentinel state for it. Returns
  * `{ reachable: true, witness }` with the event sequence that reaches it, or
  * `{ reachable: false }`.
  *
@@ -1210,18 +1437,32 @@ export interface CanReachResult {
  * const { reachable, witness } = await canReach(refundMachine, 'denied', { input: { request: 'x', amount: 5000 } });
  * // reachable → true; witness → [{ type: 'NEEDS_REVIEW' }, { type: 'DENY' }]
  * ```
+ *
+ * @example Predicate target — a violation property, no sentinel state needed
+ * ```ts
+ * const violation = await canReach(
+ *   refundMachine,
+ *   (snapshot) => snapshot.matches('issued') && !snapshot.context.approved,
+ *   { input: { amount: 5000 } },
+ * );
+ * // violation.reachable → false is the safety proof
+ * ```
  */
 export async function canReach(
   machine: AnyStateMachine,
-  statePath: string,
+  target: string | ((snapshot: AnyMachineSnapshot) => boolean),
   options: ExplorePathsOptions = {},
 ): Promise<CanReachResult> {
-  const { witness } = await explore(machine, options, (snapshot) => {
-    try {
-      return (snapshot as AnyMachineSnapshot).matches(statePath as never);
-    } catch {
-      return false;
-    }
-  });
+  const stopWhen =
+    typeof target === "function"
+      ? target
+      : (snapshot: AnyMachineSnapshot): boolean => {
+          try {
+            return snapshot.matches(target as never);
+          } catch {
+            return false;
+          }
+        };
+  const { witness } = await explore(machine, options, stopWhen);
   return witness !== undefined ? { reachable: true, witness } : { reachable: false };
 }


### PR DESCRIPTION
Ships the examples-expansion work, rebased onto current `next` and aligned with the post-consistency-pass API.

**Verification (`src/verify.ts`) upgrades** (with the `verification/` example exercising them):
- `assertAgentMachine(machine)` — throwing lint assertion sugar for tests and generation loops.
- `canReach` accepts a **snapshot predicate** target, so safety properties (state+context invariants) need no sentinel state.
- `simulateAgent` scripts gain an `events` queue: external/human events applied at idle gates, so simulations cross states a live run crosses via `actor.send(...)`; untakeable events throw instead of vanishing.

**New examples:** `chameleon` and `just-one` (multi-agent social-deduction/co-op games), `seam-scoring` (seam metadata + scoring), `snapshot-migration` (versioned snapshots: machine `version` stamping, `onVersionMismatch`, `migrateSnapshot` across two machine versions), plus the `verification` example.

**API alignment commit** on top: `isSuspended`→`isIdle`, machine's own `version` replaces the removed `machineVersion` runAgent option, `persistSnapshot` inlined, `resolveDecision(request, { decide }, ...)`.

Tests: 852 pass (was 811 on `next` — 41 new); typecheck (src+examples), lint, format clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/agent/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->