### PR TITLE
Demo design pass: viz first-load fixes, theme handling, chat chrome cleanup

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -19,7 +19,7 @@
     "@fontsource-variable/geist-mono": "^5.3.0",
     "@shadcn/react": "^0.2.1",
     "@statelyai/agent": "workspace:*",
-    "@statelyai/sdk": "^0.22.1",
+    "@statelyai/sdk": "^0.26.1",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-start": "^1.168.49",
     "@xstate/store": "^4.2.3",

--- a/demo/src/components/app-panel.tsx
+++ b/demo/src/components/app-panel.tsx
@@ -130,15 +130,9 @@ function messagesFromTurns(turns: Turn[], liveSteps: TraceStep[]): ThreadMessage
     const userMessage: ThreadMessageLike = {
       id: `turn-${turn.id}-user`,
       role: "user",
-      content: [
-        {
-          type: "text",
-          text:
-            turn.role === "action" && turn.eventType
-              ? `${turn.input}\n\n\`${turn.eventType}\``
-              : turn.input,
-        },
-      ],
+      // The transition log below already names the event (`APPROVE → approved`),
+      // so the bubble carries only the human-readable action label.
+      content: [{ type: "text", text: turn.input }],
     };
 
     if (turn.status === "loading") {
@@ -269,7 +263,7 @@ export function AppPanel({
   });
 
   const Welcome = () => (
-    <div className="aui-demo-welcome mx-auto flex w-full max-w-md flex-col gap-4 px-4">
+    <div className="aui-demo-welcome mx-auto my-auto flex w-full max-w-md flex-col gap-4 px-4 py-8">
       {intro}
       {starters.length ? (
         <div
@@ -283,7 +277,7 @@ export function AppPanel({
               variant="ghost"
               disabled={loading || !hydrated}
               onClick={starter.onStart}
-              className="aui-thread-welcome-suggestion text-foreground hover:bg-muted border-border/60 h-auto max-w-full gap-1.5 rounded-xl border px-3.5 py-1.5 text-center text-sm font-normal whitespace-normal transition-colors sm:rounded-full sm:whitespace-nowrap"
+              className="aui-thread-welcome-suggestion text-foreground hover:bg-muted border-border/60 h-auto max-w-full gap-1.5 rounded-xl border px-3.5 py-1.5 text-center text-sm font-normal whitespace-normal transition-colors sm:rounded-full"
             >
               {starter.label}
             </Button>
@@ -291,6 +285,9 @@ export function AppPanel({
         </div>
       ) : null}
       {startForm ? <StartFormCard schema={startForm.schema} onStart={startForm.onStart} /> : null}
+      <p className="chat-intro__hint">
+        The machine on the right updates with every reply.
+      </p>
     </div>
   );
   // The current wait's own checkpoint is shown but not rewindable; earlier

--- a/demo/src/components/assistant-ui/thread.tsx
+++ b/demo/src/components/assistant-ui/thread.tsx
@@ -24,11 +24,9 @@ import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
-  ActionBarMorePrimitive,
   ActionBarPrimitive,
   AuiIf,
   type AssistantState,
-  BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
   groupPartByType,
@@ -41,14 +39,8 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   CheckIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
   CopyIcon,
-  DownloadIcon,
   MicIcon,
-  MoreHorizontalIcon,
-  PencilIcon,
-  RefreshCwIcon,
   SquareIcon,
 } from "lucide-react";
 import {
@@ -152,9 +144,7 @@ const ThreadMessage: FC = () => {
   const { AssistantMessage: AssistantMessageComponent = AssistantMessage } =
     useContext(ThreadComponentsContext);
   const role = useAuiState((s) => s.message.role);
-  const isEditing = useAuiState((s) => s.message.composer.isEditing);
 
-  if (isEditing) return <EditComposer />;
   if (role === "user") return <UserMessage />;
   return <AssistantMessageComponent />;
 };
@@ -391,7 +381,6 @@ const AssistantMessage: FC = () => {
         data-slot="aui_assistant-message-footer"
         className={cn("ms-2 flex items-center", ACTION_BAR_HEIGHT)}
       >
-        <BranchPicker />
         <AssistantActionBar />
       </div>
     </MessagePrimitive.Root>
@@ -413,31 +402,6 @@ const AssistantActionBar: FC = () => {
           <CopyIcon className="animate-in zoom-in-75 fade-in duration-150" />
         </AuiIf>
       </ActionBarPrimitive.Copy>
-      <ActionBarPrimitive.Reload render={<TooltipIconButton tooltip="Refresh" />}>
-        <RefreshCwIcon />
-      </ActionBarPrimitive.Reload>
-      <ActionBarMorePrimitive.Root>
-        <ActionBarMorePrimitive.Trigger
-          render={<TooltipIconButton tooltip="More" className="data-[state=open]:bg-accent" />}
-        >
-          <MoreHorizontalIcon />
-        </ActionBarMorePrimitive.Trigger>
-        <ActionBarMorePrimitive.Content
-          side="bottom"
-          align="start"
-          sideOffset={6}
-          className="aui-action-bar-more-content bg-popover/95 text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-xl border p-1.5 shadow-lg backdrop-blur-sm"
-        >
-          <ActionBarPrimitive.ExportMarkdown
-            render={
-              <ActionBarMorePrimitive.Item className="aui-action-bar-more-item hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground flex cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none" />
-            }
-          >
-            <DownloadIcon className="size-4" />
-            Export as Markdown
-          </ActionBarPrimitive.ExportMarkdown>
-        </ActionBarMorePrimitive.Content>
-      </ActionBarMorePrimitive.Root>
     </ActionBarPrimitive.Root>
   );
 };
@@ -455,80 +419,8 @@ const UserMessage: FC = () => {
         <div className="aui-user-message-content peer bg-muted text-foreground rounded-xl px-4 py-2 wrap-break-word empty:hidden">
           <MessagePrimitive.Parts />
         </div>
-        <div className="aui-user-action-bar-wrapper absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-2 peer-empty:hidden rtl:translate-x-full">
-          <UserActionBar />
-        </div>
       </div>
 
-      <BranchPicker
-        data-slot="aui_user-branch-picker"
-        className="col-span-full col-start-1 row-start-3 -me-1 justify-end"
-      />
     </MessagePrimitive.Root>
-  );
-};
-
-const UserActionBar: FC = () => {
-  return (
-    <ActionBarPrimitive.Root
-      hideWhenRunning
-      autohide="not-last"
-      className="aui-user-action-bar-root flex flex-col items-end"
-    >
-      <ActionBarPrimitive.Edit
-        render={<TooltipIconButton tooltip="Edit" className="aui-user-action-edit" />}
-      >
-        <PencilIcon />
-      </ActionBarPrimitive.Edit>
-    </ActionBarPrimitive.Root>
-  );
-};
-
-const EditComposer: FC = () => {
-  return (
-    <MessagePrimitive.Root
-      data-slot="aui_edit-composer-wrapper"
-      className="flex flex-col px-2 [contain-intrinsic-size:auto_200px] [content-visibility:auto]"
-    >
-      <ComposerPrimitive.Root className="aui-edit-composer-root border-border/60 dark:border-muted-foreground/15 ms-auto flex w-full max-w-[85%] flex-col rounded-(--composer-radius) border bg-(--composer-bg) shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] dark:shadow-none">
-        <ComposerPrimitive.Input
-          className="aui-edit-composer-input text-foreground min-h-14 w-full resize-none bg-transparent px-4 pt-3 pb-1 text-base outline-none"
-          autoFocus
-        />
-        <div className="aui-edit-composer-footer mx-2.5 mb-2.5 flex items-center gap-1.5 self-end">
-          <ComposerPrimitive.Cancel
-            render={<Button variant="ghost" size="sm" className="h-8 rounded-full px-3.5" />}
-          >
-            Cancel
-          </ComposerPrimitive.Cancel>
-          <ComposerPrimitive.Send render={<Button size="sm" className="h-8 rounded-full px-3.5" />}>
-            Update
-          </ComposerPrimitive.Send>
-        </div>
-      </ComposerPrimitive.Root>
-    </MessagePrimitive.Root>
-  );
-};
-
-const BranchPicker: FC<BranchPickerPrimitive.Root.Props> = ({ className, ...rest }) => {
-  return (
-    <BranchPickerPrimitive.Root
-      hideWhenSingleBranch
-      className={cn(
-        "aui-branch-picker-root text-muted-foreground -ms-2 me-2 inline-flex items-center text-xs",
-        className,
-      )}
-      {...rest}
-    >
-      <BranchPickerPrimitive.Previous render={<TooltipIconButton tooltip="Previous" />}>
-        <ChevronLeftIcon />
-      </BranchPickerPrimitive.Previous>
-      <span className="aui-branch-picker-state font-medium">
-        <BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count />
-      </span>
-      <BranchPickerPrimitive.Next render={<TooltipIconButton tooltip="Next" />}>
-        <ChevronRightIcon />
-      </BranchPickerPrimitive.Next>
-    </BranchPickerPrimitive.Root>
   );
 };

--- a/demo/src/components/demo-shell.tsx
+++ b/demo/src/components/demo-shell.tsx
@@ -546,7 +546,9 @@ export function DemoShell() {
       machineKey={machineKey}
       vizConfig={
         isScenario
-          ? scenarioSource[scenario.id]
+          ? // The embed's init takes serialized machine config, not TS source —
+            // source in this slot renders as an empty canvas.
+            scenarioVizConfig[scenario.id]
           : exampleDetail
             ? (activeMachine?.vizConfig ?? null)
             : null

--- a/demo/src/components/site-header.tsx
+++ b/demo/src/components/site-header.tsx
@@ -7,25 +7,18 @@ import type { ExampleSummary } from "@/lib/example-library";
 import type { Selection } from "@/lib/selection";
 import type { ShellStore } from "@/lib/shell-store";
 
-/**
- * Header logo slot. Placeholder per the design handoff (dashed rounded rect +
- * accent dot) — swap the SVG for the real Stately brand mark.
- */
+/** Stately brand mark. Body follows `currentColor`; the head dot uses the accent. */
 function LogoSlot() {
   return (
-    <svg className="logo-slot" width="26" height="26" viewBox="0 0 26 26" aria-hidden="true">
-      <rect
-        x="1.5"
-        y="1.5"
-        width="23"
-        height="23"
-        rx="7"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeDasharray="4 3"
+    <svg className="logo-slot" width="26" height="26" viewBox="0 0 400 400" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M160.048396,62 L200.37018,102.226265 L313.959955,215.546521 L313.959955,215.570808 C315.837975,217.466064 317,220.069114 317,222.944958 C317,226.157786 315.548447,229.029294 313.267435,230.954041 L208.213956,335.758657 C203.882338,340.080448 196.858891,340.080448 192.527273,335.758657 L87.2490397,230.730253 C82.9169868,226.408463 82.9169868,219.401654 87.2490397,215.080297 L152.153757,150.3289 L159.394132,157.552991 C169.631514,167.11948 186.170262,195.360094 164.012235,218.951043 C161.846426,221.111288 161.846426,224.615126 164.012235,226.775804 L196.490243,259.176874 C198.656487,261.337552 202.167775,261.337552 204.334019,259.176874 L236.707692,226.879891 C237.766686,225.869377 238.504418,224.471572 238.504418,222.894216 C238.504418,221.359796 237.836243,219.971098 236.827242,218.965788 L209.069933,191.274668 L209.153401,191.191832 L160.173597,142.328058 C137.904715,120.111929 137.779514,84.2165628 160.048396,62 Z"
       />
-      <circle cx="13" cy="13" r="3.5" fill="var(--primary)" />
+      <path
+        fill="var(--primary)"
+        d="M244.500217,62 C260.239954,62 273,74.7595142 273,90.5 C273,106.240051 260.239954,119 244.500217,119 C228.760046,119 216,106.240051 216,90.5 C216,74.7595142 228.760046,62 244.500217,62 Z"
+      />
     </svg>
   );
 }
@@ -34,7 +27,6 @@ type SwitcherRow = {
   selection: Selection;
   title: string;
   purpose: string;
-  keyless: boolean;
 };
 
 type SwitcherGroup = { label: string; rows: SwitcherRow[] };
@@ -55,7 +47,6 @@ function buildGroups(examples: ExampleSummary[], query: string): SwitcherGroup[]
         selection: { type: "scenario", id: scenario.id } as const,
         title: scenario.name,
         purpose: scenario.eyebrow,
-        keyless: true,
       })),
     },
   ];
@@ -66,14 +57,15 @@ function buildGroups(examples: ExampleSummary[], query: string): SwitcherGroup[]
       selection: { type: "example", id: example.id },
       title: example.title,
       purpose: example.purpose ?? example.kind,
-      keyless: false,
     };
     const rows = byKind.get(example.kind) ?? [];
     rows.push(row);
     byKind.set(example.kind, rows);
   }
