### PR TITLE
Fix four API contract defects

### DIFF
--- a/.changeset/contract-fixes-xor-decisions-presets-messages.md
+++ b/.changeset/contract-fixes-xor-decisions-presets-messages.md
@@ -4,7 +4,7 @@
 
 **Four API contract fixes.**
 
-- Agent text requests now reject a request that supplies both a non-empty `prompt` and a non-empty `messages` array — the same rule the executor types already declared. Provide exactly one input source.
+- Agent text requests now require exactly one non-empty `prompt` or non-empty `messages` array at every execution boundary, matching the executor types.
 - `createDecisionLogic` is now exported from the package root (along with its `DecisionLogic` return type), matching the already-exported `DecisionLogicConfig`.
 - The machine preset factories (`createToolLoopMachine`, `createSequentialMachine`, `createParallelMachine`, `createLoopMachine`, `createRouterMachine`, `createSupervisorMachine`, `createHandoffMachine`) return typed machines instead of `AnyStateMachine`. Router, supervisor, and handoff are generic over their route/worker/agent maps, so inputs, outputs, and per-name events (`ROUTE_<name>`, `DELEGATE_<name>`, `transfer_to_<name>`) are all inferred — malformed input like `{ prompt: 123 }` is now a compile error.
-- `messagesSchema` validates message part payloads, not just part `type` tags: text parts need a string `text`, tool calls need `toolCallId`/`toolName`/`input`, tool results need a well-formed `output` envelope, and so on. Extra fields are still allowed.
+- `messagesSchema` validates role-appropriate parts, supported media payloads, nested tool-result content, and required output values in addition to each part's fields. Extra fields are still allowed.

--- a/.changeset/contract-fixes-xor-decisions-presets-messages.md
+++ b/.changeset/contract-fixes-xor-decisions-presets-messages.md
@@ -1,0 +1,10 @@
+---
+"@statelyai/agent": minor
+---
+
+**Four API contract fixes.**
+
+- Agent text requests now reject a request that supplies both a non-empty `prompt` and a non-empty `messages` array — the same rule the executor types already declared. Provide exactly one input source.
+- `createDecisionLogic` is now exported from the package root (along with its `DecisionLogic` return type), matching the already-exported `DecisionLogicConfig`.
+- The machine preset factories (`createToolLoopMachine`, `createSequentialMachine`, `createParallelMachine`, `createLoopMachine`, `createRouterMachine`, `createSupervisorMachine`, `createHandoffMachine`) return typed machines instead of `AnyStateMachine`. Router, supervisor, and handoff are generic over their route/worker/agent maps, so inputs, outputs, and per-name events (`ROUTE_<name>`, `DELEGATE_<name>`, `transfer_to_<name>`) are all inferred — malformed input like `{ prompt: 123 }` is now a compile error.
+- `messagesSchema` validates message part payloads, not just part `type` tags: text parts need a string `text`, tool calls need `toolCallId`/`toolName`/`input`, tool results need a well-formed `output` envelope, and so on. Extra fields are still allowed.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -67,10 +67,13 @@ The `allowedEvents` option accepts a single string or an array. Entries are exac
 
 ### Reusable decision logic
 
+<!-- createDecisionLogic public API from src/decision.ts and src/index.ts -->
+
 For a decision used by more than one state or machine, `createDecisionLogic` builds the same decision as standalone actor logic, exported from `@statelyai/agent`. Register the result under `actors:` and invoke it by name. It takes the same fields as the `agent.decide` input, each a static value or an `({ input }) => value` resolver, plus an optional `schemas.input` to type and validate the input.
 
 ```ts no-check
 import { createDecisionLogic } from "@statelyai/agent";
+import { z } from "zod";
 
 export const chooseAction = createDecisionLogic({
   schemas: { input: z.object({ questionsRemaining: z.number() }) },
@@ -129,7 +132,7 @@ Retry behavior:
 
 Core validates and retries. It never calls a model. Coercing the model into choosing exactly one option is the host's responsibility. Hosts do this with one tool per event and a forced tool choice, or with structured output over an event union. The shipped `createAiSdkExecutors` provides a `decide` executor for the Vercel AI SDK. The raw-SDK examples force the choice with `tool_choice`. See [Hosts](hosts.md).
 
-> **Note:** Decisions are state-local, so author them inline on the invoke. There is no reusable decision-logic object, because a decision's candidates and legality depend on the state it runs in.
+> **Note:** Decisions are state-local, so prefer authoring one-off decisions inline on the invoke.
 
 ## The decide loop for multi-event commands
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -65,6 +65,24 @@ The `allowedEvents` option accepts a single string or an array. Entries are exac
 | `'*'` | Every currently-legal event. |
 | `'todo.*'` | Every declared event under the `todo.` namespace, such as `todo.add` and `todo.toggle`. Typed against declared dotted types, so a pattern matching nothing, such as `'nope.*'`, is a compile error. |
 
+### Reusable decision logic
+
+For a decision used by more than one state or machine, `createDecisionLogic` builds the same decision as standalone actor logic, exported from `@statelyai/agent`. Register the result under `actors:` and invoke it by name. It takes the same fields as the `agent.decide` input, each a static value or an `({ input }) => value` resolver, plus an optional `schemas.input` to type and validate the input.
+
+```ts no-check
+import { createDecisionLogic } from "@statelyai/agent";
+
+export const chooseAction = createDecisionLogic({
+  schemas: { input: z.object({ questionsRemaining: z.number() }) },
+  model: "quick",
+  system: "Ask one yes/no question at a time, but guess on the final turn.",
+  prompt: ({ input }) => `Questions remaining: ${input.questionsRemaining}`,
+  allowedEvents: ["ASK", "GUESS"],
+});
+```
+
+Prefer the `agent.decide` builtin for a one-off, state-local decision: it needs no separate declaration and types `allowedEvents` against the machine's own event schemas.
+
 ## Delivering the chosen event
 
 Delivery is automatic. When the decision resolves, the `agent.decide` actor sends the chosen event to the machine, and the matching `on:` transition runs. You handle the outcome with ordinary transitions.

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -107,7 +107,7 @@ A request that needs history sends it through `messages` instead of a bare `prom
 
 ### Validating messages with messagesSchema
 
-`messagesSchema` is a root export typed as `StandardSchemaV1<AgentMessage[]>`. It checks that every message has a known `role` and that `content` is a string or an array of known parts. Use it as a standalone validator on messages that arrive from outside your process, such as an HTTP body, a stored transcript, or a client resume payload:
+`messagesSchema` is a root export typed as `StandardSchemaV1<AgentMessage[]>`. It checks each role's allowed content parts, required part fields, media payload types, and nested tool-result content. Use it as a standalone validator on messages that arrive from outside your process, such as an HTTP body, a stored transcript, or a client resume payload:
 
 ```ts
 import { messagesSchema, type AgentMessage } from "@statelyai/agent";

--- a/docs/text-requests.md
+++ b/docs/text-requests.md
@@ -47,6 +47,7 @@ const agentSetup = setupAgent({
 - Each schema field accepts any [Standard Schema](https://standardschema.dev) validator.
 - Both schema slots are optional. Omit `output` and the request resolves to `string`. Omit `input` and the invoke needs no `input`. A request with neither writes `schemas: {}`. The `schemas` key itself stays required on `requests` entries, while a standalone `createTextLogic` can omit it entirely.
 - Each request-shaping field, such as `system`, `prompt`, `messages`, `temperature`, and `maxOutputTokens`, is either a static value or a `({ input }) => value` function.
+- `prompt` and `messages` are mutually exclusive: a request must resolve exactly one of them. Resolving both, or neither, throws.
 
 ### Model references
 

--- a/examples/hierarchical-teams/index.ts
+++ b/examples/hierarchical-teams/index.ts
@@ -207,7 +207,7 @@ const writingSetup = setupAgent({
       schemas: { input: z.object({ research: z.string() }), output: z.string() },
       model: "outliner",
       system: "Create a report outline from the research notes: at most three short bullets.",
-      prompt: ({ input }) => input.research,
+      prompt: ({ input }) => `Research:\n${input.research || "(none gathered)"}`,
     },
     write: {
       schemas: {

--- a/examples/json-agent/workflow.json
+++ b/examples/json-agent/workflow.json
@@ -76,7 +76,7 @@
     "draftReply": {
       "model": "openai/gpt-5.4-mini",
       "system": "Draft a short, courteous support reply to the customer's ticket.",
-      "prompt": "{{ context.ticket }}",
+      "prompt": "{{ input.ticket }}",
       "input": {
         "type": "object",
         "properties": {

--- a/src/agent-run.test.ts
+++ b/src/agent-run.test.ts
@@ -242,6 +242,7 @@ describe("createAgentRun", () => {
     const step = createTextLogic({
       schemas: { input: z.object({}), output: z.object({}) },
       model: "test-model",
+      prompt: "work",
     });
     const agent = setupAgent({ schemas, actors: { step } });
     const machine = agent.createMachine({

--- a/src/decision.ts
+++ b/src/decision.ts
@@ -213,6 +213,9 @@ function resolveAllowedEventTypes(
  *
  * @example
  * ```ts
