### PR TITLE
Align docs with simplified Agent API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ A feature belongs in core when a machine cannot otherwise express portable inten
 - Describing external work without executing it.
 - Binding that work in any host.
 - Suspending, persisting, and resuming without changing the machine.
-- Stepping and replaying deterministically.
+- Testing control flow deterministically.
 - Observing a run without coupling it to one telemetry or evaluation vendor.
 
 A feature does not belong in core only because common agent applications need it. Search clients, vector stores, browser automation, code sandboxes, skills, prompt registries, eval scorers, and deployment servers evolve independently as specialized libraries.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -13,7 +13,6 @@ The snippets below come from [Twenty Questions](../examples/twenty-questions/ind
 
 <!-- viz: sequence diagram for one decision: machine invokes agent.decide -> host coerces the model to one candidate event -> validation (unknown-event / invalid-payload / rejected-by-guard) -> retry or send the event to the machine -->
 
-
 ## Invoking an agent decision
 
 <!-- agent.decide builtin from src/setup-agent.ts and src/decision.ts -->
@@ -52,18 +51,18 @@ deciding: {
 
 The `allowedEvents` list is typed against the machine's user-authored event schema, so a typo is a compile error. Framework events such as `agent.messages` and `@agent.usage` can be handled by the machine but are never model-facing candidates. Listing events explicitly also makes the candidate set visible in the machine.
 
-> **Note:** `agent.decide` needs a snapshot-aware host, either `runAgent` or the [step path](steps.md), to know which events are currently legal. In [uncontrolled mode](choosing-a-run-mode.md#uncontrolled-provideexecutors), under a bare `createActor(...)`, list `allowedEvents` explicitly. Wildcards and the omitted default cannot expand there.
+> **Note:** `agent.decide` needs a snapshot-aware host such as `runAgent` to know which events are currently legal. With a [long-lived actor](choosing-a-run-mode.md#long-lived-actor), list `allowedEvents` explicitly. Wildcards and the omitted default cannot expand there.
 
 ### `allowedEvents` patterns
 
 The `allowedEvents` option accepts a single string or an array. Entries are exact event types or wildcard patterns, and the two can mix, as in `['todo.*', 'reset']`.
 
-| Value | Meaning |
-| ----- | ------- |
-| `['ASK', 'GUESS']` | Exact event types, typed against the event-schema keys. A typo is a compile error. |
-| `'ASK'` | A single string, shorthand for a one-entry array. |
-| `'*'` | Every currently-legal event. |
-| `'todo.*'` | Every declared event under the `todo.` namespace, such as `todo.add` and `todo.toggle`. Typed against declared dotted types, so a pattern matching nothing, such as `'nope.*'`, is a compile error. |
+| Value              | Meaning                                                                                                                                                                                             |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `['ASK', 'GUESS']` | Exact event types, typed against the event-schema keys. A typo is a compile error.                                                                                                                  |
+| `'ASK'`            | A single string, shorthand for a one-entry array.                                                                                                                                                   |
+| `'*'`              | Every currently-legal event.                                                                                                                                                                        |
+| `'todo.*'`         | Every declared event under the `todo.` namespace, such as `todo.add` and `todo.toggle`. Typed against declared dotted types, so a pattern matching nothing, such as `'nope.*'`, is a compile error. |
 
 ### Reusable decision logic
 
@@ -100,7 +99,7 @@ Guards are transition functions that return `undefined`. See [Transitions](machi
 
 The candidate set is the `allowedEvents` list intersected with the events the state statically accepts. After the model picks one, `snapshot.can(event)` decides whether it is legal in the current snapshot. A chosen `ASK` on the final turn is rejected, and the model is asked again.
 
-`runAgent` and the step path perform this check for you. When you call [`resolveDecision`](steps.md#standalone-decision-resolution) directly in [uncontrolled mode](choosing-a-run-mode.md#uncontrolled-provideexecutors), pass the check through `canTake`:
+`runAgent` performs this check for you. When you call `resolveDecision` directly with a [long-lived actor](choosing-a-run-mode.md#long-lived-actor), pass the check through `canTake`:
 
 ```ts
 import { resolveDecision } from "@statelyai/agent";
@@ -116,10 +115,10 @@ const event = await resolveDecision(request, executors, {
 
 Each attempt runs three checks in order. Each failure is typed and fed back to the model on the next attempt:
 
-| Failure | Cause |
-| ------- | ----- |
-| `unknown-event` | The event type is not among the candidate events. |
-| `invalid-payload` | The payload does not match that event's schema. |
+| Failure             | Cause                                                                       |
+| ------------------- | --------------------------------------------------------------------------- |
+| `unknown-event`     | The event type is not among the candidate events.                           |
+| `invalid-payload`   | The payload does not match that event's schema.                             |
 | `rejected-by-guard` | The type and payload are valid, but `snapshot.can(event)` returned `false`. |
 
 Retry behavior:
@@ -144,7 +143,6 @@ A decision produces one event. When one command needs several events, such as "a
 - The trail of applied events lives in context and is appended to each step's prompt.
 
 <!-- viz: state diagram of the decide loop: planning (invoke agent.decide) -> applying (always -> planning) for ADD_TODO/TOGGLE_TODO, and DONE -> awaitingCommand -->
-
 
 ```ts no-check
 planning: {

--- a/docs/from-a-loop.md
+++ b/docs/from-a-loop.md
@@ -239,7 +239,7 @@ To handle the human pause over HTTP, persist the snapshot with `runAgent` and re
 
 ## Behavior preservation
 
-Before you ship, pin the new machine's behavior with a deterministic playthrough that uses no model. `simulateAgent` scripts the decisions and runs the same step path that `runAgent` uses, with no API key and no network access.
+Before you ship, pin the new machine's behavior with a deterministic playthrough that uses no model. `simulateAgent` scripts the decisions and traverses the same machine transitions as `runAgent`, with no API key and no network access.
 
 ```ts
 import { simulateAgent } from "@statelyai/agent";

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,16 +17,17 @@ Stately Agent is XState plus typed model requests, decisions, and host executors
 
 ## Core APIs
 
-| API | Purpose |
-| --- | --- |
-| `setupAgent` | Schema-first XState setup with Agent request actors |
-| `runAgent` | Run one in-process leg to done, idle, or error |
-| `runAgentLoop` | Drive repeated idle/resume turns |
-| `runAgentStream` | Observe requests, chunks, transitions, emissions, and settle |
-| `provideExecutors` | Bind executors for an application-owned XState actor |
-| `createScriptedExecutors` | Deterministic named request scripts |
-| `getInteraction` / `eventFromInteraction` | Render and validate human interactions |
-| `isAgentIdle` | Default composable idle-state predicate |
-| `lintAgentMachine` | Agent-specific diagnostics |
+| API                                         | Purpose                                                      |
+| ------------------------------------------- | ------------------------------------------------------------ |
+| `setupAgent`                                | Schema-first XState setup with Agent request actors          |
+| `runAgent`                                  | Run one in-process leg to done, idle, or error               |
+| `runAgentLoop`                              | Drive repeated idle/resume turns                             |
+| `runAgentStream`                            | Observe requests, chunks, transitions, emissions, and settle |
+| `provideExecutors`                          | Bind executors for an application-owned XState actor         |
+| `createScriptedExecutors`                   | Deterministic named request scripts                          |
+| `getInteraction` / `eventFromInteraction`   | Render and validate human interactions                       |
+| `isAgentIdle`                               | Default composable idle-state predicate                      |
+| `lintAgentMachine`                          | Agent-specific diagnostics                                   |
+| `ContextOf` / `EventOf` / other `*Of` types | Extract setup and machine types                              |
 
 The optional `@statelyai/agent/ai-sdk` entry provides `defineModels` and AI SDK executors. Core has no runtime dependency on the AI SDK.

--- a/docs/machines.md
+++ b/docs/machines.md
@@ -45,7 +45,7 @@ factory and trace; invalid input throws `AgentError` with code
 `invalid-machine-input`. Calling XState's `createActor` directly does not run
 this validation.
 
-To keep conversation history in context, add a `messages` field with the `z.custom<AgentMessage[]>` recipe. See [Messages](messages.md#store-messages-in-context).
+To keep conversation history in context, add a `messages` field with the `z.custom<AgentMessage[]>` recipe. See [Messages](messages.md).
 
 ### Event schemas
 
@@ -65,7 +65,7 @@ In a `HEAL` transition, `event.amount` is a `number`. Reading a field the event 
 
 ### Emitted event schemas
 
-Emitted event schemas type the progress events a machine emits with `enq.emit(...)`. Hosts receive them through [`runAgent`'s `on` handlers](observability.md#observation-callbacks). Declare them under `emitted`:
+Emitted event schemas type the progress events a machine emits with `enq.emit(...)`. Hosts receive them through `runAgent`'s `on` handlers. Declare them under `emitted`:
 
 ```ts no-check
 // setupAgent({ ... })
@@ -75,7 +75,7 @@ emitted: {
 // ...
 ```
 
-Both `enq.emit({ type: 'EVALUATED', ... })` and the host-side `on: { EVALUATED: handler }` are then typed. An undeclared type or a wrong payload is a compile error.
+Both `enq.emit({ type: 'EVALUATED', ... })` and the host-side `on: { EVALUATED: handler }` are then typed. An undeclared type or a wrong payload is a compile error. See [Observability](observability.md).
 
 > **Note:** To reuse one schema set across machines or the step helpers, declare it once with `createAgentSchemas({ context, input, output, events })` and pass it as `setupAgent({ schemas })`. This is equivalent to the inline form. See [Authoring forms](#authoring-forms).
 
@@ -85,6 +85,24 @@ When a generic host receives only a machine, call `getAgentSchemas(machine)` to
 recover its schema pack for validation or form generation. It returns
 `undefined` for plain XState machines. Read it before `machine.provide(...)`;
 the provided machine is a new object and does not carry the registration.
+
+### Type extraction
+
+<!-- public type helpers from src/type-helpers.ts and src/index.ts -->
+
+Use the exported `ContextOf`, `InputOf`, `OutputOf`, and `EventOf` helpers with
+either an Agent setup or a machine. Machine-only helpers are `SnapshotOf` and
+`StateValueOf`; `MetaOf` extracts declared metadata, and `RequestNamesOf`
+extracts a setup's registered request-name union.
+
+```ts
+import type { ContextOf, EventOf, RequestNamesOf, SnapshotOf } from "@statelyai/agent";
+
+type AgentContext = ContextOf<typeof agentSetup>;
+type AgentEvent = EventOf<typeof machine>;
+type AgentSnapshot = SnapshotOf<typeof machine>;
+type RequestName = RequestNamesOf<typeof agentSetup>;
+```
 
 ## Agent setup
 
@@ -96,7 +114,7 @@ The builtins `agent.generateText`, `agent.streamText`, `agent.decide`, and `agen
 
 ### Models
 
-The `models` map pairs a short alias with a resolved model. Request and decision `model:` values autocomplete against its keys. Pass the same map to the host adapter. See [Typed model aliases](hosts.md#typed-model-aliases).
+The `models` map pairs a short alias with a resolved model. Request and decision `model:` values autocomplete against its keys. Pass the same map to the host adapter. See [Models and providers](models-and-providers.md).
 
 ```ts
 import { openai } from "@ai-sdk/openai";
@@ -194,19 +212,18 @@ The canonical form covers most machines: a `models` registry, flat schema fields
 
 Each alternate form handles one specific need:
 
-| Form | Use it when |
-| ---- | ----------- |
-| `createAgentSchemas` pack, passed as `setupAgent({ schemas })` | You share one schema set across several machines or the [step helpers](steps.md). |
-| String model refs with `resolveModel` (`model: 'openai/gpt-5.4-mini'`, `createAiSdkExecutors({ resolveModel })`) | The machine must not name concrete models, for portability or for refs loaded from JSON [config](machines-as-data.md). |
-| `createTextLogic`, a standalone request value | A request is exported, reused across states or machines, or unit-tested on its own. See [Text requests](text-requests.md#reusable-request-logic-with-createtextlogic). |
-| `logic.withExecutor(...)` | You bind execution onto one logic instead of the whole host, so a plain `createActor` runs it without [`runAgent`](hosts.md#writing-your-own-executors)'s executor slots. Registered dynamic spawns inherit through `actors`. See [Multi-agent composition](multi-agent.md#dynamic-binding). |
+| Form                                                                                                             | Use it when                                                                                                                                                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createAgentSchemas` pack, passed as `setupAgent({ schemas })`                                                   | You share one schema set across several machines or the [step helpers](steps.md).                                                                                                                                                                 |
+| String model refs with `resolveModel` (`model: 'openai/gpt-5.4-mini'`, `createAiSdkExecutors({ resolveModel })`) | The machine must not name concrete models, for portability or for refs loaded from JSON [config](machines-as-data.md).                                                                                                                            |
+| `createTextLogic`, a standalone request value                                                                    | A request is exported, reused across states or machines, or unit-tested on its own. See [Text requests](text-requests.md#reusable-request-logic-with-createtextlogic).                                                                            |
+| `logic.withExecutor(...)`                                                                                        | You bind execution onto one logic instead of the whole host, so a plain `createActor` runs it without [`runAgent`](hosts.md)'s executor slots. Registered dynamic spawns inherit through `actors`. See [Multi-agent composition](multi-agent.md). |
 
 ## Machine creation
 
 `agentSetup.createMachine` is XState's `createMachine` with the agent's schemas and actors already bound. It registers the machine, so the step helpers and [`runAgent`](hosts.md) resolve its schemas and actors without you passing them again.
 
 <!-- viz: state diagram for the answering machine below: initial state `answering` invoking the `answerQuestion` request, onDone -> final state `done` producing { answer } -->
-
 
 ```ts no-check
 const machine = agentSetup.createMachine({

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -29,6 +29,13 @@ const machine = agent.createMachine({
 
 The default key is `messages`. Use `appendMessages({ key: "history" })` for another context field.
 
+<!-- AGENT_MESSAGES_EVENT_TYPE, appendMessages, and getMessageText from src/messages.ts, src/utils.ts, and src/index.ts -->
+
+Use `AGENT_MESSAGES_EVENT_TYPE` instead of the string literal when sharing the
+handler. `getMessageText(message)` returns the readable string content and
+joins text parts, including textual tool-result output, while ignoring
+non-text content.
+
 This is deliberately transparent: the AI SDK executor returns AI SDK messages, another framework returns its own messages, and the machine stores those values unchanged. Tool calls and tool results remain part of that framework-native chat log.
 
 See the runnable [`tool-calling`](../examples/tool-calling) example for an AI

--- a/docs/models-and-providers.md
+++ b/docs/models-and-providers.md
@@ -25,10 +25,28 @@ There are four integration paths. The first two both go through `createAiSdkExec
 
 - **AI SDK adapter.** Accepts any `LanguageModel`, including models from Mastra, Cloudflare Workers AI through `workers-ai-provider`, TanStack AI, OpenRouter's AI SDK provider, and any `@ai-sdk/*` package. Supports all three executors, including `decide`.
 - **OpenAI-compatible endpoints.** Point `createOpenAI({ baseURL })` from `@ai-sdk/openai` at any OpenAI-shaped endpoint, such as Groq, Ollama, vLLM, Together, or LM Studio, then pass the result to the same adapter. Supports all three executors, including `decide`.
-- **Hand-written executors.** Write the three executors yourself against a provider's HTTP API, or against a client that is not an AI SDK `LanguageModel`, such as a LangChain `BaseChatModel`. Supports all three executors, but you map structured output and decision retries yourself. See [Hosts](hosts.md#writing-your-own-executors) and [LangChain models](#langchain-models).
+- **Hand-written executors.** Write the three executors yourself against a provider's HTTP API, or against a client that is not an AI SDK `LanguageModel`, such as a LangChain `BaseChatModel`. Supports all three executors, but you map structured output and decision retries yourself. See [Hosts](hosts.md) and [LangChain models](#langchain-models).
 - **Raw `ai` functions.** Pass the `ai` package's `generateText` and `streamText` as your `executors` set. This path supports text only. `decide` requires the adapter, and structured output is best-effort.
 
 <!-- viz: executor sourcing paths: LanguageModel object -> createAiSdkExecutors -> { generateText, streamText, decide }, with the raw-`ai` path bypassing the adapter and losing decide/structured output -->
+
+## Host-owned model settings
+
+<!-- settings and model-entry precedence from src/ai-sdk/index.ts and src/ai-sdk/mappers.ts -->
+
+Pass provider-specific settings to `createAiSdkExecutors`, not the machine. An object applies to every call; a function can vary settings by request. A model entry may also pair one model with its defaults.
+
+```ts
+const executors = createAiSdkExecutors({
+  models: {
+    quick: openai("gpt-5.4-mini"),
+    careful: { model: openai("gpt-5.4"), settings: { reasoning: "high" } },
+  },
+  settings: (request) => ({ temperature: request.name === "draft" ? 0.7 : 0 }),
+});
+```
+
+Precedence is global `settings`, then model-entry settings, then portable generation fields declared by the request.
 
 ## Mastra models
 
@@ -121,7 +139,7 @@ await runAgent(machine, {
 
 To use Groq, vLLM, Together, OpenRouter, or LM Studio, change `baseURL` and add `apiKey` where the endpoint requires one. Nothing else changes.
 
-To avoid depending on `ai`, write the three executors over raw `fetch` against the same Chat Completions endpoint. Build the request body from the plain `AgentTextRequest` fields. Use `buildEnvelopeSchema`, `getJsonSchema`, and `parseOutput` from `@statelyai/agent` for structured output, and `renderDecisionAttempts` for decision retries. See [Hosts](hosts.md#writing-your-own-executors).
+To avoid depending on `ai`, write the three executors over raw `fetch` against the same Chat Completions endpoint. Build the request body from the plain `AgentTextRequest` fields. Use `buildEnvelopeSchema`, `getJsonSchema`, and `parseOutput` from `@statelyai/agent` for structured output, and `renderDecisionAttempts` for decision retries. See [Hosts](hosts.md).
 
 ## Raw AI SDK functions
 
@@ -154,7 +172,7 @@ Each example is a runnable host for one provider stack.
 
 | Example                                                                       | Backing                                                                                                           |
 | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| [ai-sdk-game-host](../examples/ai-sdk-game-host/index.ts)                    | Vercel AI SDK, through the optional adapter                                                                       |
+| [ai-sdk-game-host](../examples/ai-sdk-game-host/index.ts)                     | Vercel AI SDK, through the optional adapter                                                                       |
 | [openai-sdk-host](../examples/openai-sdk-host/index.ts)                       | raw `openai` (Chat Completions); structured via `response_format`, decisions via `tool_choice: 'required'`        |
 | [anthropic-sdk-host](../examples/anthropic-sdk-host/index.ts)                 | raw `@anthropic-ai/sdk` (Messages); structured via forced tool call, decisions via `tool_choice: { type: 'any' }` |
 | [langchain-host](../examples/langchain-host/index.ts)                         | LangChain `BaseChatModel` (`@langchain/core`), wrapped into the executor contract                                 |

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -15,7 +15,6 @@ The machine declares what happens:
 
 <!-- viz: ownership boundary diagram: machine (states, requests, decisions) | executors/actors seam | host capabilities (model SDK, search, memory, sandbox, store, telemetry) -->
 
-
 ```ts no-check
 searching: {
   invoke: { src: "searchWeb", input: ({ context }) => ({ query: context.query }) },
@@ -28,19 +27,19 @@ The host decides how it happens, binding `searchWeb` to the search client, cache
 
 <!-- ownership boundaries derived from src/run-agent.ts, src/steps.ts, src/types.ts, and the host/example adapters -->
 
-| Concern                                                                 | Owner                            | Stately Agent integration point                        |
-| ----------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------ |
-| Workflow states, branching, loops, parallelism, retries, approval gates | Machine                          | Machine configuration                                  |
-| Model calls and structured output                                       | Host or model SDK                | `AgentRequestExecutors`                                |
-| Tools and tool loops                                                    | Host or model SDK                | Request `tools` and `metadata`                         |
-| Search, RAG, crawling, data APIs                                        | Specialized library or service   | Request `tools`, executors, or `actors`                |
-| Long-term and semantic memory                                           | Database or memory library       | Machine `input`, plus `actors` for reads and writes    |
-| Sandboxes, filesystems, generated artifacts                             | Sandbox or workspace library     | `actors`, plus artifact handles in machine context     |
-| MCP discovery, auth, sessions, and transport                            | MCP client or host framework     | Request `tools`                                        |
-| Evaluation datasets, scorers, experiments, and dashboards               | Evaluation library               | `onTrace`, `onResult`, snapshots, and machine output   |
-| Snapshot persistence                                                    | Host store                       | XState persisted snapshots from `result.persist()`     |
-| Queues, schedules, leases, deployment, HTTP/SSE/WebSocket               | Runtime or application framework | Step path, snapshots, callbacks, and emitted events    |
-| Telemetry export                                                        | Observability library            | `onTrace` and `inspect`                                |
+| Concern                                                                 | Owner                            | Stately Agent integration point                      |
+| ----------------------------------------------------------------------- | -------------------------------- | ---------------------------------------------------- |
+| Workflow states, branching, loops, parallelism, retries, approval gates | Machine                          | Machine configuration                                |
+| Model calls and structured output                                       | Host or model SDK                | `AgentRequestExecutors`                              |
+| Tools and tool loops                                                    | Host or model SDK                | Request `tools` and `metadata`                       |
+| Search, RAG, crawling, data APIs                                        | Specialized library or service   | Request `tools`, executors, or `actors`              |
+| Long-term and semantic memory                                           | Database or memory library       | Machine `input`, plus `actors` for reads and writes  |
+| Sandboxes, filesystems, generated artifacts                             | Sandbox or workspace library     | `actors`, plus artifact handles in machine context   |
+| MCP discovery, auth, sessions, and transport                            | MCP client or host framework     | Request `tools`                                      |
+| Evaluation datasets, scorers, experiments, and dashboards               | Evaluation library               | `onTrace`, `onResult`, snapshots, and machine output |
+| Snapshot persistence                                                    | Host store                       | XState persisted snapshots from `result.persist()`   |
+| Queues, schedules, leases, deployment, HTTP/SSE/WebSocket               | Runtime or application framework | XState snapshots, callbacks, and emitted events      |
+| Telemetry export                                                        | Observability library            | `onTrace` and `inspect`                              |
 
 The repository examples show the orchestration shape. They are not replacement implementations of the systems listed above.
 
@@ -71,6 +70,6 @@ The seam between tools and actors is fixed. Tools are chosen by the model within
 
 - [Hosts and executors](hosts.md): the executor contract the host implements.
 - [Use in any stack](any-stack.md): the same machine across local, server, and edge hosts.
-- [The step path](steps.md): the per-model-call loop durable hosts own.
+- [The XState transition loop](steps.md): the effect lifecycle custom and durable hosts own.
 - [Multi-agent composition](multi-agent.md): composing machines without an orchestration layer.
 - [Post-alpha roadmap](roadmap.md): what is deliberately not shipped yet.

--- a/docs/text-requests.md
+++ b/docs/text-requests.md
@@ -51,7 +51,7 @@ const agentSetup = setupAgent({
 
 ### Model references
 
-`model` is a key into the `models` registry, or any bare string that the [host](hosts.md#typed-model-aliases) resolves at run time. See [Authoring forms](machines.md#authoring-forms).
+`model` is a key into the `models` registry, or any bare string that the [host](hosts.md) resolves at run time. See [Authoring forms](machines.md#authoring-forms).
 
 ### Standalone requests
 
@@ -93,7 +93,7 @@ const answer = parseOutput(answerSchema, rawOutput); // typed as { answer: strin
 
 Output is structured when the schema describes an object, an array, or a top-level union of them built with `z.union` or `z.discriminatedUnion`. Otherwise the output is plain text. An `output: z.object({ ... })` schema returns a validated object. An `output: z.string()` schema returns the model's text.
 
-> **Note for host implementers:** Every structured request is sent wrapped in the [structured-output envelope](./hosts.md#the-structured-output-envelope), a root object `{ result: <your schema> }`. The host must unwrap it before validation. The envelope keeps a bare union or array root portable, because providers that reject a union or array at the root still accept it nested under `result`. Machine authors declare and receive the bare schema. The envelope is invisible to the machine.
+> **Note for host implementers:** Every structured request is sent in a root object `{ result: <your schema> }`. The host must unwrap it before validation. This envelope keeps a bare union or array root portable, because providers that reject one at the root still accept it nested under `result`. Machine authors declare and receive the bare schema.
 
 ```ts
 export const triageTicket = createTextLogic({
@@ -117,7 +117,7 @@ The mode is derived from the schema automatically. You never set it. See [exampl
 
 <!-- reasoning opt-in from src/text-logic.ts (AgentTextRequest.includeReasoning) -->
 
-Set `includeReasoning: true` on a structured request to add an optional string `reasoning` field to the [envelope](./hosts.md#the-structured-output-envelope). The field is listed before `result`, so the property order prompts the model to reason before answering:
+Set `includeReasoning: true` on a structured request to add an optional string `reasoning` field to the envelope. The field is listed before `result`, so the property order prompts the model to reason before answering:
 
 ```ts
 export const triageTicket = createTextLogic({
@@ -130,7 +130,7 @@ export const triageTicket = createTextLogic({
 
 The reasoning never enters machine context or output. It surfaces in three places: on the raw executor result as `result.reasoning` from the `generateText` executor of `createAiSdkExecutors`, on `runAgent`'s `onResult(request, { raw })`, and as a `reasoning` field on the `request.end` `onTrace` event. Text-mode requests ignore the option.
 
-`includeReasoning` is not the provider's reasoning-effort setting. Effort is the host's business, because what it means differs per provider: an enum for one, a thinking-token budget for another, nothing at all for a third. A machine that named an effort level would stop being portable. Set it where the executors are built, with [`createAiSdkExecutors({ settings })`](hosts.md#per-call-provider-settings).
+`includeReasoning` is not the provider's reasoning-effort setting. Effort is the host's business, because what it means differs per provider: an enum for one, a thinking-token budget for another, nothing at all for a third. A machine that named an effort level would stop being portable. Set it where the executors are built, with [`createAiSdkExecutors({ settings })`](models-and-providers.md#host-owned-model-settings).
 
 ## Streaming requests
 

--- a/docs/thinking-in-state-machines.md
+++ b/docs/thinking-in-state-machines.md
@@ -13,7 +13,7 @@ For the mechanical refactor of an existing codebase, see [Migrating from a hand-
 
 <!-- xstate version requirement from package.json#peerDependencies -->
 
-> **Version requirement.** Build the machine with the `xstate` install this package peers on, v6 alpha.46 or newer. See [Installation](quickstart.md#installation). Machines authored for XState v5 usually port with few changes, but a machine object imported from a separate `xstate@5` install does not bind. Write event-transition guards as functions that return `undefined`. XState v6 drops named string guards on `on`, and the function form is what makes `snapshot.can(event)` reflect the guard.
+> **Version requirement.** Build the machine with the `xstate` install this package peers on, v6 alpha.46 or newer. See the [Quickstart](quickstart.md). Machines authored for XState v5 usually port with few changes, but a machine object imported from a separate `xstate@5` install does not bind. Write event-transition guards as functions that return `undefined`. XState v6 drops named string guards on `on`, and the function form is what makes `snapshot.can(event)` reflect the guard.
 
 ## The loop to model
 
@@ -302,7 +302,7 @@ For what the machine gives you over the loop, see the [overview](index.md).
 
 The design work above assumes you are writing the machine. Existing machines can still be hosted without Agent-specific authoring.
 
-- The machine already exists and contains nothing agent-specific. Any machine whose invokes resolve to values and whose events you can enumerate can be driven. Use [`getAcceptedEvents(snapshot)`](human-in-the-loop.md) for the candidates and call [`resolveDecision`](steps.md#standalone-decision-resolution) gated by `snapshot.can(event)`. See [plain-xstate](../examples/plain-xstate/index.ts).
+- The machine already exists and contains nothing agent-specific. Any machine whose invokes resolve to values and whose events you can enumerate can be driven. Use [`getAcceptedEvents(snapshot)`](human-in-the-loop.md) for the candidates and call `resolveDecision` gated by `snapshot.can(event)`. See [plain-xstate](../examples/plain-xstate/index.ts).
 
 Prompts do not have to live in the machine. Leave bare `src` strings and bind a separate prompt map through the `actors` option of `runAgent`, which is shorthand for `machine.provide({ actors })`. The explicit invokes remain part of the graph, which is what lets a machine round-trip through JSON with `setupAgent.fromConfig`. See [Machines as data](machines-as-data.md).
 

--- a/docs/usage-and-budgets.md
+++ b/docs/usage-and-budgets.md
@@ -75,7 +75,7 @@ function addUsage(a: AgentUsage, b: AgentUsage): AgentUsage {
 Two callbacks report usage per call. Both are live and read-only.
 
 - `onResult(request, { output, raw })`: `raw` is your executor's verbatim result, so `raw.usage` is that call's usage in whatever shape the executor produced.
-- `onTrace` on a `request.end` event: `usage?: AgentCallUsage` is normalized, and present only when the executor reported usage. See [Observability](observability.md#the-versioned-trace-stream).
+- `onTrace` on a `request.end` event: `usage?: AgentCallUsage` is normalized, and present only when the executor reported usage. See [Observability](observability.md#trace-one-run).
 
 ```ts
 await runAgent(machine, {
@@ -157,12 +157,12 @@ A wrapper is still host-side. The machine cannot read the remaining budget or re
 
 ## The `@agent.usage` event
 
-<!-- AGENT_USAGE_EVENT_TYPE and AgentUsageEvent from src/effects.ts -->
+<!-- AGENT_USAGE_EVENT_TYPE and AgentUsageEvent from src/usage.ts -->
 
 `@agent.usage` is a reserved event that carries one model call's tokens into the machine. Four rules govern it.
 
 - You declare nothing. `setupAgent` and `createAgentSchemas` register `'@agent.usage'` and its payload schema in every agent's events, so the handler is typed and `event.usage.totalTokens` narrows. Declaring it yourself is an error, because the `@agent.` namespace is reserved.
-- Delivery is opt-in. The event is delivered only when an active state declares a transition that matches it, either `'@agent.usage'` or the wildcard `'*'`. If no active state declares one, there is no transition, no trace event, and no event-log entry. Wildcard matching follows XState semantics, so a catch-all `on: { '*': … }` does receive `@agent.usage`. Narrow the handler on `event.type` when the catch-all is meant for other events.
+- Delivery is opt-in. The event is delivered only when an active state declares a transition that matches it, either `'@agent.usage'` or the wildcard `'*'`. Otherwise no usage event is sent to the machine. Wildcard matching follows XState semantics, so a catch-all `on: { '*': … }` does receive `@agent.usage`. Narrow the handler on `event.type` when the catch-all is meant for other events.
 - Declare the handler at machine level. A root `on: { '@agent.usage': … }` catches every call regardless of which state made it. A state-scoped handler drops calls made in other states.
 - Delivery goes to the run's root machine, including usage from requests inside an invoked child machine. Attribute those calls with `id`, `src`, and `model`.
 
@@ -191,13 +191,13 @@ Model-call results reach the machine with usage stripped out.
 
 ### Rules
 
-| Area                 | Rule                                                                                                                                                                                                                                                                                               |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Not model-facing** | The `@agent.*` namespace is excluded from `getAcceptedEvents` and `parseAgentEvent`. The event is never a decision candidate, even under `allowedEvents: ['*']`, and cannot be forged from a wire message.                                                                                         |
-| **Durability**       | The event is folded into machine context, so a native snapshot from `result.persist()` retains the counters when a later `runAgent({ snapshot })` resumes.                                                                                                                                         |
-| **Spend records**    | The cost is already incurred when the event is reported, so entries are append-only facts. Replay folds every entry, and a call re-executed by crash recovery journals its own usage on top. A recovered total therefore reflects cumulative cost, including the call whose result the crash lost. |
-| **Stragglers**       | A call that settles after a `runAgent` leg resolved still folds into `result.usage`, but its machine event is dropped. Watch `usage.dropped` on `onTrace` if a counter looks short.                                                                                                                |
-| **Coverage**         | Only usage your executor reports is delivered. No `usage` on the result means no event. [`simulateAgent`](verify.md) scripts return no usage, so a token counter stays `0` under simulation. Test budgets with `runAgent` and a usage-reporting mock.                                              |
+| Area                 | Rule                                                                                                                                                                                                                                                  |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Not model-facing** | The `@agent.*` namespace is excluded from `getAcceptedEvents` and `parseAgentEvent`. The event is never a decision candidate, even under `allowedEvents: ['*']`, and cannot be forged from a wire message.                                            |
+| **Durability**       | The event is folded into machine context, so a native snapshot from `result.persist()` retains the counters when a later `runAgent({ snapshot })` resumes.                                                                                            |
+| **Run scope**        | `result.usage` counts calls made during that run only. Persist cumulative counters in machine context when they must survive snapshot resume.                                                                                                         |
+| **Stragglers**       | A call that settles after a `runAgent` leg resolved still folds into `result.usage`, but its machine event is dropped. Watch `usage.dropped` on `onTrace` if a counter looks short.                                                                   |
+| **Coverage**         | Only usage your executor reports is delivered. No `usage` on the result means no event. [`simulateAgent`](verify.md) scripts return no usage, so a token counter stays `0` under simulation. Test budgets with `runAgent` and a usage-reporting mock. |
 
 Opt in with a transition.
 
@@ -374,7 +374,7 @@ deciding: {
 
 ### Uncontrolled: `provideExecutors` + `createActor`
 
-Delivery is built in, but it follows the binding boundary. `provideExecutors` does not descend into invoked child machines, so a child with its own agent invokes needs its own `provideExecutors(...)` call. Until it has one, its calls report no usage anywhere. `runAgent` rebinds children and reports their usage to the root. There is no run cycle on the [uncontrolled path](any-stack.md#controlled-and-uncontrolled), so no stragglers are dropped either.
+Delivery is built in, but it follows the binding boundary. `provideExecutors` does not descend into invoked child machines, so a child with its own agent invokes needs its own `provideExecutors(...)` call. Until it has one, its calls report no usage anywhere. `runAgent` rebinds children and reports their usage to the root. A [long-lived actor](choosing-a-run-mode.md#long-lived-actor) has no run cycle, so no stragglers are dropped either.
 
 ```ts no-check
 import { createActor, toPromise } from "xstate";
@@ -388,10 +388,6 @@ actor.start();
 
 const output = await toPromise(actor); // stoppedBy: 'tokens'
 ```
-
-### Step path: an ordinary event
-
-On [the step path](steps.md#token-usage-on-this-path) the host holds the raw executor result. Normalize it with `getCallUsage(raw)` and append the event yourself. The entry is journaled, so `replay` reproduces the folded counter exactly.
 
 ### Plain XState: manual send
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -14,7 +14,7 @@ This page covers the APIs that check an agent machine before it runs. None of th
 
 Use these APIs to check that an LLM-generated machine is legal before you run it. See [authoring from scratch](quickstart.md). You can also use them to confirm that a refactor preserved behavior, so a machine converted [from a loop](from-a-loop.md) is safe to ship.
 
-> **Note:** Everything on this page runs on `machine.config` and the pure step path, with no provider, no network, and no keys. It is deterministic, so these checks work as ordinary unit tests in any test runner, such as vitest or jest, and as CI checks.
+> **Note:** Everything on this page runs on `machine.config` and deterministic transition traversal, with no provider, no network, and no keys. These checks work as ordinary unit tests in any test runner, such as vitest or jest, and as CI checks.
 
 ## Machine linting
 
@@ -41,16 +41,16 @@ skip checks by code.
 assertAgentMachine(machine, { warnings: true });
 ```
 
-| Code                       | Severity | Fires when                                                                                                                                                                                                                                                                         |
-| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `unreachable-state`        | error    | A state that no transition, `always`, `choice`, `onDone`, or `onError` can reach from the initial state. The check is conservative. Dynamic function transitions over-approximate, so it never reports a false positive. It is exact for `fromConfig` machines, because the lowering retains their declared targets.                 |
-| `decide-without-events`    | error    | A state invokes `agent.decide` but neither it nor any ancestor handles any event, so the chosen event can never be delivered.                                                                                                                                                      |
-| `unserializable-context`   | warning  | The context schema exposes no JSON schema, for example a `z.custom` messages array, so its fields cannot be checked statically for JSON persist and resume.                                                                                                                                   |
-| `direct-object-src`        | warning  | An invoke `src` is a direct object or machine value that `runAgent` cannot rebind, so it inherits no host executors.                                                                                                                                                            |
-| `final-without-output`     | error    | The machine declares an output schema but a top-level final state has no `output`.                                                                                                                                                                                                 |
-| `final-output-reads-event` | warning  | A top-level final state's `output` function reads the entering `event`. Final `output` functions are evaluated more than once with different events, so `event` is unreliable. Read `context` only, and capture what you need into context in the transition that targets the final state. |
-| `undeclared-event`         | warning  | A state handles an event in `on:` that is not declared in `schemas.events` and is not a builtin or wildcard pattern. Its payload stays unvalidated. This is usually a typo. The check is skipped when the machine declares no events.                                                               |
-| `missing-final`            | warning  | The machine has no reachable final state, so it can only idle or loop. This is legal, but flagged.                                                                                                                                                                                                     |
+| Code                       | Severity | Fires when                                                                                                                                                                                                                                                                                                           |
+| -------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `unreachable-state`        | error    | A state that no transition, `always`, `choice`, `onDone`, or `onError` can reach from the initial state. The check is conservative. Dynamic function transitions over-approximate, so it never reports a false positive. It is exact for `fromConfig` machines, because the lowering retains their declared targets. |
+| `decide-without-events`    | error    | A state invokes `agent.decide` but neither it nor any ancestor handles any event, so the chosen event can never be delivered.                                                                                                                                                                                        |
+| `unserializable-context`   | warning  | The context schema exposes no JSON schema, for example a `z.custom` messages array, so its fields cannot be checked statically for JSON persist and resume.                                                                                                                                                          |
+| `direct-object-src`        | warning  | An invoke `src` is a direct object or machine value that `runAgent` cannot rebind, so it inherits no host executors.                                                                                                                                                                                                 |
+| `final-without-output`     | error    | The machine declares an output schema but a top-level final state has no `output`.                                                                                                                                                                                                                                   |
+| `final-output-reads-event` | warning  | A top-level final state's `output` function reads the entering `event`. Final `output` functions are evaluated more than once with different events, so `event` is unreliable. Read `context` only, and capture what you need into context in the transition that targets the final state.                           |
+| `undeclared-event`         | warning  | A state handles an event in `on:` that is not declared in `schemas.events` and is not a builtin or wildcard pattern. Its payload stays unvalidated. This is usually a typo. The check is skipped when the machine declares no events.                                                                                |
+| `missing-final`            | warning  | The machine has no reachable final state, so it can only idle or loop. This is legal, but flagged.                                                                                                                                                                                                                   |
 
 ## Test assertions
 
@@ -80,7 +80,7 @@ test("happy path settles done", async () => {
 });
 ```
 
-Guards stay in force throughout. `canReach` and `simulateAgent` walk the same step path that `runAgent` uses, so a graph path that a guard rejects never counts as reachable. These tests pin the machine's shape as prompts and models change.
+Guards stay in force throughout. `canReach` and `simulateAgent` traverse the same machine transitions as `runAgent`, so a graph path that a guard rejects never counts as reachable. These tests pin the machine's shape as prompts and models change.
 
 ## Deterministic executors
 
@@ -98,11 +98,11 @@ const machine = emailDrafter.provide({
 
 [examples/email-drafter/agent-logic.ts](../examples/email-drafter/agent-logic.ts) drives a full run this way, with fixed values and no model call.
 
-Use deterministic executors when the test should exercise the real `runAgent` path with canned model output. Use [`simulateAgent`](#scripted-playthroughs) when a scripted playthrough on the pure step path is enough.
+Use deterministic executors when the test should exercise the real `runAgent` path with canned model output. Use [`simulateAgent`](#scripted-playthroughs) when a model-free transition playthrough is enough.
 
 ## Scripted playthroughs
 
-`simulateAgent(machine, { input, script, maxSteps? })` runs a deterministic, model-free playthrough on the pure step path. The `script` supplies responses as FIFO queues, so runs are reproducible.
+`simulateAgent(machine, { input, script, maxSteps? })` runs a deterministic, model-free transition playthrough. The `script` supplies responses as FIFO queues, so runs are reproducible.
 
 - `decisions` holds the `ChosenEvent` to apply per decision, keyed by decision src, usually `agent.decide`.
 - `text` holds output values for text requests, keyed by request src.
@@ -154,7 +154,6 @@ if (result.status === "done") {
 
 <!-- viz: branch exploration tree for the refund machine: deciding -> AUTO_APPROVE (pruned by guard) / NEEDS_REVIEW -> awaitingHuman -> refunded, denied -->
 
-
 ```ts
 import { explorePaths } from "@statelyai/agent";
 
@@ -204,7 +203,7 @@ For machines authored as data, validate the config with `validateAgentConfig(con
 
 - [Debugging](debugging.md): scripted reproduction and the diagnostic codes in context.
 - [Evals](evals.md): scoring runs on output, trajectory, and budget.
-- [Hosts and executors](hosts.md#scripted-executors): keyless scripted executors for `runAgent`.
+- [Quickstart](quickstart.md#define-and-run-one-artifact): keyless scripted executors for `runAgent`.
 - [Machines as data](machines-as-data.md): verifying a machine lowered from a config.
 - [Migrating from a hand-rolled loop](from-a-loop.md): pinning behavior across a refactor.
 - [examples/verification](../examples/verification/index.ts): every API on this page run over one refund-approval machine, keyless, including `canReach` proving that an over-limit payout without human approval is unreachable.


### PR DESCRIPTION
## Summary

- remove stale event-log, replay, and public step-path guidance left by the API simplification
- repair dead local anchors and symbolic source references
- document exported type helpers, host-owned model settings, and message text extraction

## Validation

- `pnpm docs:check` (50 checked snippets, 0 failed)
- Oxfmt on changed Markdown
- `pnpm build && pnpm check:dts`
- local Markdown file/anchor scan (114 files, 0 misses)
- source-contract assertions and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified deterministic transition testing, simulation, verification, and agent execution guidance.
  * Added guidance for type-extraction helpers, message text handling, shared message event constants, and hand-written executor integrations.
  * Documented model settings, precedence rules, usage scopes, observability, and long-lived actor configuration.
  * Updated API references, navigation links, examples, tables, and terminology for consistency.
  * Removed obsolete manual instructions for appending usage events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->