+  // Key requirement is uniform within a group, so it lives in the group
+  // label — a badge repeated on every row is noise.
   for (const [kind, rows] of [...byKind.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-    groups.push({ label: kind.replace(/-/g, " "), rows });
+    groups.push({ label: `${kind.replace(/-/g, " ")} · API key`, rows });
   }
 
   return groups
@@ -197,11 +189,6 @@ export function SiteHeader({ store, examples, currentTitle, onSelect }: SiteHead
                             <strong>{row.title}</strong>
                             <small>{row.purpose}</small>
                           </span>
-                          {row.keyless ? (
-                            <span className="key-badge">no key</span>
-                          ) : (
-                            <span className="key-badge key-badge--needs">API key</span>
-                          )}
                           {active && <Check size={13} aria-label="Current example" />}
                         </button>
                       );

--- a/demo/src/components/viz-panel.tsx
+++ b/demo/src/components/viz-panel.tsx
@@ -151,6 +151,7 @@ function EmbedVizPanel({
   const status = useSelector(store, (snapshot) => snapshot.context.status);
   const transportError = useSelector(store, (snapshot) => snapshot.context.error);
   const frameKey = useSelector(store, (snapshot) => snapshot.context.frameKey);
+  const fitEpoch = useSelector(store, (snapshot) => snapshot.context.fitEpoch);
   const ready = status === "ready";
   const timedOut = status === "timedOut";
   const failed = status === "failed";
@@ -175,6 +176,11 @@ function EmbedVizPanel({
     function onMessage(event: MessageEvent) {
       if (!isTrustedVizMessage(event, iframeRef.current?.contentWindow ?? null, targetOrigin))
         return;
+      // The graph finished loading/laying out — the one reliable moment to
+      // fit the camera on a cold editor load.
+      if (event.data?.type === "@statelyai.loaded") {
+        post({ type: "@statelyai.camera.fit" });
+      }
       if (event.data?.type === "@statelyai.ready") {
         const latest = latestRef.current;
         store.trigger.iframeReady({
@@ -189,7 +195,7 @@ function EmbedVizPanel({
     }
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
-  }, [store, targetOrigin]);
+  }, [post, store, targetOrigin]);
 
   // Reset live inspection only when the selected machine changes. In
   // particular, do not clear observations when the iframe becomes ready.
@@ -203,17 +209,25 @@ function EmbedVizPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [machineKey, store]);
 
-  // Theme lives in the embed's init payload, so a flip means re-initing the
-  // embed and replaying whatever it was already showing.
+  // A theme flip is a live message (`setTheme`) — never a re-init, which
+  // would remount the embed and drop the camera and inspection state.
   const previousTheme = useRef(theme);
   useEffect(() => {
     if (previousTheme.current === theme) return;
     previousTheme.current = theme;
-    store.trigger.themeChanged({
-      initMessage: vizConfig ? createInitMessage(vizConfig, theme, documents) : null,
-      fallbackMessages: createStaticMessages(vizConfig, latestRef.current.frame, theme, documents),
-    });
-  }, [documents, store, theme, vizConfig]);
+    store.trigger.themeChanged({ message: { type: "@statelyai.setTheme", theme } });
+  }, [store, theme]);
+
+  // The editor never fits the camera on its own, so freshly loaded content
+  // starts off-viewport. After each content load (init, machine switch, live
+  // system init) fit once right away and once after layout settles.
+  useEffect(() => {
+    if (fitEpoch === 0) return;
+    const fit = () => post({ type: "@statelyai.camera.fit" });
+    fit();
+    const timeout = window.setTimeout(fit, 800);
+    return () => window.clearTimeout(timeout);
+  }, [fitEpoch, post]);
 
   // Fallback replay frames (only used when live inspection is unavailable).
   useEffect(() => {
@@ -293,7 +307,7 @@ function EmbedVizPanel({
               </div>
             )}
             <iframe
-              key={`${frameKey}:${theme}`}
+              key={frameKey}
               ref={iframeRef}
               className="viz-embed"
               data-ready={ready || undefined}

--- a/demo/src/lib/viz-panel-store.ts
+++ b/demo/src/lib/viz-panel-store.ts
@@ -23,6 +23,12 @@ type VizPanelContext = {
   status: VizPanelStatus;
   error: string | null;
   frameKey: number;
+  /**
+   * Bumped whenever new machine content lands in the embed (init, machine
+   * switch, live system init). The panel schedules a camera fit off it —
+   * the editor never fits on its own, so fresh content starts off-viewport.
+   */
+  fitEpoch: number;
   liveMessages: SystemMessage[];
   selectedSessionId: string | null;
   liveEvent: string | null;
@@ -36,8 +42,8 @@ type VizPanelEvents = {
   transportFailed: { message: string };
   iframeReady: { fallbackMessages: SystemMessage[] };
   machineChanged: { initMessage: SystemMessage | null };
-  /** Re-init the embed (e.g. theme flip), then replay what it was showing. */
-  themeChanged: { initMessage: SystemMessage | null; fallbackMessages: SystemMessage[] };
+  /** Flip the embed theme in place — no re-init, no replay. */
+  themeChanged: { message: SystemMessage };
   fallbackFrame: { message: SystemMessage };
   systemInit: { message: SystemMessage };
   systemMessage: { message: SystemMessage };
@@ -93,6 +99,7 @@ export function createVizPanelStore() {
       status: "connecting",
       error: null,
       frameKey: 0,
+      fitEpoch: 0,
       liveMessages: [],
       selectedSessionId: null,
       liveEvent: null,
@@ -117,7 +124,7 @@ export function createVizPanelStore() {
         // Always initialize it once, then layer buffered live snapshots on top.
         for (const message of event.fallbackMessages) enqueue.emit.post({ message });
         for (const message of context.liveMessages) enqueue.emit.post({ message });
-        return { ...context, status: "ready", error: null };
+        return { ...context, status: "ready", error: null, fitEpoch: context.fitEpoch + 1 };
       },
       machineChanged: (context, event, enqueue) => {
         if (context.status === "ready" && event.initMessage) {
@@ -129,16 +136,11 @@ export function createVizPanelStore() {
           selectedSessionId: null,
           liveEvent: null,
           liveStateLabel: null,
+          fitEpoch: context.fitEpoch + 1,
         };
       },
       themeChanged: (context, event, enqueue) => {
-        if (context.status !== "ready") return context;
-        if (context.liveMessages.length > 0) {
-          if (event.initMessage) enqueue.emit.post({ message: event.initMessage });
-          for (const message of context.liveMessages) enqueue.emit.post({ message });
-        } else {
-          for (const message of event.fallbackMessages) enqueue.emit.post({ message });
-        }
+        if (context.status === "ready") enqueue.emit.post({ message: event.message });
         return context;
       },
       fallbackFrame: (context, event, enqueue) => {
@@ -159,6 +161,7 @@ export function createVizPanelStore() {
           selectedSessionId: root?.sessionId ?? null,
           liveEvent: null,
           liveStateLabel: snapshotStateLabel(root?.snapshot),
+          fitEpoch: context.fitEpoch + 1,
         };
       },
       systemMessage: (context, event, enqueue) => {

--- a/demo/src/styles/chat.css
+++ b/demo/src/styles/chat.css
@@ -125,7 +125,10 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  max-width: 220px;
+  /* The rail wraps, so a lone chip may take the full row before truncating —
+     a clipped "Amount exceeds the $100 auto-r…" with room to spare reads as
+     a bug. */
+  max-width: 100%;
   padding: 3px 10px 3px 4px;
   border: 1px solid var(--line, rgba(127, 127, 127, 0.35));
   border-radius: 999px;
@@ -161,6 +164,22 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* One line stating the split-pane premise; the machine pane it points at is
+   hidden behind a tab on mobile, so the hint hides with it. */
+.chat-intro__hint {
+  margin: 0;
+  color: var(--quiet);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+@media (max-width: 800px) {
+  .chat-intro__hint {
+    display: none;
+  }
 }
 
 .chat-intro__status,

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",
     "@opentelemetry/sdk-trace-node": "^2.10.0",
-    "@statelyai/sdk": "^0.22.1",
+    "@statelyai/sdk": "^0.26.1",
     "@types/express": "^5.0.6",
     "@types/node": "^20.19.43",
     "@types/react": "^19.2.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^2.10.0
         version: 2.10.0(@opentelemetry/api@1.9.1)
       '@statelyai/sdk':
-        specifier: ^0.22.1
-        version: 0.22.1(cytoscape@3.34.0)(d3-force@3.0.0)(zod@4.4.3)
+        specifier: ^0.26.1
+        version: 0.26.1(cytoscape@3.34.0)(d3-force@3.0.0)(zod@4.4.3)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -153,8 +153,8 @@ importers:
         specifier: workspace:*
         version: link:..
       '@statelyai/sdk':
-        specifier: ^0.22.1
-        version: 0.22.1(cytoscape@3.34.0)(d3-force@3.0.0)(zod@4.4.3)
+        specifier: ^0.26.1
+        version: 0.26.1(cytoscape@3.34.0)(d3-force@3.0.0)(zod@4.4.3)
       '@tanstack/react-router':
         specifier: ^1.170.32
         version: 1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -4150,6 +4150,11 @@ packages:
 
   '@statelyai/sdk@0.22.1':
     resolution: {integrity: sha512-r5u6CDry6nbADRcZwgfzso0Sc5hNqX7A9QgX7JLxiIdPFcFUMcUIHb7x6kojUY4uylos3OVTGqp9zAfS/wEpbA==, tarball: https://registry.npmjs.org/@statelyai/sdk/-/sdk-0.22.1.tgz}
+    engines: {node: '>=22.4'}
+    hasBin: true
+
+  '@statelyai/sdk@0.26.1':
+    resolution: {integrity: sha512-6C8sV+oVrscWT2KReKb3PPHgZYYP5a4vM8dlxZ03MC6xcRvCet++c5GR/vZbKnid2A3HdjnkjBRvBpnrNICMDg==, tarball: https://registry.npmjs.org/@statelyai/sdk/-/sdk-0.26.1.tgz}
     engines: {node: '>=22.4'}
     hasBin: true
 
@@ -10744,6 +10749,29 @@ snapshots:
       zod: 4.4.3
 
   '@statelyai/sdk@0.22.1(cytoscape@3.34.0)(d3-force@3.0.0)(zod@4.4.3)':
+    dependencies:
+      '@statelyai/graph': 2.3.0(cytoscape@3.34.0)(d3-force@3.0.0)(zod@4.4.3)
+      esbuild: 0.27.7
+      typescript: 5.9.3
+      ws: 8.21.3
+      xstate: 5.32.5
+    transitivePeerDependencies:
+      - '@dagrejs/dagre'
+      - '@hpcc-js/wasm-graphviz'
+      - bufferutil
+      - cytoscape
+      - d3-force
+      - d3-hierarchy
+      - dotparser
+      - elkjs
+      - fast-xml-parser
+      - graphology
+      - graphology-layout-forceatlas2
+      - utf-8-validate
+      - webcola
+      - zod
+
+  '@statelyai/sdk@0.26.1(cytoscape@3.34.0)(d3-force@3.0.0)(zod@4.4.3)':
     dependencies:
       '@statelyai/graph': 2.3.0(cytoscape@3.34.0)(d3-force@3.0.0)(zod@4.4.3)
       esbuild: 0.27.7


### PR DESCRIPTION
## What

A design pass over the demo app, verified live against the running app.

### Viz panel
- **Machines render before the first run**: scenario init was sending raw TS source as the embed's machine; it now sends the serialized config (`scenarioVizConfig`) the embed actually accepts.
- **Camera fits automatically**: the editor never fits on its own, so fresh content sat off-viewport until a manual fit click. The panel now posts `@statelyai.camera.fit` after init / machine switch / live system init and on the editor's `@statelyai.loaded` signal (covers cold loads).
- **Theme flips no longer blank the pane**: theme was part of the iframe key, so toggling remounted the embed and dropped camera + inspection state. It now posts `@statelyai.setTheme` to the live embed.

### Chat panel
- Action bubbles show only the action label; the literal-backtick `\`EVENT\`` suffix is gone (the transition log already names the event).
- Checkpoint chips use the full rail width before truncating.
- Inert assistant-ui actions removed (edit, retry, branch picker, export menu) — the external-store runtime never wired them, so they were dead buttons. Copy stays.
- Empty state is vertically centered, long starter chips wrap instead of clipping, and a one-line hint states the split-pane premise (hidden on mobile).

### Header
- Key badges live in switcher group labels ("Interactive · no key needed", "agent workflow · API key") instead of repeating on every row.
- Placeholder logo replaced with the real Stately mark (inline SVG, theme-safe).

### Deps
- `@statelyai/sdk` `^0.22.1` → `^0.26.1` (its `setTheme` protocol support enables the theme fix).

## Verification
- `pnpm --dir demo typecheck` and all 64 demo tests pass; root typecheck clean.
- Verified in the browser: fresh load shows the fitted statechart with no interaction, theme toggle keeps the same iframe, chips wrap, only Copy remains on messages.

## Not included (upstream candidates)
- `sky.stately.ai` websocket warning when a viewer joins a room with no producer (being handled in a separate session against studio/viz).
- Editor-side auto-fit on init, which would make the demo's fit messages redundant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/agent/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an explanatory hint beneath the scenario start form.
  - Updated branding with the Stately logo and clearer API-key status labels.

- **Improvements**
  - Simplified conversation controls for a cleaner chat experience.
  - Improved welcome-panel spacing and responsive starter buttons.
  - Enhanced visualization loading and camera fitting.
  - Theme changes now apply without reloading the visualization.
  - Improved layout for checkpoint indicators and small-screen displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->