### PR TITLE
docs: fix agent documentation link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Stately Agent adds model requests and decisions to XState:
 
 Stately Agent 2 is in alpha. APIs may change before the stable release.
 
-[Documentation](https://stately.ai/docs/agents) · [Examples](examples/README.md) · [XState](https://github.com/statelyai/xstate)
+[Documentation](https://stately.ai/docs/packages/agent) · [Examples](examples/README.md) · [XState](https://github.com/statelyai/xstate)
 
 ## Three starting points
 


### PR DESCRIPTION
## Summary

Fixes #66.

The README linked to `/docs/agents`, which currently returns a 404. Update the Documentation link to the current `@statelyai/agent` documentation entry point at `/docs/packages/agent`.

## Compatibility

Documentation-only change; no runtime or API behavior is affected.

## Tests

- `git diff --check` — passed
- `Invoke-WebRequest -Uri https://stately.ai/docs/packages/agent -Method Head` — HTTP 200

Not run: `pnpm check` and the full test suite. This is a one-line documentation-only change, and the locally installed `pnpm` command did not start successfully in this environment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/agent/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->