+ * import { createDecisionLogic } from '@statelyai/agent';
+ * import { z } from 'zod';
+ *
  * export const chooseMove = createDecisionLogic({
  *   schemas: { input: z.object({ playerHp: z.number(), enemyHp: z.number() }) },
  *   model: 'openai/gpt-5.4-mini',
@@ -224,10 +227,6 @@ function resolveAllowedEventTypes(
  *       : ['ATTACK', 'DEFEND', 'FLEE'],
  * });
  * ```
- *
- * @internal Not part of the public API (not exported from the package root).
- * State-local decisions use the `agent.decide` builtin invoke
- * (`src: 'agent.decide'`); this backs standalone/reusable decision tests.
  */
 export function createDecisionLogic<
   TInputSchema extends StandardSchemaV1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export type {
 } from "./setup-agent.js";
 export {
   AgentDecisionExhaustedError,
+  createDecisionLogic,
   renderDecisionAttempts,
   resolveDecision,
 } from "./decision.js";
@@ -19,6 +20,8 @@ export type {
   AgentDecisionRequest,
   AgentDecisionExecutor,
   DecisionAttempt,
+  // Return type of `createDecisionLogic`, so declaration emit can name it.
+  DecisionLogic,
   DecisionLogicConfig,
   ResolveDecisionOptions,
 } from "./decision.js";

--- a/src/machines/handoff.ts
+++ b/src/machines/handoff.ts
@@ -1,4 +1,3 @@
-import type { AnyStateMachine } from "xstate";
 import { setupAgent } from "../setup-agent.js";
 import {
   assertEntryNames,
@@ -9,24 +8,45 @@ import {
   machineActors,
   objectSchema,
   type PresetEntry,
+  type PresetMachine,
 } from "./internal.js";
 
 /** Config for {@link createHandoffMachine}. */
-export interface CreateHandoffMachineConfig {
+export interface CreateHandoffMachineConfig<
+  TAgents extends Record<string, PresetEntry> = Record<string, PresetEntry>,
+> {
   /** The peer agents, keyed by name. Each is an inline request or a child machine. */
-  agents: Record<string, PresetEntry>;
+  agents: TAgents;
   /** Which agent holds the mic at the start of a run. */
-  defaultActiveAgent: string;
+  defaultActiveAgent: keyof TAgents & string;
   /** Default model ref for request agents that declare none. */
   model?: string;
 }
 
 /** Context of a {@link createHandoffMachine} machine. */
-export type HandoffContext = {
+export type HandoffContext<TAgent extends string = string> = {
   message: string;
-  activeAgent: string;
+  activeAgent: TAgent;
   reply: unknown;
 };
+
+/** Machine input of a {@link createHandoffMachine} machine. */
+export type HandoffInput<TAgent extends string = string> = {
+  message: string;
+  activeAgent?: TAgent;
+};
+/** The events a {@link createHandoffMachine} machine accepts: one per peer agent. */
+export type HandoffEvent<TAgent extends string = string> = {
+  type: `transfer_to_${TAgent}`;
+  message?: string;
+};
+/** The machine {@link createHandoffMachine} returns. There is no final state, so it has no output. */
+export type HandoffMachine<TAgent extends string = string> = PresetMachine<
+  HandoffContext<TAgent>,
+  HandoffInput<TAgent>,
+  undefined,
+  HandoffEvent<TAgent>
+>;
 
 const contextSchema = objectSchema<HandoffContext>(
   { message: jsonString, activeAgent: jsonString, reply: jsonAny },
@@ -73,7 +93,9 @@ export function transferEventType(agent: string): string {
  * });
  * ```
  */
-export function createHandoffMachine(config: CreateHandoffMachineConfig): AnyStateMachine {
+export function createHandoffMachine<const TAgents extends Record<string, PresetEntry>>(
+  config: CreateHandoffMachineConfig<TAgents>,
+): HandoffMachine<keyof TAgents & string> {
   const { agents, defaultActiveAgent, model } = config;
   const names = Object.keys(agents);
   assertEntryNames("agent", names, ["routing", "waiting"]);
@@ -151,5 +173,5 @@ export function createHandoffMachine(config: CreateHandoffMachineConfig): AnySta
 
   const machine = agentSetup.createMachine(machineConfig);
 
-  return machine as unknown as AnyStateMachine;
+  return machine as unknown as HandoffMachine<keyof TAgents & string>;
 }

--- a/src/machines/index.ts
+++ b/src/machines/index.ts
@@ -10,29 +10,76 @@
  * See docs/machines-presets.md.
  */
 export { createToolLoopMachine } from "./tool-loop.js";
-export type { CreateToolLoopMachineConfig, ToolLoopContext } from "./tool-loop.js";
+export type {
+  CreateToolLoopMachineConfig,
+  ToolLoopContext,
+  ToolLoopInput,
+  ToolLoopMachine,
+  ToolLoopOutput,
+} from "./tool-loop.js";
 
 export { createSequentialMachine } from "./sequential.js";
 export type {
   CreateSequentialMachineConfig,
   SequentialContext,
+  SequentialInput,
+  SequentialMachine,
+  SequentialOutput,
   SequentialPromptArgs,
   SequentialStep,
 } from "./sequential.js";
 
 export { createRouterMachine, routeEventType } from "./router.js";
-export type { CreateRouterMachineConfig, RouterContext } from "./router.js";
+export type {
+  CreateRouterMachineConfig,
+  RouterContext,
+  RouterEvent,
+  RouterInput,
+  RouterMachine,
+  RouterOutput,
+} from "./router.js";
 
 export { createParallelMachine } from "./parallel.js";
-export type { CreateParallelMachineConfig, ParallelContext } from "./parallel.js";
+export type {
+  CreateParallelMachineConfig,
+  ParallelContext,
+  ParallelInput,
+  ParallelMachine,
+  ParallelOutput,
+} from "./parallel.js";
 
 export { createLoopMachine } from "./loop.js";
-export type { CreateLoopMachineConfig, LoopContext, LoopState } from "./loop.js";
+export type {
+  CreateLoopMachineConfig,
+  LoopContext,
+  LoopInput,
+  LoopMachine,
+  LoopOutput,
+  LoopState,
+} from "./loop.js";
 
 export { createSupervisorMachine, delegateEventType, FINISH_EVENT_TYPE } from "./supervisor.js";
-export type { CreateSupervisorMachineConfig, SupervisorContext } from "./supervisor.js";
+export type {
+  CreateSupervisorMachineConfig,
+  SupervisorContext,
+  SupervisorEvent,
+  SupervisorInput,
+  SupervisorMachine,
+  SupervisorOutput,
+} from "./supervisor.js";
 
 export { createHandoffMachine, transferEventType } from "./handoff.js";
-export type { CreateHandoffMachineConfig, HandoffContext } from "./handoff.js";
+export type {
+  CreateHandoffMachineConfig,
+  HandoffContext,
+  HandoffEvent,
+  HandoffInput,
+  HandoffMachine,
+} from "./handoff.js";
 
-export type { PresetEntry, PresetMachineEntry, PresetRequestEntry } from "./internal.js";
+export type {
+  PresetEntry,
+  PresetMachine,
+  PresetMachineEntry,
+  PresetRequestEntry,
+} from "./internal.js";

--- a/src/machines/internal.ts
+++ b/src/machines/internal.ts
@@ -1,5 +1,45 @@
-import type { AnyStateMachine } from "xstate";
+import type {
+  AnyActorRef,
+  AnyStateMachine,
+  EventObject,
+  MachineContext,
+  MetaObject,
+  StateMachine,
+  StateSchema,
+  StateValue,
+} from "xstate";
 import type { AgentTools, StandardSchemaV1 } from "../types.js";
+
+/**
+ * The machine type a preset factory returns: its context, event union, input
+ * and output are all concrete, so callers get typed `runAgent` input and
+ * output instead of `AnyStateMachine`. The remaining slots (children, state
+ * value/tags/config, source maps) are left permissive — a preset builds its
+ * states dynamically, so there is no literal state schema to infer.
+ *
+ * @internal
+ */
+export type PresetMachine<
+  TContext extends MachineContext,
+  TInput,
+  TOutput,
+  TEvent extends EventObject = EventObject,
+> = StateMachine<
+  TContext,
+  TEvent,
+  Record<string, AnyActorRef | undefined>,
+  StateValue,
+  string,
+  TInput,
+  TOutput,
+  EventObject,
+  MetaObject,
+  StateSchema,
+  any,
+  any,
+  any,
+  any
+>;
 
 /** The builtin inline text request every preset lowers a request entry to. */
 export const GENERATE_TEXT_SRC = "agent.generateText";

--- a/src/machines/loop.ts
+++ b/src/machines/loop.ts
@@ -1,4 +1,3 @@
-import type { AnyStateMachine } from "xstate";
 import { setupAgent } from "../setup-agent.js";
 import {
   entryInput,
@@ -10,6 +9,7 @@ import {
   jsonString,
   objectSchema,
   type PresetEntry,
+  type PresetMachine,
   type PresetMachineEntry,
 } from "./internal.js";
 
@@ -48,6 +48,13 @@ export type LoopContext = {
   last: unknown;
 };
 
+/** Machine input of a {@link createLoopMachine} machine. */
+export type LoopInput = { prompt: string };
+/** Machine output of a {@link createLoopMachine} machine. */
+export type LoopOutput = { iterations: number; results: unknown[]; last: unknown };
+/** The machine {@link createLoopMachine} returns. */
+export type LoopMachine = PresetMachine<LoopContext, LoopInput, LoopOutput>;
+
 const contextSchema = objectSchema<LoopContext>(
   { prompt: jsonString, iterations: jsonNumber, results: jsonArray, last: jsonAny },
   ["prompt", "iterations", "results"],
@@ -74,7 +81,7 @@ const outputSchema = objectSchema<{ iterations: number; results: unknown[]; last
  * });
  * ```
  */
-export function createLoopMachine(config: CreateLoopMachineConfig): AnyStateMachine {
+export function createLoopMachine(config: CreateLoopMachineConfig): LoopMachine {
   const { model, body, until, maxTurns } = config;
   if (!Number.isInteger(maxTurns) || maxTurns < 1) {
     throw new Error("createLoopMachine: maxTurns must be an integer >= 1.");
@@ -150,5 +157,5 @@ export function createLoopMachine(config: CreateLoopMachineConfig): AnyStateMach
 
   const machine = agentSetup.createMachine(machineConfig);
 
-  return machine as unknown as AnyStateMachine;
+  return machine as unknown as LoopMachine;
 }

--- a/src/machines/machines.test.ts
+++ b/src/machines/machines.test.ts
@@ -254,9 +254,14 @@ describe("createRouterMachine", () => {
   });
 
   test("rejects a fallback that is not a route", () => {
-    expect(() => createRouterMachine({ model: "quick", routes: { a: {} }, fallback: "b" })).toThrow(
-      /fallback 'b' is not a declared route/,
-    );
+    expect(() =>
+      createRouterMachine({
+        model: "quick",
+        routes: { a: {} },
+        // @ts-expect-error 'b' is not a declared route — the runtime check backs the type
+        fallback: "b",
+      }),
+    ).toThrow(/fallback 'b' is not a declared route/);
   });
 });
 
@@ -451,7 +456,65 @@ describe("createHandoffMachine", () => {
 
   test("rejects a default that is not a declared agent", () => {
     expect(() =>
-      createHandoffMachine({ agents: { a: { model: "quick" } }, defaultActiveAgent: "b" }),
+      createHandoffMachine({
+        agents: { a: { model: "quick" } },
+        // @ts-expect-error 'b' is not a declared agent — the runtime check backs the type
+        defaultActiveAgent: "b",
+      }),
     ).toThrow(/defaultActiveAgent 'b' is not a declared agent/);
+  });
+});
+
+describe("preset machine types", () => {
+  const { generateText } = mockGenerateText();
+
+  test("machine input is typed, not `any`", async () => {
+    const machine = createToolLoopMachine({ model: "quick" });
+    await expect(
+      runAgent(machine, {
+        // @ts-expect-error `prompt` is a string on this machine's input
+        input: { prompt: 123 },
+        executors: { generateText },
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("machine output is typed", async () => {
+    const machine = createLoopMachine({
+      model: "quick",
+      body: {},
+      until: ({ iterations }) => iterations >= 1,
+      maxTurns: 1,
+    });
+    const result = await runAgent(machine, {
+      input: { prompt: "go" },
+      executors: { generateText },
+    });
+    if (result.status === "done") {
+      const iterations: number = result.output.iterations;
+      expect(iterations).toBe(1);
+      // @ts-expect-error `missing` is not part of the loop output
+      expect(result.output.missing).toBeUndefined();
+    }
+  });
+
+  test("route and transfer events are typed from the declared keys", async () => {
+    const handoff = createHandoffMachine({
+      model: "quick",
+      defaultActiveAgent: "travel",
+      agents: { travel: {}, food: {} },
+    });
+    const first = await runAgent(handoff, {
+      input: { message: "hi" },
+      executors: { generateText },
+    });
+    await expect(
+      runAgent(handoff, {
+        snapshot: first.snapshot,
+        // @ts-expect-error 'transfer_to_nope' is not a declared agent transfer
+        event: { type: "transfer_to_nope" },
+        executors: { generateText },
+      }),
+    ).rejects.toThrow(/cannot resume with event 'transfer_to_nope'/);
   });
 });

--- a/src/machines/parallel.ts
+++ b/src/machines/parallel.ts
@@ -1,4 +1,3 @@
-import type { AnyStateMachine } from "xstate";
 import { setupAgent } from "../setup-agent.js";
 import {
   assertEntryNames,
@@ -9,6 +8,7 @@ import {
   machineActors,
   objectSchema,
   type PresetEntry,
+  type PresetMachine,
 } from "./internal.js";
 
 /** Config for {@link createParallelMachine}. */
@@ -24,6 +24,13 @@ export type ParallelContext = {
   prompt: string;
   results: Record<string, unknown>;
 };
+
+/** Machine input of a {@link createParallelMachine} machine. */
+export type ParallelInput = { prompt: string };
+/** Machine output of a {@link createParallelMachine} machine. */
+export type ParallelOutput = { results: Record<string, unknown> };
+/** The machine {@link createParallelMachine} returns. */
+export type ParallelMachine = PresetMachine<ParallelContext, ParallelInput, ParallelOutput>;
 
 const contextSchema = objectSchema<ParallelContext>({ prompt: jsonString, results: jsonRecord }, [
   "prompt",
@@ -55,7 +62,7 @@ const outputSchema = objectSchema<{ results: Record<string, unknown> }>({ result
  * });
  * ```
  */
-export function createParallelMachine(config: CreateParallelMachineConfig): AnyStateMachine {
+export function createParallelMachine(config: CreateParallelMachineConfig): ParallelMachine {
   const { model, branches } = config;
   const names = Object.keys(branches);
   assertEntryNames("branch", names, ["running", "done"]);
@@ -114,5 +121,5 @@ export function createParallelMachine(config: CreateParallelMachineConfig): AnyS
 
   const machine = agentSetup.createMachine(machineConfig);
 
-  return machine as unknown as AnyStateMachine;
+  return machine as unknown as ParallelMachine;
 }

--- a/src/machines/router.ts
+++ b/src/machines/router.ts
@@ -1,4 +1,3 @@
-import type { AnyStateMachine } from "xstate";
 import { setupAgent } from "../setup-agent.js";
 import {
   assertEntryNames,
@@ -12,26 +11,46 @@ import {
   objectSchema,
   renderEntryList,
   type PresetEntry,
+  type PresetMachine,
 } from "./internal.js";
 
 /** Config for {@link createRouterMachine}. */
-export interface CreateRouterMachineConfig {
+export interface CreateRouterMachineConfig<
+  TRoutes extends Record<string, PresetEntry> = Record<string, PresetEntry>,
+> {
   /** Model ref for the routing decision, and the default for request routes. */
   model: string;
   /** System prompt for the routing decision. */
   instructions?: string;
   /** The legal destinations, keyed by route name. Each is an inline request or a child machine. */
-  routes: Record<string, PresetEntry>;
+  routes: TRoutes;
   /** Route taken when the routing decision errors. Without it, a failed decision ends the run. */
-  fallback?: string;
+  fallback?: keyof TRoutes & string;
 }
 
 /** Context of a {@link createRouterMachine} machine. */
-export type RouterContext = {
+export type RouterContext<TRoute extends string = string> = {
   prompt: string;
-  route: string | null;
+  route: TRoute | null;
   result: unknown;
 };
+
+/** Machine input of a {@link createRouterMachine} machine. */
+export type RouterInput = { prompt: string };
+/** Machine output of a {@link createRouterMachine} machine. */
+export type RouterOutput<TRoute extends string = string> = {
+  route: TRoute | null;
+  result: unknown;
+};
+/** The events a {@link createRouterMachine} machine accepts: one per declared route. */
+export type RouterEvent<TRoute extends string = string> = { type: `ROUTE_${TRoute}` };
+/** The machine {@link createRouterMachine} returns. */
+export type RouterMachine<TRoute extends string = string> = PresetMachine<
+  RouterContext<TRoute>,
+  RouterInput,
+  RouterOutput<TRoute>,
+  RouterEvent<TRoute>
+>;
 
 const contextSchema = objectSchema<RouterContext>(
   { prompt: jsonString, route: { type: ["string", "null"] }, result: jsonAny },
@@ -67,7 +86,9 @@ export function routeEventType(route: string): string {
  * });
  * ```
  */
-export function createRouterMachine(config: CreateRouterMachineConfig): AnyStateMachine {
+export function createRouterMachine<const TRoutes extends Record<string, PresetEntry>>(
+  config: CreateRouterMachineConfig<TRoutes>,
+): RouterMachine<keyof TRoutes & string> {
   const { model, instructions, routes, fallback } = config;
   const names = Object.keys(routes);
   assertEntryNames("route", names, ["routing", "done"]);
@@ -145,5 +166,5 @@ export function createRouterMachine(config: CreateRouterMachineConfig): AnyState
 
   const machine = agentSetup.createMachine(machineConfig);
 
-  return machine as unknown as AnyStateMachine;
+  return machine as unknown as RouterMachine<keyof TRoutes & string>;
 }

--- a/src/machines/sequential.ts
+++ b/src/machines/sequential.ts
@@ -1,4 +1,3 @@
-import type { AnyStateMachine } from "xstate";
 import { setupAgent } from "../setup-agent.js";
 import type { AgentTools, StandardSchemaV1 } from "../types.js";
 import {
@@ -9,6 +8,7 @@ import {
   jsonString,
   objectSchema,
   requestInput,
+  type PresetMachine,
 } from "./internal.js";
 
 /** Arguments a {@link SequentialStep}'s `prompt` receives. */
@@ -54,6 +54,13 @@ export type SequentialContext = {
   previous: unknown;
 };
 
+/** Machine input of a {@link createSequentialMachine} machine. */
+export type SequentialInput = { prompt: string };
+/** Machine output of a {@link createSequentialMachine} machine. */
+export type SequentialOutput = { results: Record<string, unknown>; output: unknown };
+/** The machine {@link createSequentialMachine} returns. */
+export type SequentialMachine = PresetMachine<SequentialContext, SequentialInput, SequentialOutput>;
+
 const contextSchema = objectSchema<SequentialContext>(
   { prompt: jsonString, results: jsonRecord, previous: jsonAny },
   ["prompt", "results"],
@@ -82,7 +89,7 @@ const outputSchema = objectSchema<{ results: Record<string, unknown>; output: un
  * });
  * ```
  */
-export function createSequentialMachine(config: CreateSequentialMachineConfig): AnyStateMachine {
+export function createSequentialMachine(config: CreateSequentialMachineConfig): SequentialMachine {
   const { model, steps } = config;
   assertEntryNames(
     "step",
@@ -159,5 +166,5 @@ export function createSequentialMachine(config: CreateSequentialMachineConfig): 
 
   const machine = agentSetup.createMachine(machineConfig);
 
-  return machine as unknown as AnyStateMachine;
+  return machine as unknown as SequentialMachine;
 }

--- a/src/machines/supervisor.ts
+++ b/src/machines/supervisor.ts
@@ -1,4 +1,3 @@
-import type { AnyStateMachine } from "xstate";
 import { setupAgent } from "../setup-agent.js";
 import {
   assertEntryNames,
@@ -13,27 +12,46 @@ import {
   objectSchema,
   renderEntryList,
   type PresetEntry,
+  type PresetMachine,
 } from "./internal.js";
 
 /** Config for {@link createSupervisorMachine}. */
-export interface CreateSupervisorMachineConfig {
+export interface CreateSupervisorMachineConfig<
+  TWorkers extends Record<string, PresetEntry> = Record<string, PresetEntry>,
+> {
   /** Model ref for the supervising decision, and the default for request workers. */
   model: string;
   /** System prompt for the supervising decision. */
   instructions?: string;
   /** The workers the supervisor may delegate to, keyed by name. */
-  workers: Record<string, PresetEntry>;
+  workers: TWorkers;
   /** Hard upper bound on delegations, enforced by a guard. Default 6. */
   maxTurns?: number;
 }
 
 /** Context of a {@link createSupervisorMachine} machine. */
-export type SupervisorContext = {
+export type SupervisorContext<TWorker extends string = string> = {
   task: string;
   results: Record<string, unknown>;
   turns: number;
-  worker: string | null;
+  worker: TWorker | null;
 };
+
+/** Machine input of a {@link createSupervisorMachine} machine. */
+export type SupervisorInput = { task: string };
+/** Machine output of a {@link createSupervisorMachine} machine. */
+export type SupervisorOutput = { results: Record<string, unknown>; turns: number };
+/** The events a {@link createSupervisorMachine} machine accepts: one per worker, plus `FINISH`. */
+export type SupervisorEvent<TWorker extends string = string> =
+  | { type: `DELEGATE_${TWorker}` }
+  | { type: typeof FINISH_EVENT_TYPE };
+/** The machine {@link createSupervisorMachine} returns. */
+export type SupervisorMachine<TWorker extends string = string> = PresetMachine<
+  SupervisorContext<TWorker>,
+  SupervisorInput,
+  SupervisorOutput,
+  SupervisorEvent<TWorker>
+>;
 
 const contextSchema = objectSchema<SupervisorContext>(
   {
@@ -84,7 +102,9 @@ export const FINISH_EVENT_TYPE = "FINISH";
  * });
  * ```
  */
-export function createSupervisorMachine(config: CreateSupervisorMachineConfig): AnyStateMachine {
+export function createSupervisorMachine<const TWorkers extends Record<string, PresetEntry>>(
+  config: CreateSupervisorMachineConfig<TWorkers>,
+): SupervisorMachine<keyof TWorkers & string> {
   const { model, instructions, workers, maxTurns = 6 } = config;
   const names = Object.keys(workers);
   assertEntryNames("worker", names, ["supervising", "done"]);
@@ -186,7 +206,7 @@ export function createSupervisorMachine(config: CreateSupervisorMachineConfig): 
 
   const machine = agentSetup.createMachine(machineConfig);
 
-  return machine as unknown as AnyStateMachine;
+  return machine as unknown as SupervisorMachine<keyof TWorkers & string>;
 }
 
 // Renders the accumulated worker results for the next supervising decision.

--- a/src/machines/tool-loop.ts
+++ b/src/machines/tool-loop.ts
@@ -1,7 +1,12 @@
-import type { AnyStateMachine } from "xstate";
 import { setupAgent } from "../setup-agent.js";
 import type { AgentTools, StandardSchemaV1 } from "../types.js";
-import { GENERATE_TEXT_SRC, jsonAny, jsonString, objectSchema } from "./internal.js";
+import {
+  GENERATE_TEXT_SRC,
+  jsonAny,
+  jsonString,
+  objectSchema,
+  type PresetMachine,
+} from "./internal.js";
 
 /** Config for {@link createToolLoopMachine}. */
 export interface CreateToolLoopMachineConfig {
@@ -26,6 +31,13 @@ export type ToolLoopContext = {
   prompt: string;
   result: unknown;
 };
+
+/** Machine input of a {@link createToolLoopMachine} machine. */
+export type ToolLoopInput = { prompt: string };
+/** Machine output of a {@link createToolLoopMachine} machine. */
+export type ToolLoopOutput = { result: unknown };
+/** The machine {@link createToolLoopMachine} returns. */
+export type ToolLoopMachine = PresetMachine<ToolLoopContext, ToolLoopInput, ToolLoopOutput>;
 
 const contextSchema = objectSchema<ToolLoopContext>({ prompt: jsonString, result: jsonAny }, [
   "prompt",
@@ -55,7 +67,7 @@ const outputSchema = objectSchema<{ result: unknown }>({ result: jsonAny }, ["re
  * // Snapshots and log entries carry machine.version ("1") automatically.
  * ```
  */
-export function createToolLoopMachine(config: CreateToolLoopMachineConfig): AnyStateMachine {
+export function createToolLoopMachine(config: CreateToolLoopMachineConfig): ToolLoopMachine {
   const { model, instructions, tools, outputSchema: resultSchema, maxSteps } = config;
 
   const agentSetup = setupAgent({
@@ -96,5 +108,5 @@ export function createToolLoopMachine(config: CreateToolLoopMachineConfig): AnyS
     },
   });
 
-  return machine as unknown as AnyStateMachine;
+  return machine as unknown as ToolLoopMachine;
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -68,15 +68,102 @@ function isKnownPart(part: unknown): part is { type: string } {
   );
 }
 
+// Requires `field` on `part` to be a string; returns an error message, or undefined.
+function requireString(
+  part: Record<string, unknown>,
+  type: string,
+  field: string,
+): string | undefined {
+  return typeof part[field] === "string" ? undefined : `${type} part requires a string "${field}"`;
+}
+
+// Requires `field` on `part` to be present (any defined value); returns an error message, or undefined.
+function requireDefined(
+  part: Record<string, unknown>,
+  type: string,
+  field: string,
+): string | undefined {
+  return field in part && part[field] !== undefined
+    ? undefined
+    : `${type} part requires a "${field}" value`;
+}
+
+const TOOL_RESULT_OUTPUT_TYPES = new Set(["text", "json", "error-text", "error-json", "content"]);
+
+// Validates a `tool-result` part's `output`; returns an error message, or undefined.
+function validateToolResultOutput(output: unknown): string | undefined {
+  if (!output || typeof output !== "object" || Array.isArray(output)) {
+    return 'tool-result part requires an "output" object';
+  }
+  const record = output as Record<string, unknown>;
+  const outputType = record.type;
+  if (typeof outputType !== "string" || !TOOL_RESULT_OUTPUT_TYPES.has(outputType)) {
+    return `Unknown tool-result output type: ${JSON.stringify(outputType)}`;
+  }
+  if (outputType === "text" || outputType === "error-text") {
+    if (typeof record.value !== "string") {
+      return `tool-result output of type "${outputType}" requires a string "value"`;
+    }
+    return undefined;
+  }
+  if (outputType === "content") {
+    if (!Array.isArray(record.value)) {
+      return 'tool-result output of type "content" requires an array "value"';
+    }
+    for (const contentPart of record.value) {
+      const error = validatePart(contentPart);
+      if (error) {
+        return error;
+      }
+    }
+    return undefined;
+  }
+  // "json" | "error-json": any value, but the key must be present.
+  return "value" in record
+    ? undefined
+    : `tool-result output of type "${outputType}" requires a "value"`;
+}
+
+// Validates a single content part's required fields; returns an error message, or undefined.
+function validatePart(part: unknown): string | undefined {
+  if (!isKnownPart(part)) {
+    const type = part && typeof part === "object" ? (part as { type?: unknown }).type : undefined;
+    return `Unknown message part type: ${JSON.stringify(type)}`;
+  }
+  const record = part as unknown as Record<string, unknown>;
+  switch (record.type) {
+    case "text":
+      return requireString(record, "text", "text");
+    case "image":
+      return requireDefined(record, "image", "image");
+    case "file":
+      return requireDefined(record, "file", "data") ?? requireString(record, "file", "mediaType");
+    case "tool-call":
+      return (
+        requireString(record, "tool-call", "toolCallId") ??
+        requireString(record, "tool-call", "toolName") ??
+        ("input" in record ? undefined : 'tool-call part requires an "input" value')
+      );
+    case "tool-result":
+      return (
+        requireString(record, "tool-result", "toolCallId") ??
+        requireString(record, "tool-result", "toolName") ??
+        validateToolResultOutput(record.output)
+      );
+    default:
+      return undefined;
+  }
+}
+
 // Validates a message `content` array of parts; returns an error message, or undefined if valid.
 function validatePartsArray(content: unknown): string | undefined {
   if (!Array.isArray(content)) {
     return "Expected content to be a string or an array of parts";
   }
   for (const part of content) {
-    if (!isKnownPart(part)) {
-      const type = part && typeof part === "object" ? (part as { type?: unknown }).type : undefined;
-      return `Unknown message part type: ${JSON.stringify(type)}`;
+    const error = validatePart(part);
+    if (error) {
+      return error;
     }
   }
   return undefined;
@@ -86,7 +173,8 @@ function validatePartsArray(content: unknown): string | undefined {
  * A {@link StandardSchemaV1} validating an `AgentMessage[]` context field —
  * checks that every message has a known `role` (`system`/`user`/`assistant`/
  * `tool`) and that `content` is either a string (where the role allows it) or
- * an array of parts with a known `type`. Use it directly as a context
+ * an array of parts with a known `type` whose required fields are present and
+ * of the right primitive type (extra fields are allowed). Use it directly as a context
  * schema's `messages` field when authoring with `createAgentSchemas`.
  */
 export const messagesSchema: StandardSchemaV1<AgentMessage[]> = {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -56,16 +56,25 @@ export function appendMessages<
   });
 }
 
-// Recognized `AgentMessage` content part type tags.
-const KNOWN_PART_TYPES = new Set(["text", "image", "file", "tool-call", "tool-result"]);
+type MessagePartType = "text" | "image" | "file" | "tool-call" | "tool-result";
+
+// Recognized `AgentMessage` content part type tags, narrowed per role below.
+const KNOWN_PART_TYPES = new Set<MessagePartType>([
+  "text",
+  "image",
+  "file",
+  "tool-call",
+  "tool-result",
+]);
+const USER_PART_TYPES = new Set<MessagePartType>(["text", "image", "file"]);
+const ASSISTANT_PART_TYPES = new Set<MessagePartType>(["text", "file", "tool-call", "tool-result"]);
+const TOOL_PART_TYPES = new Set<MessagePartType>(["tool-result"]);
+const TOOL_RESULT_CONTENT_PART_TYPES = new Set<MessagePartType>(["text", "image"]);
 
 // True if `part` is an object with a recognized part `type`.
-function isKnownPart(part: unknown): part is { type: string } {
-  return (
-    !!part &&
-    typeof part === "object" &&
-    KNOWN_PART_TYPES.has((part as { type?: unknown }).type as string)
-  );
+function isKnownPart(part: unknown): part is { type: MessagePartType } {
+  const type = part && typeof part === "object" ? (part as { type?: unknown }).type : undefined;
+  return typeof type === "string" && KNOWN_PART_TYPES.has(type as MessagePartType);
 }
 
 // Requires `field` on `part` to be a string; returns an error message, or undefined.
@@ -77,15 +86,23 @@ function requireString(
   return typeof part[field] === "string" ? undefined : `${type} part requires a string "${field}"`;
 }
 
-// Requires `field` on `part` to be present (any defined value); returns an error message, or undefined.
-function requireDefined(
+function isMediaData(value: unknown): boolean {
+  return (
+    typeof value === "string" ||
+    value instanceof Uint8Array ||
+    value instanceof ArrayBuffer ||
+    value instanceof URL
+  );
+}
+
+function requireMediaData(
   part: Record<string, unknown>,
-  type: string,
-  field: string,
+  type: "image" | "file",
+  field: "image" | "data",
 ): string | undefined {
-  return field in part && part[field] !== undefined
+  return isMediaData(part[field])
     ? undefined
-    : `${type} part requires a "${field}" value`;
+    : `${type} part requires "${field}" to be a string, Uint8Array, ArrayBuffer, or URL`;
 }
 
 const TOOL_RESULT_OUTPUT_TYPES = new Set(["text", "json", "error-text", "error-json", "content"]);
@@ -111,33 +128,44 @@ function validateToolResultOutput(output: unknown): string | undefined {
       return 'tool-result output of type "content" requires an array "value"';
     }
     for (const contentPart of record.value) {
-      const error = validatePart(contentPart);
+      const error = validatePart(
+        contentPart,
+        TOOL_RESULT_CONTENT_PART_TYPES,
+        "tool-result output content",
+      );
       if (error) {
         return error;
       }
     }
     return undefined;
   }
-  // "json" | "error-json": any value, but the key must be present.
-  return "value" in record
+  // "json" | "error-json": any defined value, including null.
+  return record.value !== undefined
     ? undefined
     : `tool-result output of type "${outputType}" requires a "value"`;
 }
 
 // Validates a single content part's required fields; returns an error message, or undefined.
-function validatePart(part: unknown): string | undefined {
+function validatePart(
+  part: unknown,
+  allowedTypes: ReadonlySet<MessagePartType>,
+  location: string,
+): string | undefined {
   if (!isKnownPart(part)) {
     const type = part && typeof part === "object" ? (part as { type?: unknown }).type : undefined;
     return `Unknown message part type: ${JSON.stringify(type)}`;
+  }
+  if (!allowedTypes.has(part.type)) {
+    return `${location} does not allow "${part.type}" parts`;
   }
   const record = part as unknown as Record<string, unknown>;
   switch (record.type) {
     case "text":
       return requireString(record, "text", "text");
     case "image":
-      return requireDefined(record, "image", "image");
+      return requireMediaData(record, "image", "image");
     case "file":
-      return requireDefined(record, "file", "data") ?? requireString(record, "file", "mediaType");
+      return requireMediaData(record, "file", "data") ?? requireString(record, "file", "mediaType");
     case "tool-call":
       return (
         requireString(record, "tool-call", "toolCallId") ??
@@ -156,12 +184,16 @@ function validatePart(part: unknown): string | undefined {
 }
 
 // Validates a message `content` array of parts; returns an error message, or undefined if valid.
-function validatePartsArray(content: unknown): string | undefined {
+function validatePartsArray(
+  content: unknown,
+  allowedTypes: ReadonlySet<MessagePartType>,
+  location: string,
+): string | undefined {
   if (!Array.isArray(content)) {
     return "Expected content to be a string or an array of parts";
   }
   for (const part of content) {
-    const error = validatePart(part);
+    const error = validatePart(part, allowedTypes, location);
     if (error) {
       return error;
     }
@@ -173,9 +205,9 @@ function validatePartsArray(content: unknown): string | undefined {
  * A {@link StandardSchemaV1} validating an `AgentMessage[]` context field —
  * checks that every message has a known `role` (`system`/`user`/`assistant`/
  * `tool`) and that `content` is either a string (where the role allows it) or
- * an array of parts with a known `type` whose required fields are present and
- * of the right primitive type (extra fields are allowed). Use it directly as a context
- * schema's `messages` field when authoring with `createAgentSchemas`.
+ * an array of role-appropriate parts whose required fields and media payloads
+ * have the right runtime types (extra fields are allowed). Use it directly as
+ * a context schema's `messages` field when authoring with `createAgentSchemas`.
  */
 export const messagesSchema: StandardSchemaV1<AgentMessage[]> = {
   "~standard": {
@@ -210,22 +242,22 @@ export const messagesSchema: StandardSchemaV1<AgentMessage[]> = {
         }
 
         if (role === "tool") {
-          const error =
-            validatePartsArray(content) ??
-            ((content as Array<{ type?: unknown }>).some((part) => part.type !== "tool-result")
-              ? "tool message content must contain only tool-result parts"
-              : undefined);
+          const error = validatePartsArray(content, TOOL_PART_TYPES, "tool message content");
           if (error) {
             return { issues: [{ message: error }] };
           }
           continue;
         }
 
-        // user | assistant: string or a parts array
+        // user | assistant: string or a role-appropriate parts array
         if (typeof content === "string") {
           continue;
         }
-        const error = validatePartsArray(content);
+        const error = validatePartsArray(
+          content,
+          role === "user" ? USER_PART_TYPES : ASSISTANT_PART_TYPES,
+          `${role} message content`,
+        );
         if (error) {
           return { issues: [{ message: error }] };
         }

--- a/src/run-agent.test.ts
+++ b/src/run-agent.test.ts
@@ -443,6 +443,7 @@ describe("runAgent", () => {
         output: z.number(),
       },
       model: "test-model",
+      prompt: "step",
     });
 
     const agent = setupAgent({ schemas, actors: { step } });
@@ -491,6 +492,7 @@ describe("runAgent", () => {
     const step = createTextLogic({
       schemas: { input: z.object({}), output: z.number() },
       model: "test-model",
+      prompt: "step",
     });
 
     const agent = setupAgent({ schemas, actors: { step } });
@@ -551,6 +553,7 @@ describe("runAgent", () => {
     const step = createTextLogic({
       schemas: { input: z.object({}), output: z.object({}) },
       model: "test-model",
+      prompt: "work",
     });
     const agent = setupAgent({ schemas, actors: { step } });
     const machine = agent.createMachine({
@@ -588,6 +591,7 @@ describe("runAgent", () => {
     const step = createTextLogic({
       schemas: { input: z.object({}), output: z.object({}) },
       model: "test-model",
+      prompt: "work",
     });
     const agent = setupAgent({ schemas, actors: { step } });
     const machine = agent.createMachine({
@@ -628,6 +632,7 @@ describe("runAgent", () => {
     const step = createTextLogic({
       schemas: { input: z.object({}), output: z.object({}) },
       model: "test-model",
+      prompt: "work",
     });
     const agent = setupAgent({ schemas, actors: { step } });
     const machine = agent.createMachine({
@@ -785,6 +790,7 @@ describe("runAgent", () => {
         mode: "stream",
         schemas: { input: z.object({}), output: z.string() },
         model: "test-model",
+        prompt: "summarize",
       });
       const agent = setupAgent({
         schemas: createAgentSchemas({ context: z.object({}), input: z.object({}) }),
@@ -2828,6 +2834,7 @@ describe("runAgent error cause split", () => {
     const step = createTextLogic({
       schemas: { input: z.object({}), output: z.object({}) },
       model: "test-model",
+      prompt: "work",
     });
     const agent = setupAgent({ schemas, actors: { step } });
     const machine = agent.createMachine({

--- a/src/setup-agent.test.ts
+++ b/src/setup-agent.test.ts
@@ -929,6 +929,115 @@ describe("setupAgent", () => {
     expect(result.issues).toBeUndefined();
   });
 
+  test.each([
+    {
+      role: "user",
+      part: { type: "tool-call", toolCallId: "call_1", toolName: "lookup", input: {} },
+      expected: /user message content does not allow "tool-call" parts/i,
+    },
+    {
+      role: "assistant",
+      part: { type: "image", image: "https://example.com/image.png" },
+      expected: /assistant message content does not allow "image" parts/i,
+    },
+    {
+      role: "tool",
+      part: { type: "text", text: "hello" },
+      expected: /tool message content does not allow "text" parts/i,
+    },
+  ])("messagesSchema rejects a $role message's disallowed part", ({ role, part, expected }) => {
+    const result = messagesSchema["~standard"].validate([{ role, content: [part] }]);
+
+    expect(result.issues?.[0]?.message).toMatch(expected);
+  });
+
+  test("messagesSchema rejects disallowed nested tool-result content", () => {
+    const result = messagesSchema["~standard"].validate([
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            output: {
+              type: "content",
+              value: [{ type: "file", data: "document", mediaType: "text/plain" }],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.issues?.[0]?.message).toMatch(
+      /tool-result output content does not allow "file" parts/i,
+    );
+  });
+
+  test.each([
+    { type: "image", image: 42 },
+    { type: "file", data: { bytes: [] }, mediaType: "application/octet-stream" },
+  ])("messagesSchema rejects an invalid $type media payload", (part) => {
+    const result = messagesSchema["~standard"].validate([{ role: "user", content: [part] }]);
+
+    expect(result.issues?.[0]?.message).toMatch(/string, Uint8Array, ArrayBuffer, or URL/i);
+  });
+
+  test("messagesSchema accepts all supported media payloads", () => {
+    const result = messagesSchema["~standard"].validate([
+      {
+        role: "user",
+        content: [
+          { type: "image", image: "https://example.com/image.png" },
+          { type: "image", image: new Uint8Array([1]) },
+          { type: "image", image: new ArrayBuffer(1) },
+          { type: "file", data: new URL("https://example.com/file.txt"), mediaType: "text/plain" },
+        ],
+      },
+    ]);
+
+    expect(result.issues).toBeUndefined();
+  });
+
+  test.each(["json", "error-json"] as const)(
+    "messagesSchema rejects undefined %s output",
+    (type) => {
+      const result = messagesSchema["~standard"].validate([
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call_1",
+              toolName: "lookup",
+              output: { type, value: undefined },
+            },
+          ],
+        },
+      ]);
+
+      expect(result.issues?.[0]?.message).toMatch(/requires a "value"/i);
+    },
+  );
+
+  test.each(["json", "error-json"] as const)("messagesSchema accepts null %s output", (type) => {
+    const result = messagesSchema["~standard"].validate([
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            output: { type, value: null },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.issues).toBeUndefined();
+  });
+
   test("messagesSchema rejects an unknown role", () => {
     const result = messagesSchema["~standard"].validate([{ role: "developer", content: "hi" }]);
 

--- a/src/setup-agent.test.ts
+++ b/src/setup-agent.test.ts
@@ -948,6 +948,72 @@ describe("setupAgent", () => {
     expect(result.issues![0]!.message).toMatch(/unknown message part type/i);
   });
 
+  test("messagesSchema rejects a text part missing its text", () => {
+    const result = messagesSchema["~standard"].validate([
+      { role: "user", content: [{ type: "text" }] },
+    ]);
+
+    expect(result.issues).toBeDefined();
+    expect(result.issues![0]!.message).toMatch(/text part requires a string "text"/i);
+  });
+
+  test("messagesSchema accepts a text part with extra fields", () => {
+    const result = messagesSchema["~standard"].validate([
+      { role: "user", content: [{ type: "text", text: "hi", extra: 1 }] },
+    ]);
+
+    expect(result.issues).toBeUndefined();
+  });
+
+  test("messagesSchema rejects a malformed tool-call part", () => {
+    const result = messagesSchema["~standard"].validate([
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "call_1", input: {} }],
+      },
+    ]);
+
+    expect(result.issues).toBeDefined();
+    expect(result.issues![0]!.message).toMatch(/tool-call part requires a string "toolName"/i);
+  });
+
+  test("messagesSchema rejects a tool-result part with a malformed output", () => {
+    const result = messagesSchema["~standard"].validate([
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            output: { type: "text" },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.issues).toBeDefined();
+    expect(result.issues![0]!.message).toMatch(/requires a string "value"/i);
+  });
+
+  test("messagesSchema accepts a valid tool-result part", () => {
+    const result = messagesSchema["~standard"].validate([
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            output: { type: "text", value: "done" },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.issues).toBeUndefined();
+  });
+
   test("authors reusable text actors with typed input and output", async () => {
     const getSummary = createTextLogic({
       mode: "generate",

--- a/src/text-logic.test.ts
+++ b/src/text-logic.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { createActor, toPromise } from "xstate";
 import {
@@ -140,7 +140,7 @@ describe('createTextLogic({ mode: "stream" })', () => {
       executeAgentTextRequest(
         "stream",
         "myStream",
-        { model: "test-model" },
+        { model: "test-model", prompt: "go" },
         { generateText: async () => ({ output: "nope" }) },
       ),
     ).rejects.toThrow(/no executor.*stream.*'myStream'/i);
@@ -657,9 +657,9 @@ describe("agent text request input sources", () => {
   });
 
   test("rejects a request with neither", () => {
-    expect(() =>
-      generateText.request({ model: "test-model" } as AgentTextRequest),
-    ).toThrow(/has neither a non-empty `prompt` nor `messages`/);
+    expect(() => generateText.request({ model: "test-model" } as AgentTextRequest)).toThrow(
+      /has neither a non-empty `prompt` nor `messages`/,
+    );
   });
 
   test("accepts a prompt-only request", () => {
@@ -688,5 +688,41 @@ describe("agent text request input sources", () => {
     expect(() => both.request(undefined as never)).toThrow(
       /'both' has both a non-empty `prompt` and `messages`/,
     );
+  });
+
+  test("createTextLogic lowering throws when neither source resolves", () => {
+    const neither = createTextLogic({
+      name: "neither",
+      model: "test-model",
+    });
+
+    expect(() => neither.request(undefined as never)).toThrow(
+      /'neither' has neither a non-empty `prompt` nor `messages`/,
+    );
+  });
+
+  test.each([
+    {
+      name: "both",
+      input: {
+        name: "both",
+        model: "test-model",
+        prompt: "Tell a joke.",
+        messages: [{ role: "user" as const, content: "Tell a joke." }],
+      },
+      error: /'both' has both a non-empty `prompt` and `messages`/,
+    },
+    {
+      name: "neither",
+      input: { name: "neither", model: "test-model" },
+      error: /'neither' has neither a non-empty `prompt` nor `messages`/,
+    },
+  ])("direct execution rejects a request with $name source", async ({ name, input, error }) => {
+    const generateText = vi.fn(async () => ({ output: "unreachable" }));
+
+    await expect(
+      executeAgentTextRequest("generate", name, input, { generateText }),
+    ).rejects.toThrow(error);
+    expect(generateText).not.toHaveBeenCalled();
   });
 });

--- a/src/text-logic.test.ts
+++ b/src/text-logic.test.ts
@@ -14,6 +14,7 @@ import { bindRequestExecutor, parseModelRef, parseStructuredEnvelope } from "./i
 import { type AgentRequest } from "./index.js";
 import {
   buildEnvelopeSchema,
+  builtinTextActors,
   executeAgentTextRequest,
   type AgentRequestExecutorInfo,
 } from "./text-logic.js";
@@ -636,5 +637,56 @@ describe("createTextLogic schema default typing", () => {
     });
 
     expect(typeof setupWithDefaults.requests.tellJoke.execute).toBe("function");
+  });
+});
+
+// `prompt` and `messages` are mutually exclusive at runtime: exactly one input
+// source per text request, matching what AgentExecutorTextRequest types.
+describe("agent text request input sources", () => {
+  const generateText = builtinTextActors["agent.generateText"];
+
+  test("rejects a request with both a non-empty prompt and non-empty messages", () => {
+    expect(() =>
+      generateText.request({
+        name: "tellJoke",
+        model: "test-model",
+        prompt: "Tell a joke.",
+        messages: [{ role: "user", content: "Tell a joke." }],
+      } as AgentTextRequest),
+    ).toThrow(/'tellJoke' has both a non-empty `prompt` and `messages`/);
+  });
+
+  test("rejects a request with neither", () => {
+    expect(() =>
+      generateText.request({ model: "test-model" } as AgentTextRequest),
+    ).toThrow(/has neither a non-empty `prompt` nor `messages`/);
+  });
+
+  test("accepts a prompt-only request", () => {
+    expect(
+      generateText.request({ model: "test-model", prompt: "Hi" } as AgentTextRequest).prompt,
+    ).toBe("Hi");
+  });
+
+  test("accepts a messages-only request", () => {
+    expect(
+      generateText.request({
+        model: "test-model",
+        messages: [{ role: "user", content: "Hi" }],
+      } as AgentTextRequest).messages,
+    ).toHaveLength(1);
+  });
+
+  test("createTextLogic lowering throws when both sources resolve", () => {
+    const both = createTextLogic({
+      name: "both",
+      model: "test-model",
+      prompt: () => "Tell a joke.",
+      messages: () => [{ role: "user" as const, content: "Tell a joke." }],
+    });
+
+    expect(() => both.request(undefined as never)).toThrow(
+      /'both' has both a non-empty `prompt` and `messages`/,
+    );
   });
 });

--- a/src/text-logic.ts
+++ b/src/text-logic.ts
@@ -223,10 +223,38 @@ export type BuiltinAgentActors<TEvent extends string = string, TModel extends st
   >;
 };
 
+// Returns the exclusivity error message for a request that resolved both a
+// non-empty `prompt` and a non-empty `messages` array, or `undefined` when the
+// request is fine. Shared by `agentTextInputSchema` and `createTextLogic`'s
+// lowering so config authors hit the same error as direct callers.
+function textRequestSourceIssue(request: {
+  name?: string;
+  prompt?: unknown;
+  messages?: unknown;
+}): string | undefined {
+  const hasPrompt = typeof request.prompt === "string" && request.prompt.length > 0;
+  const hasMessages = Array.isArray(request.messages) && request.messages.length > 0;
+  const label = request.name ? ` '${request.name}'` : "";
+
+  if (hasPrompt && hasMessages) {
+    return (
+      `Agent text request${label} has both a non-empty \`prompt\` and \`messages\` — ` +
+      "provide exactly one so the model has a single input source."
+    );
+  }
+  if (!hasPrompt && !hasMessages) {
+    return (
+      `Agent text request${label} has neither a non-empty \`prompt\` nor \`messages\` — ` +
+      "provide at least one so the model has something to respond to."
+    );
+  }
+  return undefined;
+}
+
 // Input schema for the `agent.generateText`/`agent.streamText` builtins: an
-// object with a string `model` AND at least one input source — a non-empty
+// object with a string `model` AND exactly one input source — a non-empty
 // `prompt` or a non-empty `messages` array — so the model is never called with
-// nothing to respond to.
+// nothing to respond to, and never with two competing sources.
 const agentTextInputSchema: StandardSchemaV1<AgentTextRequest> = {
   "~standard": {
     version: 1,
@@ -239,19 +267,9 @@ const agentTextInputSchema: StandardSchemaV1<AgentTextRequest> = {
       if (typeof request.model !== "string") {
         return { issues: [{ message: "Expected agent text input with a string `model`" }] };
       }
-      const hasPrompt = typeof request.prompt === "string" && request.prompt.length > 0;
-      const hasMessages = Array.isArray(request.messages) && request.messages.length > 0;
-      if (!hasPrompt && !hasMessages) {
-        const label = request.name ? ` '${request.name}'` : "";
-        return {
-          issues: [
-            {
-              message:
-                `Agent text request${label} has neither a non-empty \`prompt\` nor \`messages\` — ` +
-                "provide at least one so the model has something to respond to.",
-            },
-          ],
-        };
+      const issue = textRequestSourceIssue(request);
+      if (issue) {
+        return { issues: [{ message: issue }] };
       }
       return { value: request };
     },
@@ -546,12 +564,25 @@ export function createTextLogic<
     const parsedInput = validateSchemaSync<TInput>(schemas.input, input);
     const args = { input: parsedInput };
 
+    const name = resolveTextLogicValue(config.name, args);
+    const prompt = resolveTextLogicValue(config.prompt, args);
+    const messages = resolveTextLogicValue(config.messages, args);
+    const bothSources =
+      typeof prompt === "string" &&
+      prompt.length > 0 &&
+      Array.isArray(messages) &&
+      messages.length > 0;
+
+    if (bothSources) {
+      throw new Error(textRequestSourceIssue({ name, prompt, messages })!);
+    }
+
     return {
-      name: resolveTextLogicValue(config.name, args),
+      name,
       model: resolveTextLogicValue(config.model, args)!,
       system: resolveTextLogicValue(config.system, args),
-      prompt: resolveTextLogicValue(config.prompt, args),
-      messages: resolveTextLogicValue(config.messages, args),
+      prompt,
+      messages,
       tools: resolveTextLogicValue(config.tools, args),
       toolChoice: resolveTextLogicValue(config.toolChoice, args),
       outputSchema: schemas.output,
@@ -990,7 +1021,9 @@ export async function executeAgentTextRequest(
 
   // The runtime object is a plain lowered request; the cast bridges to the
   // executor-facing type (see AgentExecutorTextRequest — prompt/messages are
-  // typed as mutually exclusive there, which core guarantees at runtime).
+  // typed as mutually exclusive there, which core enforces at runtime: both
+  // agentTextInputSchema and createTextLogic's lowering reject a request that
+  // carries a non-empty `prompt` and a non-empty `messages` array).
   const raw = await executor(request as AgentExecutorTextRequest, info);
   return {
     output: await normalizeGeneratorResult(raw, id, {

--- a/src/text-logic.ts
+++ b/src/text-logic.ts
@@ -567,14 +567,10 @@ export function createTextLogic<
     const name = resolveTextLogicValue(config.name, args);
     const prompt = resolveTextLogicValue(config.prompt, args);
     const messages = resolveTextLogicValue(config.messages, args);
-    const bothSources =
-      typeof prompt === "string" &&
-      prompt.length > 0 &&
-      Array.isArray(messages) &&
-      messages.length > 0;
+    const sourceIssue = textRequestSourceIssue({ name, prompt, messages });
 
-    if (bothSources) {
-      throw new Error(textRequestSourceIssue({ name, prompt, messages })!);
+    if (sourceIssue) {
+      throw new Error(sourceIssue);
     }
 
     return {
@@ -1011,6 +1007,12 @@ export async function executeAgentTextRequest(
       ...tools,
     },
   };
+  const sourceIssue = textRequestSourceIssue(request);
+
+  if (sourceIssue) {
+    throw new Error(sourceIssue);
+  }
+
   const executor = mode === "stream" ? executors.streamText : executors.generateText;
 
   if (!executor) {
@@ -1021,9 +1023,8 @@ export async function executeAgentTextRequest(
 
   // The runtime object is a plain lowered request; the cast bridges to the
   // executor-facing type (see AgentExecutorTextRequest — prompt/messages are
-  // typed as mutually exclusive there, which core enforces at runtime: both
-  // agentTextInputSchema and createTextLogic's lowering reject a request that
-  // carries a non-empty `prompt` and a non-empty `messages` array).
+  // typed as mutually exclusive there, which core enforces at runtime through
+  // agentTextInputSchema, createTextLogic's lowering, and this direct boundary.
   const raw = await executor(request as AgentExecutorTextRequest, info);
   return {
     output: await normalizeGeneratorResult(raw, id, {

--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -359,6 +359,7 @@ describe("lintAgentMachine — each check fires on a crafted bad machine", () =>
     const inlineLogic = createTextLogic({
       schemas: { input: z.object({}), output: z.string() },
       model: "m",
+      prompt: "work",
     });
     const agent = setupAgent({
       context: z.object({}),


### PR DESCRIPTION
Four contract fixes from the API simplification audit:

- **Prompt/messages exclusivity**: agent text requests now error when both a non-empty `prompt` and `messages` are supplied (previously the adapter silently preferred `messages`). Enforced in the builtin input schema and `createTextLogic` lowering; the stale "core guarantees at runtime" comment now names the enforcement points. Decisions are intentionally exempt — both fields are legitimately optional there.
- **`createDecisionLogic` published**: exported from the root with its `DecisionLogic` return type, matching the already-exported `DecisionLogicConfig`. Docs subsection added to `docs/decisions.md`.
- **Typed preset factories**: all seven machine presets return concrete machine types instead of `AnyStateMachine`; router/supervisor/handoff are generic over their maps with per-name event unions. `{ prompt: 123 }` input is now a compile error (`@ts-expect-error` tests included). No runtime changes; `tsdown` + dts-consumer fixture pass.
- **Deeper `messagesSchema`**: per-part required-field validation (text/image/file/tool-call/tool-result incl. the output envelope, recursive for `content` outputs). Extra fields still allowed.

Touched test files: 141/141 passing. Typecheck clean outside pre-existing `src/ai-sdk/*` drift from the older installed AI SDK.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/agent/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reusable decision logic is now publicly available.
  - Preset machine factories provide stronger typing for inputs, outputs, events, routes, workers, and agent names.
  - Expanded public type exports improve editor support and compile-time guidance.

- **Bug Fixes**
  - Text requests now require exactly one of `prompt` or `messages`.
  - Message validation now checks role-specific parts, required fields, media types, nested tool results, and defined JSON outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->