### PR TITLE
docs: restore reusable decision guidance

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -151,4 +151,4 @@ These map LangGraph, Burr, and CrewAI Flow patterns onto XState. The dedicated p
 
 <!-- setupAgent config keys and decision authoring from src/setup-agent.ts and src/decision.ts -->
 
-New examples should use `createTextLogic(...)` for reusable LLM work and `setupAgent({ schemas, actors, requests })` for schema-first machine authoring. Decisions are authored inline in states via `src: 'agent.decide'` (state-local); to reuse one across states, share the _input builder_ function (a `({ context }) => ({ model, system, prompt, allowedEvents })` fn), not an actor. There is no `decisions:` key on `setupAgent`.
+New examples should use `createTextLogic(...)` for reusable LLM work and `setupAgent({ schemas, actors, requests })` for schema-first machine authoring. Author one-off decisions inline with `src: 'agent.decide'`. For reusable decisions, register `createDecisionLogic(...)` under `actors`, or share the input builder function. There is no `decisions:` key on `setupAgent`.


### PR DESCRIPTION
## Summary

- correct the example-authoring guidance for reusable decisions
- point authors to `createDecisionLogic(...)` actors or shared input builders
- retain the absence of a `decisions:` setup key

## Validation

- `pnpm docs:check` (118 checked snippets, 0 failures)
- `pnpm exec oxfmt --check examples/README.md`
- repository-wide local-link scan (623 targets, 0 misses)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reusable decision examples to clarify that decision logic can be registered alongside input-builder functions.
  * Clarified that inline decisions use the standard decision source and that agent setup does not require a separate decisions section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->