### PR TITLE
Add the event log as the source of truth for a run

### DIFF
--- a/.changeset/event-log-source-of-truth-rebuild.md
+++ b/.changeset/event-log-source-of-truth-rebuild.md
@@ -1,0 +1,16 @@
+---
+"@statelyai/agent": minor
+---
+
+**The event log is the source of truth for a run.** `runAgent` journals the root machine's external inputs as `AgentLogEntry` values, and a run resumes from that log.
+
+- `result.events` is a complete, self-contained log segment: a reserved `@agent.init` entry (carrying `input` or a persisted `snapshot`, plus a per-lineage `metadata.executionId`), then every host event, child completion, timer, `@agent.usage`, and `agent.messages` event. Raised events are re-derived on replay.
+- `onEvent(entry)` observes each entry as it is appended. `verification` (default on) stamps a per-entry `stateHash` from the live snapshot.
+- `runAgent({ events })` resumes by replay. Recorded results are never re-executed; an in-flight request re-executes with the same `info.callKey`.
+- A `snapshot` alongside the log is a cache: trusted when its `agentMeta` lineage id, index, and hash match the tail, otherwise the log wins. A diverged cache throws `AgentSnapshotDivergedError` (`snapshot-diverged`). `persist()` stamps `agentMeta: { machineId, version, logId, logIndex }`.
+- Across a `machine.version` change, pass the old `events` and the migrated `snapshot`; the result starts a new segment whose init entry records `metadata.migratedFrom`. Old events without a snapshot throw `AgentMachineVersionMismatchError`.
+- Snapshot-only resume also yields a replayable log.
+- `@agent.usage` entries are always journaled; `result.usage` folds them via `getUsageFromEvents`. Delivery to the machine is still gated on a declared transition.
+- Executors receive `info.callKey` (`<executionId>:<requestId>#<n>`), identical across crash re-execution, for provider and tool idempotency.
+- New exports: `replay`, `forkEventLog`, `getLogExecutionId`, `getSnapshotStateHash`, `agentCallOccurrence`, `AgentEventLogStore`, `createInMemoryEventLogStore`, `assertEventLogStoreConformance`, `AgentEventLogConflictError`, `AgentReplayDivergenceError`, `AgentEventLogError`.
+- Durability stays with the host. No durable runner and no SQLite subpath; the Cloudflare Durable Object example persists the journal in SQLite and drives each turn with `runAgent`.

--- a/.changeset/event-log-source-of-truth.md
+++ b/.changeset/event-log-source-of-truth.md
@@ -1,0 +1,13 @@
+---
+"@statelyai/agent": minor
+---
+
+Add the event log as the source of truth for a run; a snapshot is a verified cache over it.
+
+- `runAgent` journals the root machine's external inputs as `AgentLogEntry` values: the reserved `@agent.init` entry, host events, child completions, timers, `@agent.usage`, and `agent.messages`. `result.events` is a complete, self-contained log; `onEvent` delivers each entry as it is appended; `verification` (default on) stamps a per-entry state hash computed from the live snapshot.
+- `runAgent({ events })` resumes by replaying the log. Recorded results are reused, never re-executed; a request that was in flight re-executes with the same `info.callKey`. A `snapshot` passed alongside the log is trusted only when its `agentMeta` lineage id, index, and hash match the log's tail; otherwise the log wins, and a diverged cache throws `AgentSnapshotDivergedError`.
+- Across a `machine.version` change, pass the old `events` and the migrated `snapshot`; the result starts a new log segment whose init entry carries the snapshot and `metadata.migratedFrom`. Old events without a snapshot throw `AgentMachineVersionMismatchError`.
+- Every `@agent.usage` event is journaled as a spend record whether or not the machine handles it; `result.usage` folds the log (`getUsageFromEvents`).
+- Executors receive `info.callKey`, a deterministic per-call idempotency key (`<executionId>:<requestId>#<n>`).
+- New exports: `replay`, `forkEventLog`, `initEntry`, `createReplayEntry`, `validateReplayEntries`, `getLogExecutionId`, `getSnapshotStateHash`, `agentCallOccurrence`, `rebindActorSession`, `AgentEventLogStore`, `createInMemoryEventLogStore`, `assertEventLogStoreConformance`, `AgentEventLogConflictError`, `AgentReplayDivergenceError`, `AgentEventLogError`, `NonSerializableAgentEventError`.
+- Durability stays with the host. The Cloudflare Durable Object example persists the journal in SQLite through the store interface and drives each turn with `runAgent`.

--- a/.changeset/run-agent-write-ahead-store.md
+++ b/.changeset/run-agent-write-ahead-store.md
@@ -1,0 +1,22 @@
+---
+"@statelyai/agent": minor
+---
+
+**`runAgent` can own the event log's durability.** Pass a store and a thread and the run reads its resume log from storage and writes every entry back, write-ahead.
+
+```ts
+const result = await runAgent(machine, {
+  store,
+  threadId: "session-1",
+  input,
+  executors,
+});
+```
+
+- `store` (an `AgentEventLogStore`) plus `threadId` (required with it, `AgentError` code `missing-thread-id` otherwise). With no `events`, the thread's log is the resume — an empty thread starts fresh from `input`.
+- Each entry is appended at its own `index` as `expectedIndex`, so a concurrent writer conflicts instead of interleaving.
+- **Append-before-execute.** No text or decision call starts until every entry before it is durable; pure transitions never wait. The result resolves only once the run's writes have landed.
+- A rejected write aborts in-flight work and settles `{ status: 'error', cause: 'journal' }` — a new `RunAgentErrorCause`. No further calls run.
+- Passing `events` as well keeps that log as the resume, and the thread's length must match it.
+- `onEvent` is unchanged: a synchronous observer, never awaited. Persisting there stays at-least-once; `store` is the write-ahead seam.
+- `runAgentLoop` threads `store`/`threadId` through, reading the thread each turn instead of carrying the log itself.

--- a/docs/event-log.md
+++ b/docs/event-log.md
@@ -1,0 +1,155 @@
+# The event log
+
+The event log is an append-only journal of the external inputs a machine consumed. It is the source of truth for a run: `replay` folds it back into a snapshot without executing anything.
+
+## What is journaled
+
+Only external inputs, in the order the run accepted them:
+
+- The reserved `@agent.init` first entry, carrying machine `input` or a persisted `snapshot`.
+- Host-sent events.
+- Child completions: `xstate.done.actor` and `xstate.error.actor`, with output inline.
+- Timer firings.
+- `@agent.usage` spend records and `agent.messages` events.
+
+Raised and internal events are never journaled. Replay re-derives them from the machine's own logic, so journaling them would apply them twice.
+
+Recorded results are never re-executed. A model call whose completion is in the log runs zero times on replay.
+
+## Entry shape
+
+```ts no-check
+interface AgentLogEntry {
+  schemaVersion: 1;
+  id: string;
+  index: number;
+  recordedAt: string;
+  machineId: string;
+  machineVersion: string;
+  event: EventObject;
+  causationId?: string;
+  metadata?: Record<string, JsonValue>;
+  verification?: { stateHash: string };
+}
+```
+
+- `recordedAt` is acceptance metadata, not machine time. A transition that needs time takes it from the event.
+- `machineVersion` is the machine's declared `version`, or its structural hash when none is declared.
+- `verification.stateHash` is the hash of the persisted snapshot after the entry is applied.
+- `metadata` is host-owned and stored verbatim. The init entry's `metadata.executionId` names the lineage; read it with `getLogExecutionId(entries)`.
+
+Entries are strict JSON. `createReplayEntry`, `initEntry`, and every store append reject values JSON would drop or coerce (`undefined`, functions, symbols, bigint, non-finite numbers, `Date`, `Map`, `Set`, class instances, cycles) with `NonSerializableAgentEventError`, which carries the offending `path`. `Error` payloads on `xstate.error.actor` are normalized to `{ name, message, cause? }`. Use `assertJsonSerializable` and `assertAgentLogEntry` at custom transport boundaries.
+
+## Record a log
+
+`runAgent` returns a complete, self-contained segment as `result.events`, and calls `onEvent` once per newly accepted entry as the run proceeds, init entry first.
+
+```ts no-check
+const appended: AgentLogEntry[] = [];
+
+const result = await runAgent(machine, {
+  input,
+  executors,
+  onEvent: (entry) => appended.push(entry)
+});
+```
+
+`onEvent` is synchronous: it observes an entry after XState accepted it and cannot await a store before the transition. Buffer entries there and flush them to the store. Execution is at-least-once, not append-before-execute.
+
+To build entries yourself, use `initEntry` for index 0 and `createReplayEntry` for each subsequent external input.
+
+## Replay
+
+`replay` is a pure fold. No actor starts, no action runs, no model is called.
+
+```ts no-check
+const { snapshot, persistedSnapshot } = replay(machine, entries);
+```
+
+- The first entry seeds the fold: `input` folds from `initialTransition`, `snapshot` restores purely and the rest of the log folds onto it.
+- `replay(machine, entries.slice(0, n))` rebuilds the state as of any point in the log — time travel with no side effects.
+- Journaled child sessions are rebound to the sessions the current fold minted, so completions still apply.
+
+## Verification
+
+Every entry carries `verification.stateHash` by default. `replay` checks it as it folds.
+
+| `verify` | Behavior |
+| --- | --- |
+| `true` (default) | Checks entries that carry a hash; entries without one pass. |
+| `'strict'` | Requires a hash on every entry. |
+| `false` | No checks. |
+
+```ts no-check
+try {
+  replay(machine, entries, { verify: "strict" });
+} catch (error) {
+  if (error instanceof AgentReplayDivergenceError) {
+    console.error(error.eventId, error.index, error.kind);
+  }
+}
+```
+
+- `kind: "state"` means the machine derived a different state than the one recorded.
+- `kind: "missing-verification"` means an entry carried no hash under `'strict'`.
+- `AgentMachineVersionMismatchError` rejects an entry stamped for another machine id or version before folding it. The init-with-snapshot entry is exempt: that entry is the version bridge.
+
+Structural hashing cannot see function bodies or validator implementations. Bump the machine's own `version` when those semantics change.
+
+## Hazards
+
+Replayability rests on pure transitions.
+
+- Keep transitions, guards, and request inputs pure functions of state and event. `Date.now()` or `Math.random()` in a guard produces a different fold and throws `AgentReplayDivergenceError` on the next replay. Inject time and randomness as events or as input.
+- Never mutate a journaled entry. There is no update and no delete. Rewriting an entry invalidates every hash after it; fork instead.
+- Journal external inputs only when building entries by hand.
+- Keep context JSON-serializable. Hold sessions, clients, and sockets in closures and store only their ids.
+- Replay against the machine `runAgent` folded. When actors come in through `runAgent({ actors })`, call `replay(machine.provide({ actors }), entries)`. The executor-bound machine is never needed; recorded results replace executors.
+- A run whose initial state cannot be serialized to JSON produces no log: `result.events` is empty and `onEvent` never fires. `replay` rejects a log without an init entry, so `runAgent` journals nothing rather than a suffix.
+
+## Fork
+
+`forkEventLog(entries, upToIndex)` returns the prefix `[0, upToIndex)` as a new, still self-contained log. `upToIndex` is exclusive and must leave the init entry in place. A fork copies the init entry, so it inherits the parent's execution id.
+
+```ts no-check
+const branch = forkEventLog(entries, 8);
+```
+
+`store.fork({ threadId, newThreadId, upToIndex })` does the same at the storage layer. To diverge, append different entries to the new thread.
+
+## Usage totals
+
+`getUsageFromEvents(entries)` folds the `@agent.usage` entries into one cumulative total. The log is the source of truth, so the totals are a projection of it rather than a host-side accumulator. See [Usage and budgets](usage-and-budgets.md).
+
+## Stores
+
+`AgentEventLogStore` is the one interface a host implements. It is append-only, with optimistic concurrency on log length.
+
+```ts no-check
+const store = createInMemoryEventLogStore();
+
+await store.append({ threadId: "session-1", expectedIndex: 0, entries: [initEntry(machine, { input })] });
+
+const recent = await store.read("session-1", { from: 3 });
+const next = await store.length("session-1"); // the next expectedIndex
+```
+
+- `append` is atomic. A stale writer fails with `AgentEventLogConflictError`, carrying `threadId`, `expectedIndex`, and `actualIndex`, so two hosts resuming one thread resolve to exactly one winner. Entry indices must be contiguous from `expectedIndex`, and ids unique within the thread.
+- `read` and `length` are the only reads. Everything else about a thread is derived from its entries.
+- `fork` copies a prefix onto a fresh thread.
+
+`createInMemoryEventLogStore()` is the reference implementation. No SQLite or database store ships with the package: hosts own durability. An append-only table with a `(thread_id, index)` primary key maps onto any database.
+
+## Store conformance
+
+```ts no-check
+await assertEventLogStoreConformance(() => createMyStore(), { describe, it });
+```
+
+The suite runs a host-written store against the reference on races, isolation, ordering, and fork semantics. It drives any test runner, or a plain script.
+
+## Related
+
+- [Persistence](persistence.md): persisting the log, snapshot-as-cache, and the version bridge.
+- [Hosts and executors](hosts.md): idempotency keys for at-least-once execution.
+- [Observability](observability.md): traces alongside the log.

--- a/docs/event-log.md
+++ b/docs/event-log.md
@@ -42,7 +42,38 @@ Entries are strict JSON. `createReplayEntry`, `initEntry`, and every store appen
 
 ## Record a log
 
-`runAgent` returns a complete, self-contained segment as `result.events`, and calls `onEvent` once per newly accepted entry as the run proceeds, init entry first.
+`runAgent` returns a complete, self-contained segment as `result.events`. Two ways to get it into storage:
+
+| | `store` | `onEvent` |
+| --- | --- | --- |
+| When it writes | Write-ahead: every entry is appended to the store, and pending writes are awaited before each model call | Synchronously, as the entry is accepted |
+| Waits | The result resolves only after the run's writes land | Never awaited |
+| On failure | The run stops: `{ status: "error", cause: "journal" }` | Nothing; the host owns it |
+| Guarantee | Append-before-execute | At-least-once, if the host persists there |
+
+### `store`: write-ahead
+
+Pass a [store](#stores) and the thread to write to. The run reads that thread as its resume log and appends to it.
+
+```ts no-check
+const result = await runAgent(machine, {
+  input,
+  store,
+  threadId: "session-1",
+  executors
+});
+```
+
+- Each entry is written at its own `index` as `expectedIndex`, so a concurrent writer conflicts instead of interleaving.
+- No model call starts until every entry before it is durable. Pure transitions never wait.
+- A rejected write (an `AgentEventLogConflictError`, or any storage failure) aborts in-flight work and settles the run `{ status: "error", cause: "journal" }`. No further calls run.
+- A `@agent.usage` entry that arrives after the run settled is still written, but the result does not wait for it.
+- `threadId` is required with a `store`; without it `runAgent` throws `AgentError` with code `missing-thread-id`.
+- Passing `events` as well makes that log the resume, and the store's thread length must match it — otherwise `AgentEventLogConflictError`.
+
+### `onEvent`: observer
+
+`onEvent` fires once per newly accepted entry, init entry first. It is synchronous and never awaited: it observes an entry after XState accepted it and cannot hold up the transition. Persisting there is at-least-once, not append-before-execute.
 
 ```ts no-check
 const appended: AgentLogEntry[] = [];
@@ -53,8 +84,6 @@ const result = await runAgent(machine, {
   onEvent: (entry) => appended.push(entry)
 });
 ```
-
-`onEvent` is synchronous: it observes an entry after XState accepted it and cannot await a store before the transition. Buffer entries there and flush them to the store. Execution is at-least-once, not append-before-execute.
 
 To build entries yourself, use `initEntry` for index 0 and `createReplayEntry` for each subsequent external input.
 
@@ -105,7 +134,8 @@ Replayability rests on pure transitions.
 - Journal external inputs only when building entries by hand.
 - Keep context JSON-serializable. Hold sessions, clients, and sockets in closures and store only their ids.
 - Replay against the machine `runAgent` folded. When actors come in through `runAgent({ actors })`, call `replay(machine.provide({ actors }), entries)`. The executor-bound machine is never needed; recorded results replace executors.
-- A run whose initial state cannot be serialized to JSON produces no log: `result.events` is empty and `onEvent` never fires. `replay` rejects a log without an init entry, so `runAgent` journals nothing rather than a suffix.
+- A run whose initial state cannot be serialized to JSON produces no log: `result.events` is empty, `onEvent` never fires, and nothing is written to a `store`. `replay` rejects a log without an init entry, so `runAgent` journals nothing rather than a suffix.
+- `onEvent` alone does not make a call append-before-execute. A crash between an entry and the host's flush loses it. Use `store` when that matters.
 
 ## Fork
 
@@ -135,6 +165,7 @@ const next = await store.length("session-1"); // the next expectedIndex
 ```
 
 - `append` is atomic. A stale writer fails with `AgentEventLogConflictError`, carrying `threadId`, `expectedIndex`, and `actualIndex`, so two hosts resuming one thread resolve to exactly one winner. Entry indices must be contiguous from `expectedIndex`, and ids unique within the thread.
+- `runAgent({ store, threadId })` drives all three: `read` to resume, `append` per entry, `length` to check an explicit `events` log against the thread.
 - `read` and `length` are the only reads. Everything else about a thread is derived from its entries.
 - `fork` copies a prefix onto a fresh thread.
 

--- a/docs/event-log.md
+++ b/docs/event-log.md
@@ -67,9 +67,9 @@ const result = await runAgent(machine, {
 - Each entry is written at its own `index` as `expectedIndex`, so a concurrent writer conflicts instead of interleaving.
 - No model call starts until every entry before it is durable. Pure transitions never wait.
 - A rejected write (an `AgentEventLogConflictError`, or any storage failure) aborts in-flight work and settles the run `{ status: "error", cause: "journal" }`. No further calls run.
-- A `@agent.usage` entry that arrives after the run settled is still written, but the result does not wait for it.
+- A `@agent.usage` entry that arrives after the run settled is still written, but the result does not wait for it. Await `result.drain()` before terminating the process if you care about those straggler entries; it resolves once every write issued so far has landed, and never rejects (a failed write already settled the run with `cause: "journal"`).
 - `threadId` is required with a `store`; without it `runAgent` throws `AgentError` with code `missing-thread-id`.
-- Passing `events` as well makes that log the resume, and the store's thread length must match it — otherwise `AgentEventLogConflictError`.
+- Passing `events` as well makes that log the resume, and it must BE the thread's log: a different length throws `AgentEventLogConflictError`, and an entry-for-entry mismatch at the same length throws `AgentError` with code `event-log-conflict`.
 
 ### `onEvent`: observer
 
@@ -165,7 +165,7 @@ const next = await store.length("session-1"); // the next expectedIndex
 ```
 
 - `append` is atomic. A stale writer fails with `AgentEventLogConflictError`, carrying `threadId`, `expectedIndex`, and `actualIndex`, so two hosts resuming one thread resolve to exactly one winner. Entry indices must be contiguous from `expectedIndex`, and ids unique within the thread.
-- `runAgent({ store, threadId })` drives all three: `read` to resume, `append` per entry, `length` to check an explicit `events` log against the thread.
+- `runAgent({ store, threadId })` drives all three: `read` to resume, `append` per entry, `read` again to check an explicit `events` log against the thread.
 - `read` and `length` are the only reads. Everything else about a thread is derived from its entries.
 - `fork` copies a prefix onto a fresh thread.
 

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -20,6 +20,34 @@ const result = await runAgent(machine, {
 
 Text, stream, and decision executors all receive `(request, info)`; cancellation is `info.signal`.
 
+## Idempotency keys
+
+Execution is at-least-once. A host runs the request and then journals its completion, so a crash between the two re-executes the request on resume.
+
+`info.callKey` makes the duplicate safe to drop. Its format is `<executionId>:<requestId>#<n>`:
+
+- `executionId` is the log's lineage id, pinned in the reserved `@agent.init` entry's `metadata` and inherited by every resume.
+- `requestId` is the invoke site, and `n` counts that site's completions in the log — each iteration of a looped state gets its own key.
+- A resumed run re-executing an in-flight request passes the same `callKey` as the original attempt.
+- A fork copies the init entry, so it keeps the parent's lineage id and can reuse results cached under the parent's keys.
+- It is `undefined` off the `runAgent` path (a bare `provideExecutors` bind) and on a run with no event log.
+
+Pass it to the provider or tool as the idempotency key, and dedupe on it in your own cache:
+
+```ts no-check
+const executors = {
+  generateText: async (request, info) => {
+    const cached = info.callKey ? results.get(info.callKey) : undefined;
+    if (cached) return cached;
+    const result = await callProvider(request, { idempotencyKey: info.callKey });
+    if (info.callKey) results.set(info.callKey, result);
+    return result;
+  }
+};
+```
+
+See [The event log](event-log.md).
+
 ## Optional AI SDK default
 
 ```ts no-check

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -22,7 +22,7 @@ Text, stream, and decision executors all receive `(request, info)`; cancellation
 
 ## Idempotency keys
 
-Execution is at-least-once. A host runs the request and then journals its completion, so a crash between the two re-executes the request on resume.
+Execution is at-least-once. A host runs the request and then journals its completion, so a crash between the two re-executes the request on resume. `runAgent({ store, threadId })` makes the log durable *before* each call, which bounds the duplicate to the one call that was in flight; it does not remove it.
 
 `info.callKey` makes the duplicate safe to drop. Its format is `<executionId>:<requestId>#<n>`:
 

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -28,19 +28,21 @@ Execution is at-least-once. A host runs the request and then journals its comple
 
 - `executionId` is the log's lineage id, pinned in the reserved `@agent.init` entry's `metadata` and inherited by every resume.
 - `requestId` is the invoke site, and `n` counts that site's completions in the log — each iteration of a looped state gets its own key.
+- A decision retry appends its attempt ordinal: `<executionId>:<requestId>#<n>.<attempt>`, where `attempt` is the number of prior failed attempts. Each retry is a different request, so it gets a different key.
 - A resumed run re-executing an in-flight request passes the same `callKey` as the original attempt.
-- A fork copies the init entry, so it keeps the parent's lineage id and can reuse results cached under the parent's keys.
+- A fork copies the init entry, so it keeps the parent's lineage id and can reuse results cached under the parent's keys for the requests it has not changed.
 - It is `undefined` off the `runAgent` path (a bare `provideExecutors` bind) and on a run with no event log.
 
-Pass it to the provider or tool as the idempotency key, and dedupe on it in your own cache:
+The key names the call *site*, not the request. A fork inherits the parent's lineage id, so a fork that changes what it asks at the same invoke site produces the same key for a different request. Cache on `callKey` **and** a fingerprint of the request, and reuse the cached result only when the request also matches. Pass `callKey` to a provider as its dedupe key for that identical request:
 
 ```ts no-check
 const executors = {
   generateText: async (request, info) => {
+    const fingerprint = JSON.stringify([request.model, request.prompt, request.messages]);
     const cached = info.callKey ? results.get(info.callKey) : undefined;
-    if (cached) return cached;
+    if (cached?.fingerprint === fingerprint) return cached.result;
     const result = await callProvider(request, { idempotencyKey: info.callKey });
-    if (info.callKey) results.set(info.callKey, result);
+    if (info.callKey) results.set(info.callKey, { fingerprint, result });
     return result;
   }
 };

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -20,6 +20,7 @@
     "any-stack",
     "steps",
     "---State & durability---",
+    "event-log",
     "persistence",
     "human-in-the-loop",
     "---Production---",

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,7 +15,9 @@ await runAgent(machine, {
 
 Agent trace kinds are `run.start`, `request.start`, `request.end`, `request.error`, `stream.chunk`, `machine.transition`, `emit`, `usage.dropped`, and `run.end`.
 
-`serializeTraceEvent` creates a JSON-safe projection. Traces are observations, not a persistence protocol.
+`serializeTraceEvent` creates a JSON-safe projection. Traces are observations, not a persistence protocol; the [event log](event-log.md) is.
+
+`usage.dropped` means the `@agent.usage` event was not delivered to the machine, because no active state accepted it or the leg had already settled. The spend is still journaled and still counted: the entry is in the event log, and `getUsageFromEvents` folds it into the totals. Only the machine event is dropped.
 
 ## Async stream
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,45 +1,119 @@
 # Persistence
 
-Stately Agent uses native XState snapshots. There is no Agent event-log format or storage adapter.
+The [event log](event-log.md) is the durable artifact. A snapshot is a cache over it.
 
-## Persist and resume
+- The log is an ordered array of the external inputs the machine received. A run is fully reconstructed from it.
+- The persisted snapshot is the machine's serialized state at one point. It lets a resume skip the fold.
+- Live run state — the actor, in-flight requests, stream chunks — is derived and disposable.
+
+## Persist the log
+
+Append entries as they happen through `onEvent`, or store `result.events` when the leg settles.
 
 ```ts no-check
-const paused = await runAgent(machine, { input, executors });
+const appended: AgentLogEntry[] = [];
 
-if (paused.status === "idle") {
-  await storage.put("run-42", paused.persist());
-}
-
-const snapshot = await storage.get("run-42");
-const resumed = await runAgent(machine, {
-  snapshot,
-  event: { type: "APPROVE" },
+const result = await runAgent(machine, {
+  input,
   executors,
+  onEvent: (entry) => appended.push(entry)
+});
+
+await store.append({ threadId, expectedIndex: appended[0].index, entries: appended });
+```
+
+`onEvent` is synchronous, so it buffers rather than awaits. Flush the buffer to the store as the leg settles, or on whatever cadence the host durability model needs.
+
+`result.events` is a complete, self-contained segment: its first entry is the reserved `@agent.init` entry, so it replays with no side channel.
+
+## Resume from the log
+
+Pass `events` with no snapshot. `runAgent` folds the log and continues from there.
+
+```ts no-check
+const resumed = await runAgent(machine, {
+  events: await store.read(threadId),
+  event: { type: "APPROVE" },
+  executors
 });
 ```
 
-`result.snapshot` is the live typed snapshot for inspection. `result.persist()` is the XState persisted snapshot for serialization and later restoration.
+- Recorded results are replayed, never re-executed.
+- A request that was in flight when the log ended has no recorded completion, so it re-executes. Execution is at-least-once; key provider calls on [`info.callKey`](hosts.md#idempotency-keys).
+- A log that already reached a final state settles immediately with the recorded output.
+- The resumed result's `events` extends the same log, so the whole history stays replayable.
 
-## Versioning and migration
+## Snapshot as cache
 
-Use XState's machine-owned `version` and `migrate` fields:
+`persist()` output carries `agentMeta: { machineId, version, logId, logIndex }` — the lineage and position of the log it caches.
+
+Pass `snapshot` alongside `events` to skip the fold:
+
+```ts no-check
+const resumed = await runAgent(machine, {
+  events: await store.read(threadId),
+  snapshot: await snapshots.get(threadId),
+  event: { type: "APPROVE" },
+  executors
+});
+```
+
+- Fast path: `agentMeta.logId` names the log, `logIndex` equals the log length, and the snapshot's state hash matches the tail entry's `verification.stateHash`. Length alone is not enough — a fork or a sibling thread can sit at the same index.
+- Otherwise the log is replayed and the run resumes from the replayed state.
+- A cache that disagrees with the state the log replays to throws `AgentSnapshotDivergedError` (code `snapshot-diverged`). Drop the snapshot and resume from `events` alone.
+
+A snapshot is never authoritative within a version. Snapshot only at quiescent points: a mid-flight snapshot cannot carry in-flight request state, but the log can.
+
+Resuming from a snapshot with no log also yields a self-contained log — the new segment's init entry carries that snapshot — so every result is replayable.
+
+## Version bridge
+
+A log is truth within one `machine.version`. Across a version change, pass the old `events` together with a `snapshot`:
+
+```ts no-check
+const migrated = await runAgent(machine, {
+  events: oldEntries,
+  snapshot: oldSnapshot,
+  executors
+});
+```
+
+- XState's machine-owned `migrate` runs on the snapshot.
+- The result is a **new** segment. Its init entry carries the migrated snapshot and `metadata.migratedFrom`.
+- The old log stays as history under the old version. Keep it if you need to replay the past.
+- Old `events` with no `snapshot` throw `AgentMachineVersionMismatchError`: there is nothing to migrate from.
+
+Declare the version and migration on the machine:
 
 ```ts no-check
 const machine = setup.createMachine({
   version: "2",
-  migrate: (snapshot, fromVersion) => {
-    if (fromVersion === "1") {
-      return { ...snapshot, version: "2", context: upgrade(snapshot.context) };
-    }
-    return snapshot;
-  },
+  migrate: (snapshot, fromVersion) =>
+    fromVersion === "1"
+      ? { ...snapshot, version: "2", context: upgrade(snapshot.context) }
+      : snapshot,
   // ...
 });
 ```
 
-Without a compatible version or migration, XState restores an error snapshot. Stately Agent forwards that as `{ status: "error" }`; it does not stamp, rewrite, or interpret framework snapshots.
-
 ## Framework storage
 
-Store the snapshot through the host framework's normal mechanism: a database, Durable Object, workflow checkpoint, server action store, or XState durable adapter. The framework remains responsible for transactionality, retries, interruption recovery, and retention.
+Implement `AgentEventLogStore` against the host's database, or append through the framework's own mechanism: a Durable Object, workflow checkpoint, or server action store. See [Stores](event-log.md#stores) and [Hosts and executors](hosts.md).
+
+The recipe per turn is the same everywhere: read the log, run, append what the run produced.
+
+```ts no-check
+const events = await store.read(threadId);
+const appended: AgentLogEntry[] = [];
+
+const result = await runAgent(machine, {
+  events,
+  event: incoming,
+  executors,
+  onEvent: (entry) => appended.push(entry)
+});
+
+await store.append({ threadId, expectedIndex: events.length, entries: appended });
+```
+
+The framework remains responsible for transactionality, retries, interruption recovery, and retention.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -8,35 +8,38 @@ The [event log](event-log.md) is the durable artifact. A snapshot is a cache ove
 
 ## Persist the log
 
-Append entries as they happen through `onEvent`, or store `result.events` when the leg settles.
+Hand `runAgent` a [store](event-log.md#stores) and the thread it owns. Entries are written as they are accepted, and no model call runs against a log that is not yet durable.
 
 ```ts no-check
-const appended: AgentLogEntry[] = [];
-
 const result = await runAgent(machine, {
   input,
-  executors,
-  onEvent: (entry) => appended.push(entry)
+  store,
+  threadId,
+  executors
 });
-
-await store.append({ threadId, expectedIndex: appended[0].index, entries: appended });
 ```
 
-`onEvent` is synchronous, so it buffers rather than awaits. Flush the buffer to the store as the leg settles, or on whatever cadence the host durability model needs.
+- A rejected write stops the run: `{ status: "error", cause: "journal" }`.
+- `threadId` is required whenever `store` is given.
+
+`onEvent` remains the observer seam — synchronous, never awaited. Persisting there is at-least-once: a crash between an entry and the host's flush loses it. See [Record a log](event-log.md#record-a-log).
 
 `result.events` is a complete, self-contained segment: its first entry is the reserved `@agent.init` entry, so it replays with no side channel.
 
 ## Resume from the log
 
-Pass `events` with no snapshot. `runAgent` folds the log and continues from there.
+With a `store`, the thread's log is the resume: pass no `events` and no snapshot.
 
 ```ts no-check
 const resumed = await runAgent(machine, {
-  events: await store.read(threadId),
+  store,
+  threadId,
   event: { type: "APPROVE" },
   executors
 });
 ```
+
+An empty thread starts fresh from `input`. Pass `events` explicitly to resume from a log the host holds itself (the store's thread length must then match it).
 
 - Recorded results are replayed, never re-executed.
 - A request that was in flight when the log ended has no recorded completion, so it re-executes. Execution is at-least-once; key provider calls on [`info.callKey`](hosts.md#idempotency-keys).
@@ -100,20 +103,15 @@ const machine = setup.createMachine({
 
 Implement `AgentEventLogStore` against the host's database, or append through the framework's own mechanism: a Durable Object, workflow checkpoint, or server action store. See [Stores](event-log.md#stores) and [Hosts and executors](hosts.md).
 
-The recipe per turn is the same everywhere: read the log, run, append what the run produced.
+The recipe per turn is one call: `runAgent` reads the thread, runs, and writes back.
 
 ```ts no-check
-const events = await store.read(threadId);
-const appended: AgentLogEntry[] = [];
-
 const result = await runAgent(machine, {
-  events,
+  store,
+  threadId,
   event: incoming,
-  executors,
-  onEvent: (entry) => appended.push(entry)
+  executors
 });
-
-await store.append({ threadId, expectedIndex: events.length, entries: appended });
 ```
 
 The framework remains responsible for transactionality, retries, interruption recovery, and retention.

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,8 @@ These examples use one XState machine artifact across different model SDKs and h
 - [guardrails](guardrails), [verification](verification): legal paths and reachability
 - [parallel-streams](parallel-streams): concurrent regions
 - [hierarchical-teams](hierarchical-teams), [swarm-handoff](swarm-handoff): child machines and handoff
-- [long-running-onboarding](long-running-onboarding), [snapshot-migration](snapshot-migration), [crash-recovery](crash-recovery): pauses and native XState snapshots
+- [long-running-onboarding](long-running-onboarding), [snapshot-migration](snapshot-migration): pauses and native XState snapshots
+- [crash-recovery](crash-recovery): events-only recovery from the event log, no snapshot
 - [review-tool-calls](review-tool-calls), [sql-agent](sql-agent), [customer-support](customer-support): explicit, persistable human gates
 - [context-compaction](context-compaction), [chat-with-pdf](chat-with-pdf): framework-native message history
 - [tool-calling](tool-calling): SDK-owned multi-step tools and explicit native message retention; compare [review-tool-calls](review-tool-calls) for machine-gated calls

--- a/examples/cloudflare-agent-host/README.md
+++ b/examples/cloudflare-agent-host/README.md
@@ -1,0 +1,60 @@
+# Cloudflare Agents host
+
+A runnable Worker that hosts the [email drafter](../email-drafter/agent-logic.ts) machine in a Cloudflare Agent (a Durable Object), and the reference recipe for a **durable** host.
+
+**The log is the source of truth; no snapshot is persisted.** The Durable Object keeps one append-only event log in its own SQLite storage ([`event-log-store.ts`](./event-log-store.ts)), and that journal is the entire durable state of a conversation. An evicted Durable Object resumes by folding the log back — journaled model and tool results replay, they are never re-executed.
+
+## The turn
+
+Every turn — the first request, each POST, each WebSocket message — is one `runAgent` call:
+
+```ts
+const entries = await store.read(threadId);
+
+const result = await runAgent(machine, {
+  ...(entries.length > 0 ? { events: entries } : { input }),
+  event,
+  executors,
+  onEvent: (entry) => store.append({ threadId, expectedIndex: entry.index, entries: [entry] }),
+  onTransition: (snapshot) => broadcast(snapshot),
+});
+```
+
+- `events` carries the whole history; a fresh thread has none and starts from `input`.
+- `onEvent` streams each entry to storage at its own index, so the append is optimistic: a concurrent writer conflicts instead of interleaving.
+- Turns are serialized per Durable Object — one leg at a time.
+- A settled turn is cached in memory only. After an eviction it is gone, and the next request folds the log again.
+
+## Protocol
+
+One Durable Object per `:name`, i.e. one conversation.
+
+| Request                            | Effect                                                               |
+| ---------------------------------- | -------------------------------------------------------------------- |
+| `GET /agents/email-drafter/:name`  | The current view: state, interaction, accepted events, draft, output |
+| `POST /agents/email-drafter/:name` | Body is a machine event; validated, then run as one turn             |
+| WebSocket on the same path         | Same events; every transition is broadcast as `{ type: "state", … }` |
+
+An event the current state does not accept is a 400 with the current view. A malformed WebSocket frame gets `{ type: "error", issues }` and schedules no turn. A conversation whose log cannot be folded at all reports 500 — there is no state to show.
+
+## Run
+
+```sh
+pnpm --filter @statelyai/example-cloudflare-agent-host dev        # keyless, scripted
+pnpm --filter @statelyai/example-cloudflare-agent-host dev:live   # real models
+
+curl -X POST localhost:3009/agents/email-drafter/demo \
+  -d '{"type":"PROMPT_SUBMITTED","prompt":"Email ana@x.com about Friday'\''s launch"}'
+curl -X POST localhost:3009/agents/email-drafter/demo -d '{"type":"SEND"}'
+curl -X POST localhost:3009/agents/email-drafter/demo -d '{"type":"END"}'
+```
+
+Without `OPENAI_API_KEY` the host falls back to keyless scripted executors, so the example boots and completes with no credentials.
+
+## Test
+
+```sh
+pnpm --filter @statelyai/example-cloudflare-agent-host test
+```
+
+The suite runs in real workerd. It drives a full cycle across two evictions (asserting the model-call count does not move on resume), checks the journal's shape, and covers the error paths.

--- a/examples/cloudflare-agent-host/README.md
+++ b/examples/cloudflare-agent-host/README.md
@@ -9,19 +9,19 @@ A runnable Worker that hosts the [email drafter](../email-drafter/agent-logic.ts
 Every turn — the first request, each POST, each WebSocket message — is one `runAgent` call:
 
 ```ts
-const entries = await store.read(threadId);
-
 const result = await runAgent(machine, {
-  ...(entries.length > 0 ? { events: entries } : { input }),
+  store,
+  threadId,
+  input, // used only when the thread's log is empty
   event,
   executors,
-  onEvent: (entry) => store.append({ threadId, expectedIndex: entry.index, entries: [entry] }),
   onTransition: (snapshot) => broadcast(snapshot),
 });
 ```
 
-- `events` carries the whole history; a fresh thread has none and starts from `input`.
-- `onEvent` streams each entry to storage at its own index, so the append is optimistic: a concurrent writer conflicts instead of interleaving.
+- `runAgent` reads the thread, runs, and writes back: the store is the whole durable state, and a fresh thread has none and starts from `input`.
+- Writes are write-ahead — each entry is durable before the next model call — and each lands at its own index, so the append is optimistic: a concurrent writer conflicts instead of interleaving.
+- A rejected write fails the turn: `runAgent` rejects, and the cached turn is left where the journal is.
 - Turns are serialized per Durable Object — one leg at a time.
 - A settled turn is cached in memory only. After an eviction it is gone, and the next request folds the log again.
 

--- a/examples/cloudflare-agent-host/README.md
+++ b/examples/cloudflare-agent-host/README.md
@@ -21,7 +21,7 @@ const result = await runAgent(machine, {
 
 - `runAgent` reads the thread, runs, and writes back: the store is the whole durable state, and a fresh thread has none and starts from `input`.
 - Writes are write-ahead — each entry is durable before the next model call — and each lands at its own index, so the append is optimistic: a concurrent writer conflicts instead of interleaving.
-- A rejected write fails the turn: `runAgent` rejects, and the cached turn is left where the journal is.
+- A rejected write settles `runAgent` with an error result. This host throws that result, and the cached turn is left where the journal is.
 - Turns are serialized per Durable Object — one leg at a time.
 - A settled turn is cached in memory only. After an eviction it is gone, and the next request folds the log again.
 

--- a/examples/cloudflare-agent-host/event-log-store.ts
+++ b/examples/cloudflare-agent-host/event-log-store.ts
@@ -1,0 +1,191 @@
+/// <reference types="@cloudflare/workers-types" />
+/**
+ * An {@link AgentEventLogStore} backed by Durable Object SQLite storage.
+ *
+ * This is the host's durability artifact: the append-only journal of external
+ * inputs IS the source of truth for a conversation. A snapshot, if one is kept
+ * at all, is only a compaction cache over what this log already implies.
+ *
+ * The shape: one table keyed by `(thread_id, idx)` with a unique
+ * `(thread_id, entry_id)` index, entries stored as JSON text (so reads and
+ * writes are deep copies by construction), and an optimistic `expectedIndex`
+ * on append that rejects with {@link AgentEventLogConflictError} when a
+ * concurrent writer got there first.
+ *
+ * Durable Object SQL (`ctx.storage.sql.exec`) is synchronous, so no `await`
+ * interleaves between the length check and the insert: two appends racing on
+ * the same `expectedIndex` resolve to exactly one winner, and every write a
+ * synchronous block performs commits as one implicit transaction. When the
+ * full `ctx.storage` is passed, `transactionSync` makes that all-or-nothing
+ * guarantee explicit (and rolls the batch back on a mid-append throw).
+ *
+ * It lives in the example rather than the library because it is host-specific
+ * glue: the contract it implements (`AgentEventLogStore`) is the library's, and
+ * the shared conformance suite (`assertEventLogStoreConformance`) checks that
+ * this implementation really honors it — see `test/event-log-store.workers-test.ts`.
+ */
+import {
+  AgentEventLogConflictError,
+  assertAgentLogEntry,
+  type AgentEventLogStore,
+  type AgentLogEntry,
+} from "@statelyai/agent";
+
+export interface DurableObjectEventLogStoreOptions {
+  /** Table holding the log entries. Defaults to `agent_event_log`. */
+  table?: string;
+}
+
+/**
+ * Either half of a Durable Object's storage API is accepted: `ctx.storage.sql`
+ * (all this store strictly needs) or the whole `ctx.storage`, which also
+ * carries `transactionSync` for an explicit all-or-nothing multi-entry append.
+ */
+export type DurableObjectEventLogStorage = SqlStorage | DurableObjectStorage;
+
+function quoteIdentifier(name: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(
+      `Invalid SQLite table name '${name}': use letters, digits, and underscores only.`,
+    );
+  }
+  return `"${name}"`;
+}
+
+/**
+ * Creates the store on a Durable Object's SQL storage.
+ *
+ * `storage` is the DO's `ctx.storage.sql` (or `ctx.storage`); the table is
+ * created on first use, so the same DO can hold this log alongside whatever
+ * else it stores.
+ */
+export function createDurableObjectEventLogStore(
+  storage: DurableObjectEventLogStorage,
+  options: DurableObjectEventLogStoreOptions = {},
+): AgentEventLogStore {
+  const sql: SqlStorage = "sql" in storage ? storage.sql : storage;
+  // `transactionSync` only exists on the full storage object; without it the
+  // synchronous block is still one implicit transaction in workerd, but an
+  // explicit one also unwinds partial inserts when a guard throws mid-batch.
+  const transact: (run: () => void) => void =
+    "transactionSync" in storage ? (run) => storage.transactionSync(run) : (run) => run();
+
+  const name = options.table ?? "agent_event_log";
+  const table = quoteIdentifier(name);
+  const index = quoteIdentifier(`${name}_thread_entry_id`);
+
+  sql.exec(
+    `CREATE TABLE IF NOT EXISTS ${table} (
+       thread_id TEXT NOT NULL,
+       idx INTEGER NOT NULL,
+       entry_id TEXT NOT NULL,
+       entry TEXT NOT NULL,
+       PRIMARY KEY (thread_id, idx)
+     )`,
+  );
+  sql.exec(`CREATE UNIQUE INDEX IF NOT EXISTS ${index} ON ${table} (thread_id, entry_id)`);
+
+  const lengthOf = (threadId: string): number => {
+    const row = sql.exec(`SELECT COUNT(*) AS n FROM ${table} WHERE thread_id = ?`, threadId).one();
+    return Number(row.n ?? 0);
+  };
+
+  const entryIdsOf = (threadId: string): Set<string> =>
+    new Set(
+      sql
+        .exec(`SELECT entry_id FROM ${table} WHERE thread_id = ?`, threadId)
+        .toArray()
+        .map((row) => String(row.entry_id)),
+    );
+
+  return {
+    async append({ threadId, expectedIndex, entries }) {
+      for (const entry of entries) {
+        assertAgentLogEntry(entry);
+      }
+      for (let i = 0; i < entries.length; i++) {
+        if (entries[i]!.index !== expectedIndex + i) {
+          throw new Error(
+            `AgentEventLogStore.append: entry.index (${entries[i]!.index}) must be contiguous ` +
+              `from expectedIndex (${expectedIndex}); expected ${expectedIndex + i} at position ${i} ` +
+              `on thread "${threadId}".`,
+          );
+        }
+      }
+
+      // No `await` from here to the insert: the check and the write are one
+      // synchronous critical section, so racing appends cannot both win.
+      transact(() => {
+        const length = lengthOf(threadId);
+        if (length !== expectedIndex) {
+          throw new AgentEventLogConflictError(threadId, expectedIndex, length);
+        }
+        // Duplicate ids are checked up front rather than caught off the unique
+        // index: the index is the integrity backstop, this is the diagnosable
+        // error the contract asks for.
+        const ids = entryIdsOf(threadId);
+        for (const entry of entries) {
+          if (ids.has(entry.id)) {
+            throw new Error(
+              `AgentEventLogStore.append: duplicate event id "${entry.id}" in thread "${threadId}".`,
+            );
+          }
+          ids.add(entry.id);
+        }
+        for (const entry of entries) {
+          sql.exec(
+            `INSERT INTO ${table} (thread_id, idx, entry_id, entry) VALUES (?, ?, ?, ?)`,
+            threadId,
+            entry.index,
+            entry.id,
+            JSON.stringify(entry),
+          );
+        }
+      });
+    },
+
+    async read(threadId, readOptions) {
+      const from = readOptions?.from ?? 0;
+      return sql
+        .exec(
+          `SELECT entry FROM ${table} WHERE thread_id = ? AND idx >= ? ORDER BY idx ASC`,
+          threadId,
+          from,
+        )
+        .toArray()
+        .map((row) => JSON.parse(String(row.entry)) as AgentLogEntry);
+    },
+
+    async length(threadId) {
+      return lengthOf(threadId);
+    },
+
+    async fork({ threadId, newThreadId, upToIndex }) {
+      transact(() => {
+        if (lengthOf(newThreadId) > 0) {
+          throw new Error(
+            `AgentEventLogStore.fork: newThreadId "${newThreadId}" already has entries.`,
+          );
+        }
+        const sourceLength = lengthOf(threadId);
+        if (sourceLength === 0) {
+          throw new Error(`AgentEventLogStore.fork: unknown source thread "${threadId}".`);
+        }
+        const upTo = upToIndex ?? sourceLength;
+        if (upTo < 0 || upTo > sourceLength) {
+          throw new Error(
+            `AgentEventLogStore.fork: thread "${threadId}" (length ${sourceLength}) ` +
+              `has no index ${upTo} to fork up to.`,
+          );
+        }
+        sql.exec(
+          `INSERT INTO ${table} (thread_id, idx, entry_id, entry)
+           SELECT ?, idx, entry_id, entry FROM ${table} WHERE thread_id = ? AND idx < ?`,
+          newThreadId,
+          threadId,
+          upTo,
+        );
+      });
+    },
+  };
+}

--- a/examples/cloudflare-agent-host/event-log-store.ts
+++ b/examples/cloudflare-agent-host/event-log-store.ts
@@ -172,10 +172,12 @@ export function createDurableObjectEventLogStore(
           throw new Error(`AgentEventLogStore.fork: unknown source thread "${threadId}".`);
         }
         const upTo = upToIndex ?? sourceLength;
-        if (upTo < 0 || upTo > sourceLength) {
+        // `upToIndex` is exclusive and must keep the reserved init entry, so
+        // the smallest legal cutoff is 1.
+        if (!Number.isInteger(upTo) || upTo < 1 || upTo > sourceLength) {
           throw new Error(
             `AgentEventLogStore.fork: thread "${threadId}" (length ${sourceLength}) ` +
-              `has no index ${upTo} to fork up to.`,
+              `cannot fork up to index ${upTo}; expected an integer in [1, ${sourceLength}].`,
           );
         }
         sql.exec(

--- a/examples/cloudflare-agent-host/index.ts
+++ b/examples/cloudflare-agent-host/index.ts
@@ -1,11 +1,18 @@
 /// <reference types="@cloudflare/workers-types" />
 /**
- * Cloudflare Agents host for XState agent machines — a complete, runnable Worker.
+ * Cloudflare Agents host for XState agent machines — a complete, runnable
+ * Worker, and the reference recipe for a DURABLE host.
  *
  * The shape:
- * - The Agent (a Durable Object) hosts the XState actor.
- * - The persisted snapshot lives in Agent state, so the machine survives
- *   hibernation/eviction and resumes exactly where it left off.
+ * - The Agent (a Durable Object) owns an append-only event log in its own
+ *   SQLite storage (`./event-log-store.ts`). THE LOG IS THE SOURCE OF TRUTH;
+ *   no snapshot is persisted anywhere.
+ * - Every turn is one `runAgent` call: read the journal, run, append what the
+ *   run produced. A turn is a `runAgent` leg that settles idle (the machine is
+ *   waiting on a human) or done.
+ * - Eviction is a non-event: the next request reads the journal back and
+ *   `runAgent` folds it — journaled model/tool results are replayed, never
+ *   re-executed.
  * - Clients drive the machine with plain machine events, over HTTP
  *   (`onRequest`) or WebSocket (`onMessage`) — provider/runtime details stay in
  *   the host, never in the machine.
@@ -22,8 +29,7 @@
  *                                              accepted events, draft, output)
  *   POST /agents/email-drafter/:name        -> body is a machine event
  *                                              (`{"type":"PROMPT_SUBMITTED", ...}`),
- *                                              validated, sent, then awaited
- *                                              until the machine is idle again
+ *                                              validated, then run as one turn
  *
  * Run:
  *   pnpm --filter @statelyai/example-cloudflare-agent-host dev        # keyless
@@ -35,19 +41,22 @@
  *   curl -X POST localhost:3009/agents/email-drafter/demo -d '{"type":"END"}'
  */
 import { Agent, routeAgentRequest, type Connection } from "agents";
-import { createActor, type Actor, type AnyMachineSnapshot, type Snapshot } from "xstate";
+import type { EventFromLogic } from "xstate";
 import { createOpenAI } from "@ai-sdk/openai";
 import {
   createScriptedExecutors,
   getAcceptedEvents,
   getStateMeta,
   parseAgentEvent,
-  provideExecutors,
+  runAgent,
+  type AgentEventLogStore,
   type AgentRequestExecutors,
   type AgentTextRequest,
+  type RunAgentResult,
 } from "@statelyai/agent";
 import { createAiSdkExecutors } from "@statelyai/agent/ai-sdk";
 import { emailDrafter, emailDrafterSchemas } from "../email-drafter/agent-logic.js";
+import { createDurableObjectEventLogStore } from "./event-log-store.js";
 
 interface Env {
   EmailDrafter: DurableObjectNamespace<EmailDrafter>;
@@ -55,9 +64,29 @@ interface Env {
   OPENAI_API_KEY?: string;
 }
 
-interface EmailDrafterState {
-  snapshot?: Snapshot<unknown>;
-}
+type Turn = RunAgentResult<typeof emailDrafter>;
+type ClientEvent = { type: string } & Record<string, unknown>;
+
+/**
+ * One Durable Object is one conversation, so the log needs only one thread.
+ * A host that packs several conversations into one DO would key this per
+ * conversation instead — the store is thread-keyed for exactly that.
+ */
+const THREAD_ID = "main";
+
+/** An event the current state does not accept: a client mistake (400), not a host failure. */
+class RejectedEventError extends Error {}
+
+const messageOf = (error: unknown) =>
+  error instanceof Error ? error.message : String(error ?? "Unknown error");
+
+/**
+ * How many keyless model calls this Worker has made. The durability claim of
+ * this host is that a resume REPLAYS journaled calls instead of re-running
+ * them, and this counter is what makes that observable — see
+ * `test/agent.workers-test.ts`.
+ */
+export const scriptedModelCalls = { count: 0 };
 
 /**
  * Keyless answers, routed on the request's model ref (`model: 'promptEvaluator'`
@@ -66,6 +95,7 @@ interface EmailDrafterState {
  * for a handful of drafting rounds.
  */
 const scriptedAnswer = (request: AgentTextRequest) => {
+  scriptedModelCalls.count += 1;
   switch (request.model) {
     case "promptEvaluator":
       return { satisfied: true, missing: [], questions: [] };
@@ -97,57 +127,134 @@ function resolveExecutors(env: Env): AgentRequestExecutors {
   });
 }
 
-/** Idle = the machine is waiting on a human (it declares an interaction) or finished. */
-function isSettled(snapshot: AnyMachineSnapshot): boolean {
-  return snapshot.status !== "active" || Boolean(getStateMeta(snapshot).interaction);
-}
+export class EmailDrafter extends Agent<Env> {
+  #store: AgentEventLogStore | undefined;
+  #executors: AgentRequestExecutors | undefined;
+  /**
+   * The last settled turn — a cache of what the log already implies, held only
+   * for this DO's lifetime. Undefined after an eviction (and before the first
+   * turn), which is why every entry point goes through `#current()`.
+   */
+  #last: Turn | undefined;
+  /** Turns are serialized: one `runAgent` leg at a time per conversation. */
+  #turns: Promise<unknown> = Promise.resolve();
 
-export class EmailDrafter extends Agent<Env, EmailDrafterState> {
-  initialState: EmailDrafterState = {};
-  #actor: Actor<typeof emailDrafter> | undefined;
+  /** Lazy so the DO's storage is bound before the table is created. */
+  get #log(): AgentEventLogStore {
+    this.#store ??= createDurableObjectEventLogStore(this.ctx.storage);
+    return this.#store;
+  }
 
-  onStart() {
-    // Executors are provided by the host; the machine only names its requests.
-    const machine = provideExecutors(emailDrafter, resolveExecutors(this.env));
+  /** Runs `work` after every turn already queued, and keeps the chain alive on failure. */
+  #enqueue<T>(work: () => Promise<T>): Promise<T> {
+    const next = this.#turns.then(work, work);
+    this.#turns = next.catch(() => undefined);
+    return next;
+  }
 
-    // Restore from the persisted snapshot if the DO was evicted mid-run.
-    this.#actor = createActor(machine, { snapshot: this.state.snapshot, input: undefined });
+  /**
+   * One turn: read the journal, run, append what the run produced.
+   *
+   * `events` is the whole durable state — a fresh thread has none and starts
+   * from `input` instead. Entries stream to storage through `onEvent` as the
+   * run makes them, each at its own index, so a crash mid-turn loses nothing
+   * but the call that was in flight.
+   */
+  async #run(event?: EventFromLogic<typeof emailDrafter>): Promise<Turn> {
+    const entries = await this.#log.read(THREAD_ID);
+    this.#executors ??= resolveExecutors(this.env);
 
-    this.#actor.subscribe((snapshot) => {
-      // Durable persistence on every transition: this is the journal the
-      // analytics/visualization layer reads, keyed by this Agent instance.
-      this.setState({ snapshot: this.#actor!.getPersistedSnapshot() });
-      this.broadcast(
-        JSON.stringify({
-          type: "state",
-          value: snapshot.value,
-          // meta is schema-typed: clients get the interaction protocol
-          // (text / select / confirm) for the current state.
-          meta: snapshot.getMeta(),
-        }),
-      );
-    });
+    // `onEvent` is synchronous; appends chain off it and are awaited below.
+    let appends: Promise<void> = Promise.resolve();
 
-    this.#actor.start();
+    try {
+      const result = await runAgent(emailDrafter, {
+        ...(entries.length > 0 ? { events: entries } : { input: undefined }),
+        ...(event !== undefined ? { event } : {}),
+        executors: this.#executors,
+        onEvent: (entry) => {
+          appends = appends.then(() =>
+            this.#log.append({
+              threadId: THREAD_ID,
+              // The entry's own index IS the optimistic precondition: a
+              // concurrent writer at that position makes the append conflict
+              // instead of silently interleaving.
+              expectedIndex: entry.index,
+              entries: [entry],
+            }),
+          );
+        },
+        onTransition: (snapshot) => {
+          this.broadcast(
+            JSON.stringify({
+              type: "state",
+              value: snapshot.value,
+              // meta is schema-typed: clients get the interaction protocol
+              // (text / select / confirm) for the current state.
+              meta: snapshot.getMeta(),
+            }),
+          );
+        },
+      });
+      this.#last = result;
+      return result;
+    } finally {
+      // Await the journal even when the run failed: what did happen is durable.
+      await appends;
+    }
+  }
+
+  /**
+   * The turn this DO is currently at. After an eviction (or on the very first
+   * request) there is no cached turn, so one no-event `runAgent` leg folds the
+   * journal back — replaying journaled results, executing nothing new.
+   */
+  async #current(): Promise<Turn> {
+    return this.#last ?? (await this.#run());
+  }
+
+  /** Validates the event against the current state's accepted events + payload schemas. */
+  #parse(current: Turn, event: ClientEvent) {
+    try {
+      return parseAgentEvent(current.snapshot, event, { events: emailDrafterSchemas.events });
+    } catch (error) {
+      throw new RejectedEventError(messageOf(error));
+    }
   }
 
   onMessage(connection: Connection, message: string) {
     // Client messages are machine events (PROMPT_SUBMITTED, SEND, ...).
-    const event = JSON.parse(message) as { type: string; [key: string]: unknown };
+    let event: ClientEvent | undefined;
     try {
-      this.#send(event);
+      event = JSON.parse(message) as ClientEvent;
     } catch (error) {
-      connection.send(
-        JSON.stringify({
-          type: "error",
-          issues: [{ message: (error as Error).message }],
-        }),
-      );
+      // A malformed frame never reaches the queue: nothing is run for it.
+      this.#sendError(connection, `Invalid JSON: ${messageOf(error)}`);
+      return;
     }
+    if (!event?.type) {
+      this.#sendError(connection, "Send a machine event: { type, ...payload }");
+      return;
+    }
+
+    const accepted = event;
+    void this.#enqueue(async () => {
+      const current = await this.#current();
+      await this.#run(this.#parse(current, accepted));
+    }).catch((error: unknown) => this.#sendError(connection, messageOf(error)));
+  }
+
+  #sendError(connection: Connection, message: string) {
+    connection.send(JSON.stringify({ type: "error", issues: [{ message }] }));
   }
 
   async onRequest(request: Request): Promise<Response> {
     if (request.method === "GET") {
+      try {
+        await this.#enqueue(() => this.#current());
+      } catch (error) {
+        return Response.json({ error: messageOf(error) }, { status: 500 });
+      }
       return Response.json(this.#view());
     }
     if (request.method !== "POST") {
@@ -159,9 +266,7 @@ export class EmailDrafter extends Agent<Env, EmailDrafterState> {
       );
     }
 
-    const event = (await request.json().catch(() => null)) as
-      | ({ type: string } & Record<string, unknown>)
-      | null;
+    const event = (await request.json().catch(() => null)) as ClientEvent | null;
     if (!event?.type) {
       return Response.json(
         { error: "POST a machine event: { type, ...payload }" },
@@ -170,49 +275,33 @@ export class EmailDrafter extends Agent<Env, EmailDrafterState> {
     }
 
     try {
-      this.#send(event);
+      // One POST maps to one settled turn: the response is always an idle (or
+      // final) state, with the journal already written.
+      await this.#enqueue(async () => {
+        const current = await this.#current();
+        await this.#run(this.#parse(current, event));
+      });
     } catch (error) {
-      return Response.json({ error: (error as Error).message, ...this.#view() }, { status: 400 });
+      if (error instanceof RejectedEventError) {
+        return Response.json({ ...this.#view(), error: error.message }, { status: 400 });
+      }
+      return Response.json({ error: messageOf(error) }, { status: 500 });
     }
 
-    // Hold the request open across the machine's async work, so one POST maps
-    // to one settled turn: the response is always an idle (or final) state.
-    await this.#settle();
     return Response.json(this.#view());
   }
 
-  /** Validates the event against the snapshot's accepted events + payload schemas, then sends it. */
-  #send(event: { type: string } & Record<string, unknown>) {
-    const snapshot = this.#actor?.getSnapshot();
-    if (!snapshot) {
-      throw new Error("Agent actor is not running.");
-    }
-    this.#actor!.send(parseAgentEvent(snapshot, event, { events: emailDrafterSchemas.events }));
-  }
-
-  /** Resolves once the machine is waiting on a human again, or is done. */
-  #settle(timeoutMs = 60_000): Promise<void> {
-    const actor = this.#actor!;
-    if (isSettled(actor.getSnapshot())) {
-      return Promise.resolve();
-    }
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        subscription.unsubscribe();
-        reject(new Error(`Machine did not settle within ${timeoutMs}ms.`));
-      }, timeoutMs);
-      const subscription = actor.subscribe((snapshot) => {
-        if (!isSettled(snapshot)) return;
-        clearTimeout(timer);
-        subscription.unsubscribe();
-        resolve();
-      });
-    });
-  }
-
-  /** The wire view of the machine: what a client needs to render the next step. */
+  /**
+   * The wire view of the machine: what a client needs to render the next step.
+   * Derived from the last settled turn — with none (no turn has ever succeeded
+   * on this instance) there is no state to report, only the error.
+   */
   #view() {
-    const snapshot = this.#actor!.getSnapshot();
+    const result = this.#last;
+    if (!result) {
+      return { error: "No settled turn: the agent could not be resumed from its event log." };
+    }
+    const { snapshot } = result;
     const { display, interaction } = getStateMeta(snapshot);
     return {
       status: snapshot.status,
@@ -223,7 +312,7 @@ export class EmailDrafter extends Agent<Env, EmailDrafterState> {
         (candidate) => candidate.type,
       ),
       draft: snapshot.context.draft,
-      output: snapshot.status === "done" ? snapshot.output : undefined,
+      output: result.status === "done" ? result.output : undefined,
     };
   }
 }
@@ -235,7 +324,8 @@ const usage = [
   "  POST /agents/email-drafter/:name   send a machine event, e.g.",
   '       {"type":"PROMPT_SUBMITTED","prompt":"Email ana@example.com about Friday\'s launch"}',
   "",
-  "Each :name is its own Durable Object, i.e. its own conversation.",
+  "Each :name is its own Durable Object, i.e. its own conversation, backed by",
+  "its own append-only event log in that Durable Object's SQLite storage.",
 ].join("\n");
 
 export default {

--- a/examples/cloudflare-agent-host/index.ts
+++ b/examples/cloudflare-agent-host/index.ts
@@ -186,6 +186,14 @@ export class EmailDrafter extends Agent<Env> {
         );
       },
     });
+    // A turn becomes the cached view only once the journal holds it. A rejected
+    // write settles the run as `{ status: 'error', cause: 'journal' }` rather
+    // than throwing, and caching that would report state the log never
+    // recorded — so an errored turn leaves `#last` where the journal is, and
+    // the request reports the failure instead.
+    if (result.status === "error") {
+      throw result.error instanceof Error ? result.error : new Error(messageOf(result.error));
+    }
     this.#last = result;
     return result;
   }

--- a/examples/cloudflare-agent-host/index.ts
+++ b/examples/cloudflare-agent-host/index.ts
@@ -7,9 +7,10 @@
  * - The Agent (a Durable Object) owns an append-only event log in its own
  *   SQLite storage (`./event-log-store.ts`). THE LOG IS THE SOURCE OF TRUTH;
  *   no snapshot is persisted anywhere.
- * - Every turn is one `runAgent` call: read the journal, run, append what the
- *   run produced. A turn is a `runAgent` leg that settles idle (the machine is
- *   waiting on a human) or done.
+ * - Every turn is one `runAgent` call, handed the store: it reads the journal,
+ *   runs, and writes each new entry back before the next model call. A turn is
+ *   a `runAgent` leg that settles idle (the machine is waiting on a human) or
+ *   done.
  * - Eviction is a non-event: the next request reads the journal back and
  *   `runAgent` folds it — journaled model/tool results are replayed, never
  *   re-executed.
@@ -153,55 +154,40 @@ export class EmailDrafter extends Agent<Env> {
   }
 
   /**
-   * One turn: read the journal, run, append what the run produced.
+   * One turn: hand `runAgent` the store and let it read the journal, run, and
+   * write back.
    *
-   * `events` is the whole durable state — a fresh thread has none and starts
-   * from `input` instead. Entries stream to storage through `onEvent` as the
-   * run makes them, each at its own index, so a crash mid-turn loses nothing
-   * but the call that was in flight.
+   * The log in the store is the whole durable state — a fresh thread has none
+   * and starts from `input` instead. Entries are written at their own index
+   * (the optimistic precondition: a concurrent writer at that position makes
+   * the append conflict instead of silently interleaving) and each write is
+   * awaited before the next model call, so a crash mid-turn loses nothing but
+   * the call that was in flight.
    */
   async #run(event?: EventFromLogic<typeof emailDrafter>): Promise<Turn> {
-    const entries = await this.#log.read(THREAD_ID);
     this.#executors ??= resolveExecutors(this.env);
 
-    // `onEvent` is synchronous; appends chain off it and are awaited below.
-    let appends: Promise<void> = Promise.resolve();
-
-    try {
-      const result = await runAgent(emailDrafter, {
-        ...(entries.length > 0 ? { events: entries } : { input: undefined }),
-        ...(event !== undefined ? { event } : {}),
-        executors: this.#executors,
-        onEvent: (entry) => {
-          appends = appends.then(() =>
-            this.#log.append({
-              threadId: THREAD_ID,
-              // The entry's own index IS the optimistic precondition: a
-              // concurrent writer at that position makes the append conflict
-              // instead of silently interleaving.
-              expectedIndex: entry.index,
-              entries: [entry],
-            }),
-          );
-        },
-        onTransition: (snapshot) => {
-          this.broadcast(
-            JSON.stringify({
-              type: "state",
-              value: snapshot.value,
-              // meta is schema-typed: clients get the interaction protocol
-              // (text / select / confirm) for the current state.
-              meta: snapshot.getMeta(),
-            }),
-          );
-        },
-      });
-      this.#last = result;
-      return result;
-    } finally {
-      // Await the journal even when the run failed: what did happen is durable.
-      await appends;
-    }
+    const result = await runAgent(emailDrafter, {
+      store: this.#log,
+      threadId: THREAD_ID,
+      // Used only when the thread's log is empty; a resume ignores it.
+      input: undefined,
+      ...(event !== undefined ? { event } : {}),
+      executors: this.#executors,
+      onTransition: (snapshot) => {
+        this.broadcast(
+          JSON.stringify({
+            type: "state",
+            value: snapshot.value,
+            // meta is schema-typed: clients get the interaction protocol
+            // (text / select / confirm) for the current state.
+            meta: snapshot.getMeta(),
+          }),
+        );
+      },
+    });
+    this.#last = result;
+    return result;
   }
 
   /**

--- a/examples/cloudflare-agent-host/metadata.json
+++ b/examples/cloudflare-agent-host/metadata.json
@@ -10,7 +10,7 @@
   },
   "comparison": {
     "targets": ["Cloudflare Agents", "durable agent runtimes"],
-    "purpose": "Persists XState actor snapshots in Durable Object state, so a conversation survives eviction; keyless scripted executors by default, live AI SDK models when OPENAI_API_KEY is bound."
+    "purpose": "Durable host recipe: the Durable Object persists an append-only event log (its SQLite storage) and drives every turn with runAgent — the log is the source of truth, no snapshot is persisted, so an evicted conversation resumes by folding the journal instead of re-running model calls; keyless scripted executors by default, live AI SDK models when OPENAI_API_KEY is bound."
   },
   "starters": []
 }

--- a/examples/cloudflare-agent-host/test/agent.workers-test.ts
+++ b/examples/cloudflare-agent-host/test/agent.workers-test.ts
@@ -1,13 +1,22 @@
 /**
  * Runs the Worker in real workerd (via @cloudflare/vitest-plugin), so the
- * Durable Object, its SQLite storage, and the persisted XState snapshot are the
+ * Durable Object, its SQLite event log, and the folded XState machine are the
  * real thing — not a Node stand-in. Keyless: `vitest.config.ts` forces the
  * `OPENAI_API_KEY` binding empty (it would otherwise be picked up from a
  * `.dev.vars` left behind by `dev:live`), so the host falls back to scripted
  * executors and this suite never bills a provider.
+ *
+ * What these specs are really testing is the host's durability claim: the
+ * append-only log in the Durable Object is the ONLY persisted state, and a
+ * conversation survives eviction by folding it back — replaying journaled
+ * model calls instead of re-running them.
  */
-import { SELF } from "cloudflare:test";
+import { getAgentByName } from "agents";
+import { env, runInDurableObject, SELF } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
+import type { AgentLogEntry } from "@statelyai/agent";
+import { EmailDrafter, scriptedModelCalls } from "../index.js";
+import { createDurableObjectEventLogStore } from "../event-log-store.js";
 
 interface View {
   status: string;
@@ -20,6 +29,17 @@ interface View {
 
 const url = (name: string) => `https://example.com/agents/email-drafter/${name}`;
 
+const namespace = () =>
+  (env as unknown as { EmailDrafter: DurableObjectNamespace<EmailDrafter> }).EmailDrafter;
+
+/** The very stub the Worker's own routing resolves `:name` to. */
+const stubFor = (name: string) => getAgentByName(namespace(), name);
+
+async function get(name: string): Promise<{ status: number; view: View }> {
+  const response = await SELF.fetch(url(name));
+  return { status: response.status, view: (await response.json()) as View };
+}
+
 async function send(name: string, event: Record<string, unknown>): Promise<View> {
   const response = await SELF.fetch(url(name), {
     method: "POST",
@@ -28,17 +48,64 @@ async function send(name: string, event: Record<string, unknown>): Promise<View>
   return (await response.json()) as View;
 }
 
+/** The conversation's whole durable state, read straight out of the DO's SQLite. */
+async function journal(name: string): Promise<AgentLogEntry[]> {
+  return runInDurableObject(await stubFor(name), async (_instance, state) =>
+    createDurableObjectEventLogStore(state.storage).read("main"),
+  );
+}
+
+/**
+ * Simulates an eviction: `abort()` discards the running Durable Object, so the
+ * next request builds a brand-new instance with nothing in memory — only the
+ * log on disk.
+ */
+async function evict(name: string): Promise<void> {
+  const stub = await stubFor(name);
+  try {
+    await runInDurableObject(stub, (_instance, state) => {
+      state.abort("test eviction");
+    });
+  } catch {
+    // `abort()` tears down the very context the callback runs in.
+  }
+}
+
 describe("cloudflare agent host", () => {
   it("starts idle at the first interaction", async () => {
-    const response = await SELF.fetch(url("start"));
-    const view = (await response.json()) as View;
+    const { status, view } = await get("start");
 
-    expect(response.status).toBe(200);
+    expect(status).toBe(200);
     expect(view.state).toBe("prompting");
     expect(view.acceptedEvents).toEqual(["PROMPT_SUBMITTED"]);
   });
 
-  it("drives a full start -> idle -> resume -> done cycle", async () => {
+  it("journals the log the run produced, and nothing else", async () => {
+    const name = "journal-shape";
+    await send(name, {
+      type: "PROMPT_SUBMITTED",
+      prompt: "Email ana@example.com about Friday's launch",
+    });
+    const entries = await journal(name);
+
+    // The reserved init entry opens the log and pins the execution lineage.
+    expect(entries[0]?.event.type).toBe("@agent.init");
+    expect(typeof entries[0]?.metadata?.executionId).toBe("string");
+    expect(entries.map((entry) => entry.index)).toEqual(entries.map((_entry, i) => i));
+    expect(entries.length).toBeGreaterThan(1);
+    // Every entry records the state it folds to, so a replay can prove itself.
+    for (const entry of entries) {
+      expect(typeof entry.verification?.stateHash).toBe("string");
+      expect(entry.machineId).toBe("email-drafter");
+    }
+    // No snapshot is persisted: the log is all there is.
+    const keys = await runInDurableObject(await stubFor(name), (_i, state) =>
+      state.storage.list({ prefix: "" }),
+    );
+    expect([...keys.keys()].filter((key) => key.includes("snapshot"))).toEqual([]);
+  });
+
+  it("drives a full cycle across two Durable Object instances", async () => {
     const name = "cycle";
 
     const drafted = await send(name, {
@@ -48,21 +115,33 @@ describe("cloudflare agent host", () => {
     expect(drafted.state).toBe("reviewing");
     expect(drafted.draft?.subject).toBe("Friday's launch");
 
+    const callsAfterDrafting = scriptedModelCalls.count;
+    const journaledAfterDrafting = (await journal(name)).length;
+
+    // Eviction #1: the instance that drafted is gone.
+    await evict(name);
+    const resumed = await get(name);
+    expect(resumed.status).toBe(200);
+    expect(resumed.view.state).toBe("reviewing");
+    expect(resumed.view.draft?.subject).toBe("Friday's launch");
+    // Folding the log re-executed nothing and appended nothing.
+    expect(scriptedModelCalls.count).toBe(callsAfterDrafting);
+    expect(await journal(name)).toHaveLength(journaledAfterDrafting);
+
     const sent = await send(name, { type: "SEND" });
     expect(sent.state).toBe("sent");
+    expect(scriptedModelCalls.count).toBe(callsAfterDrafting);
 
+    // Eviction #2: the conversation still finishes on a third instance.
+    await evict(name);
     const done = await send(name, { type: "END" });
     expect(done.status).toBe("done");
     expect(done.output?.sentEmails).toHaveLength(1);
-  });
+    expect(scriptedModelCalls.count).toBe(callsAfterDrafting);
 
-  it("persists the snapshot in Durable Object state across requests", async () => {
-    const name = "persisted";
-    await send(name, { type: "PROMPT_SUBMITTED", prompt: "Email ana@example.com" });
-
-    const view = (await (await SELF.fetch(url(name))).json()) as View;
-    expect(view.state).toBe("reviewing");
-    expect(view.draft).not.toBeNull();
+    const entries = await journal(name);
+    expect(entries.map((entry) => entry.index)).toEqual(entries.map((_entry, i) => i));
+    expect(entries.filter((entry) => entry.event.type === "@agent.init")).toHaveLength(1);
   });
 
   it("rejects an event the current state does not accept", async () => {
@@ -77,10 +156,74 @@ describe("cloudflare agent host", () => {
     expect(view.state).toBe("prompting");
   });
 
+  it("answers a malformed WebSocket frame with an error, and schedules no turn", async () => {
+    const name = "malformed";
+    await get(name);
+    const before = (await journal(name)).length;
+
+    const response = await SELF.fetch(url(name), { headers: { Upgrade: "websocket" } });
+    const socket = response.webSocket;
+    expect(socket).toBeTruthy();
+    socket!.accept();
+
+    // The `agents` runtime sends its own frames (`cf_agent_identity`, …) on
+    // connect; wait for the host's structured error channel specifically.
+    const frame = new Promise<{ type: string; issues: { message: string }[] }>((resolve) => {
+      socket!.addEventListener("message", (event) => {
+        const payload = JSON.parse(String(event.data)) as {
+          type: string;
+          issues: { message: string }[];
+        };
+        if (payload.type === "error") {
+          resolve(payload);
+        }
+      });
+    });
+    socket!.send("{ not json");
+    const message = await frame;
+    socket!.close();
+
+    expect(message.type).toBe("error");
+    expect(message.issues[0]?.message).toContain("Invalid JSON");
+    expect(await journal(name)).toHaveLength(before);
+  });
+
+  it("reports a 500 (not a TypeError) when no turn can settle", async () => {
+    const name = "corrupt";
+    // A log written by another machine version, with no snapshot to migrate
+    // from: `runAgent` refuses it, so no turn ever settles on this instance.
+    await runInDurableObject(await stubFor(name), async (_instance, state) => {
+      await createDurableObjectEventLogStore(state.storage).append({
+        threadId: "main",
+        expectedIndex: 0,
+        entries: [
+          {
+            schemaVersion: 1,
+            id: "evt_0",
+            index: 0,
+            recordedAt: "2026-01-01T00:00:00.000Z",
+            machineId: "email-drafter",
+            machineVersion: "from-a-previous-life",
+            event: { type: "@agent.init" },
+          },
+        ],
+      });
+    });
+
+    const response = await SELF.fetch(url(name));
+    const view = (await response.json()) as View;
+
+    expect(response.status).toBe(500);
+    expect(view.error).toBeTruthy();
+    expect(view.error).not.toContain("undefined is not an object");
+    expect(view.state).toBeUndefined();
+  });
+
   it("keeps each :name in its own Durable Object", async () => {
     await send("alice", { type: "PROMPT_SUBMITTED", prompt: "Email alice@example.com" });
-    const bob = (await (await SELF.fetch(url("bob"))).json()) as View;
+    const bob = await get("bob");
 
-    expect(bob.state).toBe("prompting");
+    expect(bob.view.state).toBe("prompting");
+    expect(await journal("bob")).toHaveLength(1);
   });
 });

--- a/examples/cloudflare-agent-host/test/agent.workers-test.ts
+++ b/examples/cloudflare-agent-host/test/agent.workers-test.ts
@@ -219,6 +219,45 @@ describe("cloudflare agent host", () => {
     expect(view.state).toBeUndefined();
   });
 
+  it("leaves the cached turn where the journal is when an append fails", async () => {
+    const name = "append-fails";
+    await get(name);
+    const before = await journal(name);
+
+    // Break exactly the next append: the store writes inside `transactionSync`,
+    // so failing it once fails the write-ahead append for the incoming event
+    // and `runAgent` rejects before it can return a turn.
+    await runInDurableObject(await stubFor(name), (_instance, state) => {
+      const storage = state.storage;
+      const transactionSync = storage.transactionSync.bind(storage);
+      let broken = true;
+      Object.defineProperty(storage, "transactionSync", {
+        configurable: true,
+        writable: true,
+        value: <T>(run: () => T): T => {
+          if (broken) {
+            broken = false;
+            throw new Error("storage unavailable");
+          }
+          return transactionSync(run);
+        },
+      });
+    });
+
+    const failed = await SELF.fetch(url(name), {
+      method: "POST",
+      body: JSON.stringify({ type: "PROMPT_SUBMITTED", prompt: "Email ana@example.com" }),
+    });
+    expect(failed.status).toBe(500);
+
+    // Nothing was journaled, and the view still reports the state the journal
+    // implies — not the turn that failed to persist.
+    expect(await journal(name)).toHaveLength(before.length);
+    const { view } = await get(name);
+    expect(view.state).toBe("prompting");
+    expect(view.draft).toBeNull();
+  });
+
   it("keeps each :name in its own Durable Object", async () => {
     await send("alice", { type: "PROMPT_SUBMITTED", prompt: "Email alice@example.com" });
     const bob = await get("bob");

--- a/examples/cloudflare-agent-host/test/event-log-store.workers-test.ts
+++ b/examples/cloudflare-agent-host/test/event-log-store.workers-test.ts
@@ -1,0 +1,73 @@
+/**
+ * Runs the library's shared `AgentEventLogStore` conformance suite against the
+ * Durable Object SQLite store, inside real workerd — so the append/read/
+ * conflict/fork semantics are checked on the actual storage engine the host
+ * runs on, not a stand-in.
+ *
+ * The suite asks for a FRESH, EMPTY store per case; a new table name per
+ * `create()` gives that isolation on one Durable Object's SQL storage.
+ */
+import { assertEventLogStoreConformance } from "@statelyai/agent";
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { createDurableObjectEventLogStore } from "../event-log-store.js";
+
+const namespace = () => (env as { EmailDrafter: DurableObjectNamespace }).EmailDrafter;
+
+function stubFor(name: string) {
+  const ns = namespace();
+  return ns.get(ns.idFromName(name));
+}
+
+describe("durable object event log store", () => {
+  it("satisfies the AgentEventLogStore conformance suite (ctx.storage)", async () => {
+    await runInDurableObject(stubFor("event-log-store-conformance"), async (_instance, state) => {
+      let table = 0;
+      await assertEventLogStoreConformance(() =>
+        createDurableObjectEventLogStore(state.storage, { table: `conformance_${table++}` }),
+      );
+    });
+  });
+
+  it("satisfies the conformance suite when handed only ctx.storage.sql", async () => {
+    await runInDurableObject(stubFor("event-log-store-conformance-sql"), async (_i, state) => {
+      let table = 0;
+      await assertEventLogStoreConformance(() =>
+        createDurableObjectEventLogStore(state.storage.sql, { table: `sql_only_${table++}` }),
+      );
+    });
+  });
+
+  it("persists across store instances over the same table", async () => {
+    await runInDurableObject(stubFor("event-log-store-persistence"), async (_i, state) => {
+      const first = createDurableObjectEventLogStore(state.storage, { table: "persisted" });
+      await first.append({
+        threadId: "t",
+        expectedIndex: 0,
+        entries: [
+          {
+            schemaVersion: 1,
+            id: "evt_0",
+            index: 0,
+            recordedAt: "2026-01-01T00:00:00.000Z",
+            machineId: "host",
+            machineVersion: "v1",
+            event: { type: "start" },
+          },
+        ],
+      });
+
+      const second = createDurableObjectEventLogStore(state.storage, { table: "persisted" });
+      expect(await second.length("t")).toBe(1);
+      expect((await second.read("t"))[0]?.id).toBe("evt_0");
+    });
+  });
+
+  it("rejects an unusable table name", async () => {
+    await runInDurableObject(stubFor("event-log-store-names"), (_i, state) => {
+      expect(() =>
+        createDurableObjectEventLogStore(state.storage, { table: "drop table; --" }),
+      ).toThrow(/Invalid SQLite table name/);
+    });
+  });
+});

--- a/examples/crash-recovery/index.test.ts
+++ b/examples/crash-recovery/index.test.ts
@@ -1,23 +1,36 @@
 import { describe, expect, test } from "vitest";
-import { recover, runUntilCrash } from "./index.js";
+import { recover, runUntilCrash, store } from "./index.js";
 
 describe("crash-recovery", () => {
-  test("recovers from the persisted snapshot, re-executing only the in-flight request", async () => {
-    const snapshot = await runUntilCrash();
-    const recovered = await recover(snapshot);
+  test("recovers from the log alone, re-executing only the in-flight request", async () => {
+    const crashed = await runUntilCrash();
+    expect(crashed.calls).toBe(2);
+
+    const { recovered, calls } = await recover(crashed.threadId);
+    // The journaled outline call is replayed, not re-executed.
+    expect(calls).toBe(1);
     expect(recovered.status).toBe("done");
     expect(recovered.status === "done" ? recovered.output.outline : "").toContain("Intro");
   });
 
-  test("the topic survives the crash: recovery drafts the original topic", async () => {
-    const snapshot = await runUntilCrash("the history of the fax machine");
-    const recovered = await recover(snapshot);
+  test("the in-flight request re-executes under the same callKey", async () => {
+    const crashed = await runUntilCrash();
+    const { replayedCallKey } = await recover(crashed.threadId);
+
+    expect(crashed.inFlightCallKey).toBeDefined();
+    expect(replayedCallKey).toBe(crashed.inFlightCallKey);
+  });
+
+  test("the topic survives the crash and the whole thread stays in the log", async () => {
+    const crashed = await runUntilCrash("the history of the fax machine");
+    const { recovered } = await recover(crashed.threadId);
 
     expect(recovered.status).toBe("done");
     if (recovered.status !== "done") return;
     expect(recovered.output.topic).toBe("the history of the fax machine");
-    expect(recovered.output.outline).toContain("the history of the fax machine");
-    // The draft prompt (and so the article) is topic-specific, not generic.
     expect(recovered.output.article).toContain("the history of the fax machine");
+
+    const stored = await store.read(crashed.threadId);
+    expect(stored).toEqual(recovered.events);
   });
 });

--- a/examples/crash-recovery/index.ts
+++ b/examples/crash-recovery/index.ts
@@ -1,28 +1,27 @@
 /**
- * Crash recovery — resume a run from XState's persisted snapshot.
+ * Crash recovery — resume a run from its event log, with no snapshot.
  *
- * The process "crashes" mid-request:
- * the second model call is in flight when the run aborts, so its result was
- * never completed. The host stores `result.persist()`, then recovery is one
- * `runAgent(machine, { snapshot })` call:
- *
- * - completed state is restored (call one runs once);
- * - XState v6 re-enters the request that was in flight at the crash; the host
- *   executor must supply any required idempotency key and retry policy because
- *   the provider may have accepted the original request;
- * - the run continues to done.
+ * The log is the source of truth: `onEvent` hands the host every external input
+ * the machine accepted, and `runAgent({ events })` folds that journal back into
+ * state without executing anything it already recorded. A request that was
+ * still in flight at the crash has no recorded completion, so it — and only it
+ * — runs again, under the same `info.callKey` the first attempt used, which is
+ * the idempotency key a real host would send to the provider.
  *
  * No API key needed: executors are scripted. Run:
  * npx tsx examples/crash-recovery/index.ts
  */
 import { z } from "zod";
-import type { Snapshot } from "xstate";
-import { runAgent, setupAgent } from "@statelyai/agent";
-import type { AgentRequestExecutor } from "@statelyai/agent";
+import {
+  createInMemoryEventLogStore,
+  createScriptedExecutors,
+  runAgent,
+  setupAgent,
+} from "@statelyai/agent";
+import type { AgentLogEntry } from "@statelyai/agent";
 
 const crashRecoverySetup = setupAgent({
   context: z.object({
-    // The topic is part of context, so it survives snapshot persistence.
     topic: z.string(),
     outline: z.string().nullable(),
     article: z.string().nullable(),
@@ -72,55 +71,92 @@ export const crashRecoveryMachine = crashRecoverySetup.createMachine({
   },
 });
 
-/** First process: answers the outline call, hangs on the draft call, then "crashes". */
-export async function runUntilCrash(topic = "state machines"): Promise<Snapshot<unknown>> {
-  const abort = new AbortController();
+/** Stands in for the host's database: an append-only log per thread. */
+export const store = createInMemoryEventLogStore();
 
-  const generateText: AgentRequestExecutor = async (request) => {
-    if (request.prompt?.startsWith("Write the article")) {
-      // The draft call never resolves; the process dies while it is in flight.
-      setTimeout(() => abort.abort(new Error("process crashed")), 10);
-      return new Promise(() => {}) as never;
-    }
-    // Scripted, but topic-aware: the outline reflects the requested topic.
-    return { output: `1. Intro to ${topic} 2. Body on ${topic} 3. Outro` };
-  };
+/**
+ * First process: answers the outline call, hangs on the draft call, then
+ * "crashes" — everything it journaled up to that point is in the store.
+ */
+export async function runUntilCrash(topic = "state machines", threadId = crypto.randomUUID()) {
+  const abort = new AbortController();
+  let inFlightCallKey: string | undefined;
+
+  const executors = createScriptedExecutors({
+    text: [
+      () => `1. Intro to ${topic} 2. Body on ${topic} 3. Outro`,
+      (_request, info) => {
+        inFlightCallKey = info?.callKey;
+        // The draft call never resolves; the process dies while it is in flight,
+        // so no completion for it is ever journaled.
+        setTimeout(() => abort.abort(new Error("process crashed")), 10);
+        return new Promise<string>(() => {});
+      },
+    ],
+  });
+
+  // `onEvent` is synchronous, so it buffers; the buffer is flushed to the store
+  // once the leg settles (a real host may flush on its own cadence).
+  const journal: AgentLogEntry[] = [];
 
   const crashed = await runAgent(crashRecoveryMachine, {
     input: { topic },
-    executors: { generateText },
+    executors,
     signal: abort.signal,
+    onEvent: (entry) => journal.push(entry),
   });
 
+  await store.append({ threadId, expectedIndex: 0, entries: journal });
+
   console.log(`crashed with status '${crashed.status}'`);
-  return crashed.persist();
+  console.log(`model calls before the crash: ${executors.calls.length}`); // 2 — one completed
+  console.log(`journaled entries: ${journal.length}`);
+  return { threadId, inFlightCallKey, calls: executors.calls.length };
 }
 
-/** Second process: recover from XState's persisted snapshot. */
-export async function recover(persisted: Snapshot<unknown>) {
-  const calls: string[] = [];
-  const generateText: AgentRequestExecutor = async (request) => {
-    calls.push(request.prompt ?? "");
-    return { output: `Draft based on: ${request.prompt}` };
-  };
+/**
+ * Second process: read the log back and resume from it. No snapshot is passed
+ * — nothing but the journal crossed the process boundary.
+ */
+export async function recover(threadId: string) {
+  let replayedCallKey: string | undefined;
 
-  const recovered = await runAgent(crashRecoveryMachine, {
-    snapshot: persisted,
-    executors: { generateText },
+  // Exactly ONE scripted answer: if the recovered run re-executed the outline
+  // call, the script would run dry and throw.
+  const executors = createScriptedExecutors({
+    text: [
+      (request, info) => {
+        replayedCallKey = info?.callKey;
+        return `Draft based on: ${request.prompt}`;
+      },
+    ],
+  });
+
+  const events = await store.read(threadId);
+  const recovered = await runAgent(crashRecoveryMachine, { events, executors });
+
+  // The resumed result's `events` extends the same log, so the thread stays
+  // replayable end to end.
+  await store.append({
+    threadId,
+    expectedIndex: events.length,
+    entries: recovered.events.slice(events.length),
   });
 
   console.log(`recovered with status '${recovered.status}'`);
-  console.log(`model calls made during recovery: ${calls.length}`); // 1 — only the draft
+  console.log(`model calls during recovery: ${executors.calls.length}`); // 1 — only the draft
+  console.log(`full log length: ${recovered.events.length}`);
   if (recovered.status === "done") {
-    // The topic came back from context, so the recovered draft is specific.
     console.log(`topic: ${recovered.output.topic}`);
     console.log(`article: ${recovered.output.article}`);
   }
-  return recovered;
+  return { recovered, replayedCallKey, calls: executors.calls.length };
 }
 
 const isMain = process.argv[1]?.endsWith("crash-recovery/index.ts");
 if (isMain) {
-  const snapshot = await runUntilCrash();
-  await recover(snapshot);
+  const { threadId, inFlightCallKey } = await runUntilCrash();
+  const { replayedCallKey } = await recover(threadId);
+  // Same key both times: the retry is safe to dedupe at the provider.
+  console.log(`callKey matched: ${inFlightCallKey === replayedCallKey}`);
 }

--- a/examples/crash-recovery/index.ts
+++ b/examples/crash-recovery/index.ts
@@ -1,12 +1,13 @@
 /**
  * Crash recovery — resume a run from its event log, with no snapshot.
  *
- * The log is the source of truth: `onEvent` hands the host every external input
- * the machine accepted, and `runAgent({ events })` folds that journal back into
- * state without executing anything it already recorded. A request that was
- * still in flight at the crash has no recorded completion, so it — and only it
- * — runs again, under the same `info.callKey` the first attempt used, which is
- * the idempotency key a real host would send to the provider.
+ * The log is the source of truth: `runAgent({ store, threadId })` writes every
+ * external input the machine accepted straight to durable storage — before the
+ * next model call — and reads it back to resume, folding the journal into state
+ * without executing anything it already recorded. A request that was still in
+ * flight at the crash has no recorded completion, so it — and only it — runs
+ * again, under the same `info.callKey` the first attempt used, which is the
+ * idempotency key a real host would send to the provider.
  *
  * No API key needed: executors are scripted. Run:
  * npx tsx examples/crash-recovery/index.ts
@@ -18,8 +19,6 @@ import {
   runAgent,
   setupAgent,
 } from "@statelyai/agent";
-import type { AgentLogEntry } from "@statelyai/agent";
-
 const crashRecoverySetup = setupAgent({
   context: z.object({
     topic: z.string(),
@@ -95,22 +94,19 @@ export async function runUntilCrash(topic = "state machines", threadId = crypto.
     ],
   });
 
-  // `onEvent` is synchronous, so it buffers; the buffer is flushed to the store
-  // once the leg settles (a real host may flush on its own cadence).
-  const journal: AgentLogEntry[] = [];
-
+  // Write-ahead: each entry reaches the store as it is appended, and the outline
+  // call cannot start until the entries before it are durable.
   const crashed = await runAgent(crashRecoveryMachine, {
     input: { topic },
+    store,
+    threadId,
     executors,
     signal: abort.signal,
-    onEvent: (entry) => journal.push(entry),
   });
-
-  await store.append({ threadId, expectedIndex: 0, entries: journal });
 
   console.log(`crashed with status '${crashed.status}'`);
   console.log(`model calls before the crash: ${executors.calls.length}`); // 2 — one completed
-  console.log(`journaled entries: ${journal.length}`);
+  console.log(`journaled entries: ${crashed.events.length}`);
   return { threadId, inFlightCallKey, calls: executors.calls.length };
 }
 
@@ -132,16 +128,9 @@ export async function recover(threadId: string) {
     ],
   });
 
-  const events = await store.read(threadId);
-  const recovered = await runAgent(crashRecoveryMachine, { events, executors });
-
-  // The resumed result's `events` extends the same log, so the thread stays
-  // replayable end to end.
-  await store.append({
-    threadId,
-    expectedIndex: events.length,
-    entries: recovered.events.slice(events.length),
-  });
+  // No `events`, no snapshot: the store's thread IS the resume, and the run
+  // keeps appending to it, so the thread stays replayable end to end.
+  const recovered = await runAgent(crashRecoveryMachine, { store, threadId, executors });
 
   console.log(`recovered with status '${recovered.status}'`);
   console.log(`model calls during recovery: ${executors.calls.length}`); // 1 — only the draft

--- a/examples/crash-recovery/metadata.json
+++ b/examples/crash-recovery/metadata.json
@@ -1,15 +1,15 @@
 {
   "name": "crash-recovery",
-  "title": "Resume a run that crashed mid-way",
+  "title": "Resume a crashed run from its event log",
   "kind": "agent-workflow",
   "origin": {
     "type": "stately-agent",
-    "source": "Native XState snapshot resume after a simulated process crash",
+    "source": "Event-log recovery after a simulated process crash",
     "url": null
   },
   "comparison": {
     "targets": ["LangGraph checkpointer"],
-    "purpose": "Writes an article in two steps, persists a native idle snapshot, and resumes it in a fresh run without an Agent-specific storage layer."
+    "purpose": "Writes an article in two steps, journals every accepted input through `onEvent`, and resumes from the log alone — recorded model calls are replayed, and the in-flight one re-executes under the same `info.callKey`."
   },
   "starters": ["state machines", "the history of the fax machine", "why builds are slow"]
 }

--- a/examples/crash-recovery/metadata.json
+++ b/examples/crash-recovery/metadata.json
@@ -9,7 +9,7 @@
   },
   "comparison": {
     "targets": ["LangGraph checkpointer"],
-    "purpose": "Writes an article in two steps, journals every accepted input through `onEvent`, and resumes from the log alone — recorded model calls are replayed, and the in-flight one re-executes under the same `info.callKey`."
+    "purpose": "Writes an article in two steps, journals every accepted input to the store before the next model call, and resumes from the log alone — recorded model calls are replayed, and the in-flight one re-executes under the same `info.callKey`."
   },
   "starters": ["state machines", "the history of the fax machine", "why builds are slow"]
 }

--- a/src/event-log-store-conformance.ts
+++ b/src/event-log-store-conformance.ts
@@ -1,0 +1,362 @@
+/**
+ * The runner-agnostic conformance suite for {@link AgentEventLogStore}
+ * implementations. Split out of `event-log-store.ts` so the store contract and
+ * the reference implementation stay readable.
+ *
+ * Every case throws a descriptive `Error` on the first violation, so any test
+ * runner (or a plain script) can drive it against its own store. Pass a
+ * `{ describe, it }` harness to register one test per case instead.
+ * @module
+ */
+import { AgentEventLogConflictError, type AgentEventLogStore } from "./event-log-store.js";
+import { AGENT_EVENT_SCHEMA_VERSION, type AgentLogEntry, type JsonValue } from "./event-log.js";
+
+/** Produces a fresh, empty store for one case. */
+type CreateStore = () => Promise<AgentEventLogStore> | AgentEventLogStore;
+
+/**
+ * A test runner's registration functions. `expect` is accepted and unused —
+ * every case asserts by throwing, so the suite stays runner-agnostic.
+ */
+export interface EventLogStoreConformanceHarness {
+  describe: (name: string, register: () => void) => void;
+  it: (name: string, run: () => Promise<void>) => void;
+  expect?: unknown;
+}
+
+function fail(message: string): never {
+  throw new Error(`event-log-store conformance: ${message}`);
+}
+
+function entry(index: number, type: string, metadata?: Record<string, JsonValue>): AgentLogEntry {
+  return {
+    schemaVersion: AGENT_EVENT_SCHEMA_VERSION,
+    id: `evt_${index}`,
+    index,
+    recordedAt: "2026-01-01T00:00:00.000Z",
+    machineId: "conformance",
+    machineVersion: "v1",
+    event: { type, seq: index },
+    ...(metadata !== undefined ? { metadata } : {}),
+  } as AgentLogEntry;
+}
+
+function entriesFrom(start: number, count: number): AgentLogEntry[] {
+  return Array.from({ length: count }, (_unused, i) => entry(start + i, `e${start + i}`));
+}
+
+function assertJsonEqual(actual: unknown, expected: unknown, message: string): void {
+  const a = JSON.stringify(actual);
+  const b = JSON.stringify(expected);
+  if (a !== b) {
+    fail(`${message} (expected ${b}, got ${a})`);
+  }
+}
+
+const cases: Array<{ name: string; run: (create: CreateStore) => Promise<void> }> = [
+  {
+    name: "an unknown thread reads empty and has length 0",
+    async run(create) {
+      const store = await create();
+      assertJsonEqual(await store.read("missing"), [], "read of an unknown thread must be empty");
+      if ((await store.length("missing")) !== 0) {
+        fail("length of an unknown thread must be 0");
+      }
+    },
+  },
+  {
+    name: "a single append reads back verbatim",
+    async run(create) {
+      const store = await create();
+      const e = entry(0, "start", { label: "first" });
+      await store.append({ threadId: "t", expectedIndex: 0, entries: [e] });
+      assertJsonEqual(await store.read("t"), [e], "read must return the appended entry");
+      if ((await store.length("t")) !== 1) {
+        fail("length after a single append must be 1");
+      }
+    },
+  },
+  {
+    name: "a second append extends the log in order",
+    async run(create) {
+      const store = await create();
+      await store.append({ threadId: "t", expectedIndex: 0, entries: entriesFrom(0, 3) });
+      await store.append({ threadId: "t", expectedIndex: 3, entries: entriesFrom(3, 2) });
+      if ((await store.length("t")) !== 5) {
+        fail("length after appending 3 then 2 entries must be 5");
+      }
+      assertJsonEqual(
+        (await store.read("t")).map((e) => e.index),
+        [0, 1, 2, 3, 4],
+        "reads must return entries in contiguous log order",
+      );
+    },
+  },
+  {
+    name: "a non-contiguous entry.index is misuse, not a race",
+    async run(create) {
+      const store = await create();
+      let caught: unknown;
+      try {
+        // expectedIndex 0 but entry.index 1: a hole.
+        await store.append({ threadId: "t", expectedIndex: 0, entries: [entry(1, "gap")] });
+      } catch (error) {
+        caught = error;
+      }
+      if (!(caught instanceof Error) || caught instanceof AgentEventLogConflictError) {
+        fail("a non-contiguous entry.index must throw a plain Error, not a conflict");
+      }
+    },
+  },
+  {
+    name: "a stale expectedIndex conflicts with correct fields",
+    async run(create) {
+      const store = await create();
+      await store.append({ threadId: "t", expectedIndex: 0, entries: [entry(0, "a")] });
+      let caught: unknown;
+      try {
+        // expectedIndex 0 is stale (length is 1); entry.index 0 clears the contiguity guard.
+        await store.append({ threadId: "t", expectedIndex: 0, entries: [entry(0, "b")] });
+      } catch (error) {
+        caught = error;
+      }
+      if (!(caught instanceof AgentEventLogConflictError)) {
+        fail("a stale expectedIndex must throw AgentEventLogConflictError");
+      }
+      if (caught.threadId !== "t" || caught.expectedIndex !== 0 || caught.actualIndex !== 1) {
+        fail("conflict error must carry threadId, expectedIndex, and the actual index");
+      }
+    },
+  },
+  {
+    name: "entry ids are unique within a thread",
+    async run(create) {
+      const store = await create();
+      await store.append({ threadId: "t", expectedIndex: 0, entries: [entry(0, "a")] });
+      let caught: unknown;
+      try {
+        await store.append({
+          threadId: "t",
+          expectedIndex: 1,
+          entries: [{ ...entry(1, "b"), id: "evt_0" }],
+        });
+      } catch (error) {
+        caught = error;
+      }
+      if (!(caught instanceof Error) || caught instanceof AgentEventLogConflictError) {
+        fail("a duplicate event id within a thread must throw a plain Error");
+      }
+    },
+  },
+  {
+    name: "concurrent appends at the same index have exactly one winner",
+    async run(create) {
+      const store = await create();
+      await store.append({ threadId: "t", expectedIndex: 0, entries: [entry(0, "a")] });
+      const results = await Promise.allSettled([
+        store.append({ threadId: "t", expectedIndex: 1, entries: [entry(1, "w-a")] }),
+        store.append({ threadId: "t", expectedIndex: 1, entries: [entry(1, "w-b")] }),
+      ]);
+      const winners = results.filter((r) => r.status === "fulfilled");
+      const conflicts = results.filter(
+        (r) => r.status === "rejected" && r.reason instanceof AgentEventLogConflictError,
+      );
+      if (winners.length !== 1) {
+        fail(`exactly one racing append must win, got ${winners.length}`);
+      }
+      if (conflicts.length !== 1) {
+        fail(`exactly one racing append must reject with a conflict, got ${conflicts.length}`);
+      }
+      if ((await store.length("t")) !== 2) {
+        fail("after the race the log length must be 2");
+      }
+    },
+  },
+  {
+    name: "read({ from }) is incrementally correct",
+    async run(create) {
+      const store = await create();
+      await store.append({ threadId: "t", expectedIndex: 0, entries: entriesFrom(0, 5) });
+      assertJsonEqual(
+        (await store.read("t", { from: 2 })).map((e) => e.index),
+        [2, 3, 4],
+        "read({ from }) must skip entries below `from`",
+      );
+      assertJsonEqual(
+        await store.read("t", { from: 5 }),
+        [],
+        "read({ from }) at the log length must be empty",
+      );
+    },
+  },
+  {
+    name: "threads are isolated and grow independently",
+    async run(create) {
+      const store = await create();
+      await store.append({ threadId: "a", expectedIndex: 0, entries: [entry(0, "x")] });
+      if ((await store.length("b")) !== 0) {
+        fail("an append to one thread must not create another");
+      }
+      await store.append({ threadId: "b", expectedIndex: 0, entries: entriesFrom(0, 2) });
+      if ((await store.length("a")) !== 1 || (await store.length("b")) !== 2) {
+        fail("threads must grow independently");
+      }
+    },
+  },
+  {
+    name: "metadata round-trips verbatim",
+    async run(create) {
+      const store = await create();
+      const metadata = { source: "user", nested: { attempt: 2 }, tags: ["x", "y"] };
+      await store.append({ threadId: "t", expectedIndex: 0, entries: [entry(0, "e", metadata)] });
+      assertJsonEqual(
+        (await store.read("t"))[0]!.metadata,
+        metadata,
+        "metadata must round-trip verbatim",
+      );
+    },
+  },
+  {
+    name: "stored entries are isolated from caller mutation",
+    async run(create) {
+      const store = await create();
+      const e = entry(0, "e", { tags: ["a"] });
+      await store.append({ threadId: "t", expectedIndex: 0, entries: [e] });
+      (e.metadata!.tags as string[]).push("mutated-after-append");
+      (e.event as { type: string; seq: number }).seq = 999;
+
+      const read = await store.read("t");
+      (read[0]!.metadata!.tags as string[]).push("mutated-after-read");
+      (read[0]!.event as { type: string; seq: number }).seq = 888;
+
+      const reread = await store.read("t");
+      assertJsonEqual(
+        reread[0]!.metadata,
+        { tags: ["a"] },
+        "stored entry must be isolated from post-append and post-read mutation",
+      );
+      assertJsonEqual(
+        reread[0]!.event,
+        { type: "e", seq: 0 },
+        "stored event must be isolated from mutation of an appended or read copy",
+      );
+    },
+  },
+  {
+    name: "fork copies a prefix and then diverges independently",
+    async run(create) {
+      const store = await create();
+      await store.append({ threadId: "src", expectedIndex: 0, entries: entriesFrom(0, 3) });
+
+      // Full prefix (default upToIndex).
+      await store.fork({ threadId: "src", newThreadId: "fork-full" });
+      if ((await store.length("fork-full")) !== 3) {
+        fail("fork with the default upToIndex must copy the full log");
+      }
+
+      // Partial prefix.
+      await store.fork({ threadId: "src", newThreadId: "fork-1", upToIndex: 1 });
+      assertJsonEqual(
+        (await store.read("fork-1")).map((e) => e.index),
+        [0],
+        "fork with upToIndex 1 must copy only entry 0",
+      );
+
+      // upToIndex is exclusive.
+      await store.fork({ threadId: "src", newThreadId: "fork-2", upToIndex: 2 });
+      assertJsonEqual(
+        (await store.read("fork-2")).map((e) => e.id),
+        ["evt_0", "evt_1"],
+        "fork with upToIndex 2 must copy entries 0 and 1 only",
+      );
+
+      // The fork appends independently from its copied length; the source is untouched.
+      await store.append({ threadId: "fork-1", expectedIndex: 1, entries: [entry(1, "branch")] });
+      assertJsonEqual(
+        (await store.read("fork-1")).map((e) => (e.event as { type: string }).type),
+        ["e0", "branch"],
+        "a forked thread must append independently from its copied length",
+      );
+      if ((await store.length("src")) !== 3) {
+        fail("appending to a fork must not touch the source thread");
+      }
+    },
+  },
+  {
+    name: "fork rejects a non-empty target, an unknown source, and an out-of-range cutoff",
+    async run(create) {
+      const store = await create();
+      await store.append({ threadId: "src", expectedIndex: 0, entries: entriesFrom(0, 3) });
+      await store.fork({ threadId: "src", newThreadId: "fork-full" });
+
+      let caughtExisting: unknown;
+      try {
+        await store.fork({ threadId: "src", newThreadId: "fork-full" });
+      } catch (error) {
+        caughtExisting = error;
+      }
+      if (
+        !(caughtExisting instanceof Error) ||
+        caughtExisting instanceof AgentEventLogConflictError
+      ) {
+        fail("forking onto a non-empty thread must reject with a plain Error");
+      }
+
+      let caughtUnknown: unknown;
+      try {
+        await store.fork({ threadId: "nope", newThreadId: "fork-nope" });
+      } catch (error) {
+        caughtUnknown = error;
+      }
+      if (
+        !(caughtUnknown instanceof Error) ||
+        caughtUnknown instanceof AgentEventLogConflictError
+      ) {
+        fail("forking an unknown source thread must reject with a plain Error");
+      }
+
+      let caughtRange: unknown;
+      try {
+        await store.fork({ threadId: "src", newThreadId: "fork-range", upToIndex: 99 });
+      } catch (error) {
+        caughtRange = error;
+      }
+      if (!(caughtRange instanceof Error) || caughtRange instanceof AgentEventLogConflictError) {
+        fail("forking past the source length must reject with a plain Error");
+      }
+    },
+  },
+];
+
+/**
+ * Validates a store against the reference's semantics: empty read + zero length
+ * for unknown threads; single and multi-entry append; contiguity misuse guard;
+ * stale-`expectedIndex` conflict with correct fields; an interleaved concurrent
+ * append race (exactly one winner); entry-id uniqueness; `read({ from })`
+ * incremental correctness; thread isolation; metadata round-trip; deep-copy
+ * isolation on append and read; and the full fork contract.
+ *
+ * Without a `harness`, every case runs in sequence and the first violation
+ * throws. With one, each case is registered as its own test:
+ *
+ * ```ts
+ * import { describe, it } from 'vitest';
+ * assertEventLogStoreConformance(createMyStore, { describe, it });
+ * ```
+ */
+export async function assertEventLogStoreConformance(
+  create: CreateStore,
+  harness?: EventLogStoreConformanceHarness,
+): Promise<void> {
+  if (harness) {
+    harness.describe("AgentEventLogStore conformance", () => {
+      for (const testCase of cases) {
+        harness.it(testCase.name, () => testCase.run(create));
+      }
+    });
+    return;
+  }
+  for (const testCase of cases) {
+    await testCase.run(create);
+  }
+}

--- a/src/event-log-store-conformance.ts
+++ b/src/event-log-store-conformance.ts
@@ -283,7 +283,7 @@ const cases: Array<{ name: string; run: (create: CreateStore) => Promise<void> }
     },
   },
   {
-    name: "fork rejects a non-empty target, an unknown source, and an out-of-range cutoff",
+    name: "fork rejects a non-empty target, an unknown source, and an out-of-range cutoff (0 included)",
     async run(create) {
       const store = await create();
       await store.append({ threadId: "src", expectedIndex: 0, entries: entriesFrom(0, 3) });
@@ -323,6 +323,20 @@ const cases: Array<{ name: string; run: (create: CreateStore) => Promise<void> }
       }
       if (!(caughtRange instanceof Error) || caughtRange instanceof AgentEventLogConflictError) {
         fail("forking past the source length must reject with a plain Error");
+      }
+
+      // `upToIndex` is exclusive, so 0 would produce a log with no init entry.
+      let caughtZero: unknown;
+      try {
+        await store.fork({ threadId: "src", newThreadId: "fork-zero", upToIndex: 0 });
+      } catch (error) {
+        caughtZero = error;
+      }
+      if (!(caughtZero instanceof Error) || caughtZero instanceof AgentEventLogConflictError) {
+        fail("forking with upToIndex 0 must reject with a plain Error");
+      }
+      if ((await store.length("fork-zero")) !== 0) {
+        fail("a rejected fork must not create the target thread");
       }
     },
   },

--- a/src/event-log-store.test.ts
+++ b/src/event-log-store.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, test } from "vitest";
+import { AGENT_EVENT_SCHEMA_VERSION, type AgentLogEntry } from "./event-log.js";
+import { AgentEventLogConflictError, createInMemoryEventLogStore } from "./event-log-store.js";
+import { assertEventLogStoreConformance } from "./event-log-store-conformance.js";
+
+function testEntry(index: number, type: string): AgentLogEntry {
+  return {
+    schemaVersion: AGENT_EVENT_SCHEMA_VERSION,
+    id: `evt_${index}`,
+    index,
+    recordedAt: "2026-01-01T00:00:00.000Z",
+    machineId: "test",
+    machineVersion: "v1",
+    event: { type },
+  };
+}
+
+// The harness form: each conformance case becomes its own test.
+void assertEventLogStoreConformance(createInMemoryEventLogStore, { describe, it, expect });
+
+describe("createInMemoryEventLogStore", () => {
+  test("passes the conformance suite in its runner-agnostic form", async () => {
+    await expect(
+      assertEventLogStoreConformance(createInMemoryEventLogStore),
+    ).resolves.toBeUndefined();
+  });
+
+  test("a stale expectedIndex throws AgentEventLogConflictError with both indices", async () => {
+    const store = createInMemoryEventLogStore();
+    await store.append({ threadId: "t", expectedIndex: 0, entries: [testEntry(0, "a")] });
+
+    let caught: unknown;
+    try {
+      await store.append({ threadId: "t", expectedIndex: 0, entries: [testEntry(0, "b")] });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AgentEventLogConflictError);
+    const conflict = caught as AgentEventLogConflictError;
+    expect(conflict.code).toBe("event-log-conflict");
+    expect(conflict.threadId).toBe("t");
+    expect(conflict.expectedIndex).toBe(0);
+    expect(conflict.actualIndex).toBe(1);
+    expect(conflict.name).toBe("AgentEventLogConflictError");
+  });
+
+  test("rejects an entry that is not a valid envelope", async () => {
+    const store = createInMemoryEventLogStore();
+
+    await expect(
+      store.append({
+        threadId: "t",
+        expectedIndex: 0,
+        entries: [{ ...testEntry(0, "a"), recordedAt: "yesterday" }],
+      }),
+    ).rejects.toThrowError(/RFC 3339/);
+  });
+});

--- a/src/event-log-store.test.ts
+++ b/src/event-log-store.test.ts
@@ -45,6 +45,16 @@ describe("createInMemoryEventLogStore", () => {
     expect(conflict.name).toBe("AgentEventLogConflictError");
   });
 
+  test("fork rejects upToIndex 0, which would drop the init entry", async () => {
+    const store = createInMemoryEventLogStore();
+    await store.append({ threadId: "t", expectedIndex: 0, entries: [testEntry(0, "a")] });
+
+    await expect(
+      store.fork({ threadId: "t", newThreadId: "f", upToIndex: 0 }),
+    ).rejects.toThrowError(/upToIndex must be an integer in \[1, 1\]/);
+    expect(await store.length("f")).toBe(0);
+  });
+
   test("rejects an entry that is not a valid envelope", async () => {
     const store = createInMemoryEventLogStore();
 

--- a/src/event-log-store.ts
+++ b/src/event-log-store.ts
@@ -1,0 +1,165 @@
+/**
+ * Durable storage for {@link AgentLogEntry} logs: the one interface a host
+ * implements, plus the in-memory reference implementation the conformance
+ * suite is written against.
+ * @module
+ */
+import { AgentError } from "./errors.js";
+import { assertAgentLogEntry, type AgentLogEntry } from "./event-log.js";
+
+/**
+ * An append-only event log: the authoritative durability artifact of a thread.
+ * The journal of external inputs IS the source of truth — deterministic
+ * `replay` derives every snapshot from it, and a fork is a copied log prefix.
+ *
+ * Userland stores (a Postgres table with a `(thread_id, index)` primary key, an
+ * append-only object in blob storage, …) implement this one shape so they
+ * interoperate; {@link createInMemoryEventLogStore} is the reference, and
+ * `assertEventLogStoreConformance` checks an implementation against it.
+ */
+export interface AgentEventLogStore {
+  /**
+   * Append `entries` starting at `expectedIndex` (the current length of the
+   * thread's log; 0 for a new thread). Atomic — all entries land or none do.
+   * Rejects with {@link AgentEventLogConflictError} when the thread's length
+   * differs from `expectedIndex`: a concurrent writer appended first. Each
+   * entry's `index` must be contiguous from `expectedIndex` (a plain `Error`
+   * otherwise: that is caller misuse, not a race).
+   */
+  append(input: {
+    threadId: string;
+    expectedIndex: number;
+    entries: AgentLogEntry[];
+  }): Promise<void>;
+  /**
+   * Read a thread's entries in log order. `from` (default 0) skips entries
+   * below that index for incremental catch-up. An unknown thread reads as an
+   * empty array.
+   */
+  read(threadId: string, options?: { from?: number }): Promise<AgentLogEntry[]>;
+  /** The thread's current log length (0 for an unknown thread) — the next `expectedIndex`. */
+  length(threadId: string): Promise<number>;
+  /**
+   * Copy the prefix `[0, upToIndex)` onto a fresh, empty `newThreadId`.
+   * Without `upToIndex` the full source is copied. The fork then appends
+   * independently. Rejects (plain `Error`) if `newThreadId` already has
+   * entries, the source is unknown, or `upToIndex` is out of range.
+   * Implementations may copy-on-write or physically copy; observable behavior
+   * must match a full copy.
+   */
+  fork(input: {
+    threadId: string;
+    newThreadId: string;
+    /** Exclusive index cutoff. */
+    upToIndex?: number;
+  }): Promise<void>;
+}
+
+/**
+ * Rejection from {@link AgentEventLogStore.append} when the thread's stored
+ * length is not the `expectedIndex` the writer held — a concurrent writer
+ * appended first. `actualIndex` is the next index the store would accept.
+ */
+export class AgentEventLogConflictError extends AgentError {
+  readonly threadId: string;
+  readonly expectedIndex: number;
+  readonly actualIndex: number;
+
+  constructor(threadId: string, expectedIndex: number, actualIndex: number) {
+    super(
+      "event-log-conflict",
+      `AgentEventLogStore.append: index conflict on thread "${threadId}": ` +
+        `expected index ${expectedIndex} but found ${actualIndex} — a concurrent writer won.`,
+    );
+    this.name = "AgentEventLogConflictError";
+    this.threadId = threadId;
+    this.expectedIndex = expectedIndex;
+    this.actualIndex = actualIndex;
+  }
+}
+
+/**
+ * In-memory reference store, and the baseline the conformance suite runs
+ * against. Per-thread entries are held in a contiguous, index-ordered list;
+ * append's check-and-push runs synchronously (no `await` between reading the
+ * length and writing), so two appends racing on the same `expectedIndex`
+ * resolve to exactly one winner. Every stored and returned entry is
+ * `structuredClone`d, so a caller can neither mutate stored state through a
+ * value it appended nor through a value it read.
+ */
+export function createInMemoryEventLogStore(): AgentEventLogStore {
+  // threadId → entries, index i holding the entry whose `index` is i (contiguous).
+  const threads = new Map<string, AgentLogEntry[]>();
+  const clone = <T>(value: T): T => structuredClone(value);
+
+  return {
+    async append({ threadId, expectedIndex, entries }) {
+      for (const entry of entries) {
+        assertAgentLogEntry(entry);
+      }
+      // Contiguity: every entry.index must follow expectedIndex in order.
+      for (let i = 0; i < entries.length; i++) {
+        if (entries[i]!.index !== expectedIndex + i) {
+          throw new Error(
+            `AgentEventLogStore.append: entry.index (${entries[i]!.index}) must be contiguous ` +
+              `from expectedIndex (${expectedIndex}); expected ${expectedIndex + i} at position ${i} ` +
+              `on thread "${threadId}".`,
+          );
+        }
+      }
+      const list = threads.get(threadId);
+      const length = list ? list.length : 0;
+      if (length !== expectedIndex) {
+        throw new AgentEventLogConflictError(threadId, expectedIndex, length);
+      }
+      const ids = new Set((list ?? []).map((entry) => entry.id));
+      for (const entry of entries) {
+        if (ids.has(entry.id)) {
+          throw new Error(
+            `AgentEventLogStore.append: duplicate event id "${entry.id}" in thread "${threadId}".`,
+          );
+        }
+        ids.add(entry.id);
+      }
+      const cloned = entries.map((entry) => clone(entry));
+      if (list) {
+        for (const entry of cloned) list.push(entry);
+      } else {
+        threads.set(threadId, cloned);
+      }
+    },
+
+    async read(threadId, options) {
+      const list = threads.get(threadId) ?? [];
+      const from = options?.from ?? 0;
+      return list.slice(from).map((entry) => clone(entry));
+    },
+
+    async length(threadId) {
+      return threads.get(threadId)?.length ?? 0;
+    },
+
+    async fork({ threadId, newThreadId, upToIndex }) {
+      if ((threads.get(newThreadId)?.length ?? 0) > 0) {
+        throw new Error(
+          `AgentEventLogStore.fork: newThreadId "${newThreadId}" already has entries.`,
+        );
+      }
+      const source = threads.get(threadId);
+      if (!source) {
+        throw new Error(`AgentEventLogStore.fork: unknown source thread "${threadId}".`);
+      }
+      const upTo = upToIndex ?? source.length;
+      if (upTo < 0 || upTo > source.length) {
+        throw new Error(
+          `AgentEventLogStore.fork: thread "${threadId}" (length ${source.length}) ` +
+            `has no index ${upTo} to fork up to.`,
+        );
+      }
+      threads.set(
+        newThreadId,
+        source.slice(0, upTo).map((entry) => clone(entry)),
+      );
+    },
+  };
+}

--- a/src/event-log-store.ts
+++ b/src/event-log-store.ts
@@ -41,7 +41,9 @@ export interface AgentEventLogStore {
   length(threadId: string): Promise<number>;
   /**
    * Copy the prefix `[0, upToIndex)` onto a fresh, empty `newThreadId`.
-   * Without `upToIndex` the full source is copied. The fork then appends
+   * Without `upToIndex` the full source is copied. `upToIndex` is exclusive
+   * and must be an integer in `[1, length]`, so the fork keeps the reserved
+   * init entry and stays a self-contained log. The fork then appends
    * independently. Rejects (plain `Error`) if `newThreadId` already has
    * entries, the source is unknown, or `upToIndex` is out of range.
    * Implementations may copy-on-write or physically copy; observable behavior
@@ -150,10 +152,12 @@ export function createInMemoryEventLogStore(): AgentEventLogStore {
         throw new Error(`AgentEventLogStore.fork: unknown source thread "${threadId}".`);
       }
       const upTo = upToIndex ?? source.length;
-      if (upTo < 0 || upTo > source.length) {
+      // `upToIndex` is exclusive and must leave the reserved init entry in
+      // place: a fork of 0 entries is not a self-contained log.
+      if (!Number.isInteger(upTo) || upTo < 1 || upTo > source.length) {
         throw new Error(
-          `AgentEventLogStore.fork: thread "${threadId}" (length ${source.length}) ` +
-            `has no index ${upTo} to fork up to.`,
+          `AgentEventLogStore.fork: upToIndex must be an integer in ` +
+            `[1, ${source.length}] on thread "${threadId}"; got ${String(upTo)}.`,
         );
       }
       threads.set(

--- a/src/event-log.test.ts
+++ b/src/event-log.test.ts
@@ -1,0 +1,431 @@
+import { describe, expect, test } from "vitest";
+import {
+  createAsyncLogic,
+  setup,
+  transition,
+  type AnyMachineSnapshot,
+  type EventObject,
+} from "xstate";
+import {
+  AGENT_EVENT_SCHEMA_VERSION,
+  AGENT_INIT_EVENT_TYPE,
+  AgentEventLogError,
+  AgentMachineVersionMismatchError,
+  AgentReplayDivergenceError,
+  NonSerializableAgentEventError,
+  agentCallOccurrence,
+  assertAgentLogEntry,
+  createReplayEntry,
+  forkEventLog,
+  getLogExecutionId,
+  getSnapshotStateHash,
+  getUsageFromEvents,
+  initEntry,
+  rebindActorSession,
+  replay,
+  validateReplayEntries,
+  type AgentLogEntry,
+} from "./event-log.js";
+import { AGENT_USAGE_EVENT_TYPE } from "./usage.js";
+
+// A machine with one invoked async actor. The actor throws if it is ever run,
+// so any test that reaches `done` proves replay never executed it.
+function createJobMachine() {
+  const job = createAsyncLogic<string, { attempt: number }>({
+    run: () => {
+      throw new Error("the invoked actor must never run during replay");
+    },
+  });
+  return setup({ actors: { job } }).createMachine({
+    id: "jobber",
+    initial: "idle",
+    context: ({ input }: { input?: { attempt?: number } }) => ({
+      attempt: input?.attempt ?? 0,
+      result: null as string | null,
+    }),
+    states: {
+      idle: { on: { GO: { target: "working" } } },
+      working: {
+        invoke: {
+          id: "job",
+          src: "job",
+          input: ({ context }) => ({ attempt: context.attempt }),
+          onDone: ({ output }: { output: string }) => ({
+            target: "done",
+            context: { result: output },
+          }),
+          onError: { target: "failed" },
+        },
+      },
+      done: { type: "final" },
+      failed: {},
+    },
+  });
+}
+
+/** Journaled events carry actor identity fields that `EventObject` does not declare. */
+function journaled(event: Record<string, unknown> & { type: string }): EventObject {
+  return event as EventObject;
+}
+
+const machine = createJobMachine();
+
+/** Builds the log of a run that goes idle → working → done, by hand. */
+function buildLog(options: { output?: string; error?: unknown } = {}): AgentLogEntry[] {
+  const entries: AgentLogEntry[] = [
+    initEntry(machine, { input: { attempt: 1 } }, { metadata: { executionId: "exec_1" } }),
+  ];
+  entries.push(createReplayEntry(machine, entries, { type: "GO" }));
+  // The invoke's session id at this point in the fold; `rebindActorSession`
+  // re-derives it on replay, so any plausible value round-trips.
+  const { snapshot } = replay(machine, entries);
+  const sessionId = (
+    Object.values((snapshot as AnyMachineSnapshot).children)[0] as {
+      sessionId: string;
+    }
+  ).sessionId;
+  entries.push(
+    createReplayEntry(
+      machine,
+      entries,
+      "error" in options
+        ? journaled({ type: "xstate.error.actor", actorId: "job", sessionId, error: options.error })
+        : journaled({
+            type: "xstate.done.actor",
+            actorId: "job",
+            sessionId,
+            output: options.output ?? "shipped",
+          }),
+    ),
+  );
+  return entries;
+}
+
+describe("entry creation", () => {
+  test("initEntry carries input, index 0, and a recorded state hash", () => {
+    const entry = initEntry(machine, { input: { attempt: 2 } }, { metadata: { executionId: "e" } });
+
+    expect(entry.schemaVersion).toBe(AGENT_EVENT_SCHEMA_VERSION);
+    expect(entry.id).toBe("evt_00000000");
+    expect(entry.index).toBe(0);
+    expect(entry.event.type).toBe(AGENT_INIT_EVENT_TYPE);
+    expect((entry.event as unknown as { input: unknown }).input).toEqual({ attempt: 2 });
+    expect(entry.machineId).toBe("jobber");
+    expect(entry.verification?.stateHash).toMatch(/^[0-9a-f]{8}$/);
+    expect(() => assertAgentLogEntry(entry)).not.toThrow();
+  });
+
+  test("initEntry rejects both input and snapshot", () => {
+    const { persistedSnapshot } = replay(machine, [initEntry(machine, { input: undefined })]);
+
+    expect(() =>
+      initEntry(machine, { input: 1, snapshot: persistedSnapshot } as never),
+    ).toThrowError(AgentEventLogError);
+  });
+
+  test("createReplayEntry indexes from the prefix and honors id/recordedAt/causationId", () => {
+    const entries = [initEntry(machine, { input: undefined })];
+    const entry = createReplayEntry(
+      machine,
+      entries,
+      { type: "GO" },
+      {
+        id: "custom",
+        recordedAt: "2026-01-01T00:00:00.000Z",
+        causationId: entries[0]!.id,
+        metadata: { note: "manual" },
+      },
+    );
+
+    expect(entry.index).toBe(1);
+    expect(entry.id).toBe("custom");
+    expect(entry.recordedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(entry.causationId).toBe("evt_00000000");
+    expect(entry.metadata).toEqual({ note: "manual" });
+  });
+
+  test("verification: false omits the hash", () => {
+    const entry = initEntry(machine, { input: undefined }, { verification: false });
+
+    expect(entry.verification).toBeUndefined();
+  });
+
+  test("an explicit snapshot option matches the folded hash", () => {
+    const entries = [initEntry(machine, { input: undefined })];
+    const { snapshot } = replay(machine, entries);
+    const [next] = transition(machine, snapshot, { type: "GO" } as never);
+
+    const withSnapshot = createReplayEntry(machine, entries, { type: "GO" }, { snapshot: next });
+    const folded = createReplayEntry(machine, entries, { type: "GO" });
+
+    expect(withSnapshot.verification).toEqual(folded.verification);
+  });
+
+  test("Error payloads are normalized into plain objects", () => {
+    const entries = [initEntry(machine, { input: undefined })];
+    const entry = createReplayEntry(
+      machine,
+      entries,
+      journaled({ type: "xstate.error.actor", actorId: "job", error: new TypeError("boom") }),
+      { verification: false },
+    );
+
+    expect((entry.event as unknown as { error: unknown }).error).toEqual({
+      name: "TypeError",
+      message: "boom",
+    });
+  });
+
+  test("non-serializable payloads are rejected with the offending path", () => {
+    const entries = [initEntry(machine, { input: undefined })];
+
+    let caught: unknown;
+    try {
+      createReplayEntry(machine, entries, { type: "GO", fn: () => 1 } as never);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(NonSerializableAgentEventError);
+    expect((caught as NonSerializableAgentEventError).path).toBe("entry.event.fn");
+    expect((caught as NonSerializableAgentEventError).code).toBe("non-serializable-event");
+  });
+
+  test("a log round-trips through JSON unchanged, metadata included", () => {
+    const entries = buildLog();
+    const roundTripped = JSON.parse(JSON.stringify(entries)) as AgentLogEntry[];
+
+    expect(roundTripped).toEqual(entries);
+    expect(getLogExecutionId(roundTripped)).toBe("exec_1");
+  });
+});
+
+describe("validateReplayEntries", () => {
+  test("accepts a well-formed log", () => {
+    expect(() => validateReplayEntries(buildLog(), { machine })).not.toThrow();
+  });
+
+  test("rejects a log that does not start with the init entry", () => {
+    const entries = buildLog()
+      .slice(1)
+      .map((entry, index) => ({ ...entry, index }));
+
+    expect(() => validateReplayEntries(entries)).toThrowError(AgentEventLogError);
+  });
+
+  test("rejects non-contiguous indices", () => {
+    const entries = buildLog();
+    entries[2] = { ...entries[2]!, index: 5 };
+
+    expect(() => validateReplayEntries(entries)).toThrowError(/contiguous/);
+  });
+
+  test("rejects duplicate entry ids", () => {
+    const entries = buildLog();
+    entries[2] = { ...entries[2]!, id: entries[1]!.id };
+
+    expect(() => validateReplayEntries(entries)).toThrowError(/duplicate entry id/);
+  });
+
+  test("rejects a bad schemaVersion", () => {
+    const entries = buildLog();
+    entries[1] = { ...entries[1]!, schemaVersion: 2 as never };
+
+    expect(() => validateReplayEntries(entries)).toThrowError(/schema version/);
+  });
+});
+
+describe("replay", () => {
+  test("folds a journaled invoke completion without running the actor", () => {
+    const entries = buildLog({ output: "shipped" });
+
+    const { snapshot, persistedSnapshot } = replay(machine, entries);
+
+    expect(snapshot.value).toBe("done");
+    expect(snapshot.context.result).toBe("shipped");
+    expect((persistedSnapshot as unknown as { value: unknown }).value).toBe("done");
+  });
+
+  test("rebinds actor sessions across a JSON round-trip", () => {
+    const entries = JSON.parse(JSON.stringify(buildLog())) as AgentLogEntry[];
+    // A stale session id from another process: without rebinding, XState drops
+    // the completion and the machine never leaves `working`.
+    entries[2] = {
+      ...entries[2]!,
+      event: journaled({ ...entries[2]!.event, sessionId: "stale:from:another:run" }),
+    };
+
+    const { snapshot } = replay(machine, entries, { verify: false });
+
+    expect(snapshot.value).toBe("done");
+  });
+
+  test("rebindActorSession leaves non-actor events alone", () => {
+    const event = { type: "GO" };
+
+    expect(rebindActorSession(event, {} as AnyMachineSnapshot, new Map())).toBe(event);
+  });
+
+  test("a journaled error completion replays to the error branch", () => {
+    const { snapshot } = replay(machine, buildLog({ error: new Error("nope") }));
+
+    expect(snapshot.value).toBe("failed");
+  });
+
+  test("verify: true accepts an untampered log and rejects a tampered hash", () => {
+    const entries = buildLog();
+
+    expect(() => replay(machine, entries, { verify: true })).not.toThrow();
+
+    entries[2] = { ...entries[2]!, verification: { stateHash: "deadbeef" } };
+    let caught: unknown;
+    try {
+      replay(machine, entries, { verify: true });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AgentReplayDivergenceError);
+    expect((caught as AgentReplayDivergenceError).kind).toBe("state");
+    expect((caught as AgentReplayDivergenceError).index).toBe(2);
+    expect((caught as AgentReplayDivergenceError).expected).toBe("deadbeef");
+    expect((caught as AgentReplayDivergenceError).code).toBe("replay-diverged");
+  });
+
+  test("verify: 'strict' requires a hash on every entry; verify: false skips both", () => {
+    const entries = buildLog();
+    const withoutHash = { ...entries[1]! };
+    delete withoutHash.verification;
+    entries[1] = withoutHash;
+
+    expect(() => replay(machine, entries, { verify: true })).not.toThrow();
+    expect(() => replay(machine, entries, { verify: false })).not.toThrow();
+
+    let caught: unknown;
+    try {
+      replay(machine, entries, { verify: "strict" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AgentReplayDivergenceError);
+    expect((caught as AgentReplayDivergenceError).kind).toBe("missing-verification");
+  });
+
+  test("a machine version mismatch throws", () => {
+    const entries = buildLog();
+    entries[1] = { ...entries[1]!, machineVersion: "some-other-version" };
+
+    let caught: unknown;
+    try {
+      replay(machine, entries);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AgentMachineVersionMismatchError);
+    expect((caught as AgentMachineVersionMismatchError).code).toBe("machine-version-mismatch");
+    expect((caught as AgentMachineVersionMismatchError).index).toBe(1);
+  });
+
+  test("an init-with-snapshot entry bridges an older version and replays onward", () => {
+    // The persisted snapshot of a run paused mid-invoke, as a host would store it.
+    const previous = buildLog().slice(0, 2);
+    const { persistedSnapshot } = replay(machine, previous);
+    const bridged = JSON.parse(JSON.stringify(persistedSnapshot)) as typeof persistedSnapshot;
+
+    const entries: AgentLogEntry[] = [
+      initEntry(machine, { snapshot: bridged }, { machineVersion: "v0-legacy" }),
+    ];
+    entries.push(
+      createReplayEntry(
+        machine,
+        entries,
+        journaled({
+          type: "xstate.done.actor",
+          actorId: "job",
+          sessionId: "recorded:elsewhere",
+          output: "bridged",
+        }),
+      ),
+    );
+
+    const { snapshot } = replay(machine, entries);
+
+    expect(snapshot.value).toBe("done");
+    expect(snapshot.context.result).toBe("bridged");
+  });
+
+  test("an empty log cannot be replayed", () => {
+    expect(() => replay(machine, [])).toThrowError(AgentEventLogError);
+  });
+});
+
+describe("getSnapshotStateHash", () => {
+  test("is stable across a JSON round-trip and changes with state", () => {
+    const early = replay(machine, buildLog().slice(0, 2)).persistedSnapshot;
+    const late = replay(machine, buildLog()).persistedSnapshot;
+
+    expect(getSnapshotStateHash(early)).toBe(
+      getSnapshotStateHash(JSON.parse(JSON.stringify(early))),
+    );
+    expect(getSnapshotStateHash(early)).not.toBe(getSnapshotStateHash(late));
+  });
+});
+
+describe("agentCallOccurrence", () => {
+  test("counts done and error completions for the site, 1-based", () => {
+    const history = [
+      journaled({ type: "GO" }),
+      journaled({ type: "xstate.done.actor", actorId: "job", output: 1 }),
+      journaled({ type: "xstate.error.actor", actorId: "job", error: "x" }),
+      journaled({ type: "xstate.done.actor", actorId: "other", output: 2 }),
+    ];
+
+    expect(agentCallOccurrence(history, "job")).toBe(3);
+    expect(agentCallOccurrence(history, "other")).toBe(2);
+    expect(agentCallOccurrence(history, "unknown")).toBe(1);
+    expect(agentCallOccurrence(undefined, "job")).toBe(1);
+  });
+
+  test("accepts log entries as well as bare events", () => {
+    expect(agentCallOccurrence(buildLog(), "job")).toBe(2);
+  });
+});
+
+describe("getUsageFromEvents", () => {
+  test("sums reported token fields and ignores non-finite values", () => {
+    const usage = getUsageFromEvents([
+      journaled({ type: AGENT_USAGE_EVENT_TYPE, usage: { inputTokens: 10, outputTokens: 4 } }),
+      journaled({
+        type: AGENT_USAGE_EVENT_TYPE,
+        usage: { inputTokens: 5, outputTokens: Number.NaN },
+      }),
+      journaled({ type: "GO" }),
+      journaled({ type: AGENT_USAGE_EVENT_TYPE }),
+    ]);
+
+    expect(usage.inputTokens).toBe(15);
+    expect(usage.outputTokens).toBe(4);
+    expect(usage.totalTokens).toBeUndefined();
+  });
+});
+
+describe("forkEventLog", () => {
+  test("slices an exclusive prefix that still replays", () => {
+    const entries = buildLog();
+
+    const forked = forkEventLog(entries, 2);
+
+    expect(forked).toHaveLength(2);
+    expect(forked[1]).toEqual(entries[1]);
+    expect(replay(machine, forked).snapshot.value).toBe("working");
+  });
+
+  test("rejects a cutoff that drops the init entry or overruns the log", () => {
+    const entries = buildLog();
+
+    expect(() => forkEventLog(entries, 0)).toThrowError(AgentEventLogError);
+    expect(() => forkEventLog(entries, 99)).toThrowError(AgentEventLogError);
+  });
+});

--- a/src/event-log.test.ts
+++ b/src/event-log.test.ts
@@ -362,6 +362,61 @@ describe("replay", () => {
 });
 
 describe("getSnapshotStateHash", () => {
+  test("hashes a reserved key that lives in context as application data", () => {
+    const base = { status: "active", value: "idle", children: {} };
+
+    expect(getSnapshotStateHash({ ...base, context: { sessionId: 1 } })).not.toBe(
+      getSnapshotStateHash({ ...base, context: { sessionId: 2 } }),
+    );
+    expect(getSnapshotStateHash({ ...base, context: { nested: { _nextTimerId: 1 } } })).not.toBe(
+      getSnapshotStateHash({ ...base, context: { nested: { _nextTimerId: 9 } } }),
+    );
+    // An event payload carried in `output` is application data too.
+    expect(getSnapshotStateHash({ ...base, output: { sessionId: "a" } })).not.toBe(
+      getSnapshotStateHash({ ...base, output: { sessionId: "b" } }),
+    );
+  });
+
+  test("strips re-minted identity only at the snapshot and children positions", () => {
+    const snapshotWith = (sessionId: string, childSessionId: string, nextTimerId: number) => ({
+      status: "active",
+      value: "working",
+      sessionId,
+      _nextTimerId: nextTimerId,
+      _nextActorIds: { job: nextTimerId },
+      context: { attempt: 1 },
+      children: {
+        job: {
+          sessionId: childSessionId,
+          src: "job",
+          syncSnapshot: false,
+          snapshot: { status: "active", sessionId: `${childSessionId}:inner`, context: {} },
+        },
+      },
+    });
+
+    expect(getSnapshotStateHash(snapshotWith("x:1", "x:2", 0))).toBe(
+      getSnapshotStateHash(snapshotWith("y:1", "y:2", 7)),
+    );
+  });
+
+  test("two live actors of the same machine at the same state hash identically", () => {
+    const first = replay(machine, buildLog().slice(0, 2)).persistedSnapshot;
+    const second = replay(machine, buildLog().slice(0, 2)).persistedSnapshot;
+
+    expect(getSnapshotStateHash(first)).toBe(getSnapshotStateHash(second));
+  });
+
+  test("terminates on a self-containing Map or Set", () => {
+    const map = new Map<string, unknown>();
+    map.set("self", map);
+    const set = new Set<unknown>();
+    set.add(set);
+
+    expect(getSnapshotStateHash({ context: { map } })).toMatch(/^[0-9a-f]{8}$/);
+    expect(getSnapshotStateHash({ context: { set } })).toMatch(/^[0-9a-f]{8}$/);
+  });
+
   test("is stable across a JSON round-trip and changes with state", () => {
     const early = replay(machine, buildLog().slice(0, 2)).persistedSnapshot;
     const late = replay(machine, buildLog()).persistedSnapshot;
@@ -390,6 +445,23 @@ describe("agentCallOccurrence", () => {
 
   test("accepts log entries as well as bare events", () => {
     expect(agentCallOccurrence(buildLog(), "job")).toBe(2);
+  });
+
+  test("does not unwrap a bare event that carries its own `event` payload", () => {
+    const history = [
+      journaled({ type: "WRAPPED", event: { type: "xstate.done.actor", actorId: "job" } }),
+      journaled({ type: "xstate.done.actor", actorId: "job", output: 1 }),
+    ];
+
+    expect(agentCallOccurrence(history, "job")).toBe(2);
+    expect(
+      getUsageFromEvents([
+        journaled({
+          type: "WRAPPED",
+          event: { type: AGENT_USAGE_EVENT_TYPE, usage: { inputTokens: 99 } },
+        }),
+      ]).inputTokens,
+    ).toBeUndefined();
   });
 });
 
@@ -427,5 +499,33 @@ describe("forkEventLog", () => {
 
     expect(() => forkEventLog(entries, 0)).toThrowError(AgentEventLogError);
     expect(() => forkEventLog(entries, 99)).toThrowError(AgentEventLogError);
+  });
+});
+
+describe("validateReplayEntries", () => {
+  test("a bridged log validates standalone, without a machine", () => {
+    const previous = buildLog().slice(0, 2);
+    const { persistedSnapshot } = replay(machine, previous);
+    const entries: AgentLogEntry[] = [
+      initEntry(machine, { snapshot: persistedSnapshot }, { machineVersion: "v0-legacy" }),
+    ];
+    entries.push(
+      createReplayEntry(
+        machine,
+        entries,
+        journaled({ type: "xstate.done.actor", actorId: "job", output: "bridged" }),
+      ),
+    );
+
+    // Entry 0 carries the OLD version it bridges from; entry 1 the current one.
+    expect(entries[0]!.machineVersion).not.toBe(entries[1]!.machineVersion);
+    expect(() => validateReplayEntries(entries)).not.toThrow();
+  });
+
+  test("still rejects a genuinely mismatched entry with no machine", () => {
+    const entries = buildLog();
+    entries[2] = { ...entries[2]!, machineVersion: "some-other-version" };
+
+    expect(() => validateReplayEntries(entries)).toThrowError(AgentMachineVersionMismatchError);
   });
 });

--- a/src/event-log.test.ts
+++ b/src/event-log.test.ts
@@ -417,6 +417,14 @@ describe("getSnapshotStateHash", () => {
     expect(getSnapshotStateHash({ context: { set } })).toMatch(/^[0-9a-f]{8}$/);
   });
 
+  test("terminates on an Error whose cause chain is cyclic", () => {
+    const outer = new Error("outer");
+    const inner = new Error("inner", { cause: outer });
+    (outer as { cause?: unknown }).cause = inner;
+
+    expect(getSnapshotStateHash({ context: { failure: outer } })).toMatch(/^[0-9a-f]{8}$/);
+  });
+
   test("is stable across a JSON round-trip and changes with state", () => {
     const early = replay(machine, buildLog().slice(0, 2)).persistedSnapshot;
     const late = replay(machine, buildLog()).persistedSnapshot;

--- a/src/event-log.ts
+++ b/src/event-log.ts
@@ -1,0 +1,892 @@
+/**
+ * The event log: an append-only journal of the EXTERNAL inputs a machine
+ * consumed, and the pure fold ({@link replay}) that turns that journal back
+ * into a snapshot without executing anything.
+ *
+ * A journaled entry is always an external input — an invoke completion
+ * (`xstate.done.actor`/`xstate.error.actor` carrying its output inline), a
+ * user-sent event, a timer firing, a reserved `@agent.usage` record. Never a
+ * raised/internal event: replay re-derives those from the machine's own logic,
+ * so journaling them would double-apply them.
+ *
+ * A log is self-contained: its reserved first entry ({@link initEntry}) carries
+ * either the machine `input` (a fresh start) or a persisted snapshot (a
+ * continuation across a machine version, or from a log-less legacy snapshot),
+ * so {@link replay} needs no side channel.
+ * @module
+ */
+import {
+  initialTransition,
+  transition,
+  type AnyMachineSnapshot,
+  type AnyStateMachine,
+  type EventObject,
+  type Snapshot,
+  type SnapshotFrom,
+} from "xstate";
+import { AgentError } from "./errors.js";
+import { AGENT_USAGE_EVENT_TYPE } from "./usage.js";
+import { AGENT_USAGE_TOKEN_FIELDS, type AgentCallUsage } from "./text-logic.js";
+import { djb2Hex, resolveMachineVersion } from "./utils.js";
+
+/** The durable entry envelope version. */
+export const AGENT_EVENT_SCHEMA_VERSION = 1 as const;
+
+/**
+ * The reserved event type of the first entry of every log. It carries the
+ * machine `input` (fresh start) or a persisted `snapshot` (continuation), so a
+ * log replays with no side channel. Lives in the reserved `@agent.*` namespace
+ * so it can never collide with a machine's own vocabulary; it is consumed by
+ * {@link replay} and never fed to `transition`.
+ */
+export const AGENT_INIT_EVENT_TYPE = "@agent.init" as const;
+
+/** Values that round-trip through JSON without adapters or silent coercion. */
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** A persisted (JSON-safe) machine snapshot, as `machine.getPersistedSnapshot()` returns. */
+export type AgentPersistedSnapshot = Snapshot<unknown>;
+
+/** Recorded projection hash used by {@link replay} verification. */
+export interface AgentLogVerification {
+  /** {@link getSnapshotStateHash} of the persisted snapshot after this entry is applied. */
+  stateHash: string;
+}
+
+/**
+ * One journaled external input, JSON-safe and stored verbatim.
+ */
+export interface AgentLogEntry {
+  /** Version of this outer envelope, independent of the machine event type. */
+  schemaVersion: typeof AGENT_EVENT_SCHEMA_VERSION;
+  /** Stable identity within the log. Forked prefixes retain their ids. */
+  id: string;
+  /** 0-based position in the log. */
+  index: number;
+  /** RFC 3339 wall-clock time when the host accepted the entry. Metadata only. */
+  recordedAt: string;
+  /** The authored XState machine id. */
+  machineId: string;
+  /** Explicit version or structural hash of the machine that accepted the event. */
+  machineVersion: string;
+  event: EventObject;
+  /** Optional causal parent entry id, scoped to the same log. */
+  causationId?: string;
+  /** Host-owned, JSON-safe; stored verbatim, never interpreted. */
+  metadata?: Record<string, JsonValue>;
+  /** Recorded projection hash used by replay verification. */
+  verification?: AgentLogVerification;
+}
+
+/** The payload of the reserved {@link AGENT_INIT_EVENT_TYPE} first entry. */
+export interface AgentInitEvent extends EventObject {
+  type: typeof AGENT_INIT_EVENT_TYPE;
+  /** Machine input for a fresh start. Mutually exclusive with `snapshot`. */
+  input?: unknown;
+  /** Persisted snapshot to continue from. Mutually exclusive with `input`. */
+  snapshot?: AgentPersistedSnapshot;
+}
+
+/** A malformed or internally inconsistent log. */
+export class AgentEventLogError extends AgentError {
+  constructor(message: string) {
+    super("invalid-event-log", message);
+    this.name = "AgentEventLogError";
+  }
+}
+
+/** A precise failure when an entry would not survive a JSON round-trip. */
+export class NonSerializableAgentEventError extends AgentError {
+  readonly path: string;
+  readonly valueType: string;
+
+  constructor(path: string, valueType: string) {
+    super(
+      "non-serializable-event",
+      `Agent event field '${path}' is not JSON-serializable (${valueType}).`,
+    );
+    this.name = "NonSerializableAgentEventError";
+    this.path = path;
+    this.valueType = valueType;
+  }
+}
+
+/** Replay reached a state that does not match the entry's recorded hash. */
+export class AgentReplayDivergenceError extends AgentError {
+  constructor(
+    readonly eventId: string,
+    readonly index: number,
+    readonly kind: "state" | "missing-verification",
+    readonly expected?: string,
+    readonly actual?: string,
+  ) {
+    super(
+      "replay-diverged",
+      kind === "missing-verification"
+        ? `Replay entry '${eventId}' at index ${index} has no recorded verification hash.`
+        : `Replay diverged after '${eventId}' at index ${index}: ` +
+            `expected state hash '${expected}', got '${actual}'.`,
+    );
+    this.name = "AgentReplayDivergenceError";
+  }
+}
+
+/**
+ * An entry was recorded against a different machine (id) or a different
+ * machine version than the one replaying it. An init-with-snapshot entry is
+ * exempt: that entry IS the bridge from the old version to the new one.
+ */
+export class AgentMachineVersionMismatchError extends AgentError {
+  constructor(
+    readonly eventId: string,
+    readonly index: number,
+    readonly expected: { machineId: string; machineVersion: string },
+    readonly actual: { machineId: string; machineVersion: string },
+  ) {
+    super(
+      "machine-version-mismatch",
+      `Event log entry '${eventId}' at index ${index} targets machine ` +
+        `'${actual.machineId}'@'${actual.machineVersion}', expected ` +
+        `'${expected.machineId}'@'${expected.machineVersion}'.`,
+    );
+    this.name = "AgentMachineVersionMismatchError";
+  }
+}
+
+// --- JSON safety -----------------------------------------------------------
+
+// Symbol keys and non-enumerable string properties are silently dropped by
+// JSON, so both the array and object branches below reject them. `isOwnKey`
+// exempts the string keys a container legitimately owns (an array's `length`
+// and its indices).
+function assertNoHiddenKeys(
+  value: object,
+  path: string,
+  isOwnKey?: (key: string) => boolean,
+): void {
+  const symbols = Object.getOwnPropertySymbols(value);
+  if (symbols.length > 0) {
+    throw new NonSerializableAgentEventError(`${path}.[${String(symbols[0])}]`, "symbol key");
+  }
+  const hiddenKey = Object.getOwnPropertyNames(value).find(
+    (key) => !isOwnKey?.(key) && !Object.getOwnPropertyDescriptor(value, key)?.enumerable,
+  );
+  if (hiddenKey !== undefined) {
+    throw new NonSerializableAgentEventError(`${path}.${hiddenKey}`, "non-enumerable property");
+  }
+}
+
+// Canonical array index, as JSON.stringify treats them.
+const arrayIndexPattern = /^(?:0|[1-9]\d*)$/;
+
+/**
+ * Rejects values JSON would drop or coerce. Unlike `JSON.stringify`, this does
+ * not silently erase `undefined`/functions or turn non-finite numbers into
+ * `null`; durable entries contain only plain JSON values.
+ */
+export function assertJsonSerializable(
+  value: unknown,
+  path = "entry",
+  ancestors: WeakSet<object> = new WeakSet(),
+): asserts value is JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || Object.is(value, -0)) {
+      throw new NonSerializableAgentEventError(path, Object.is(value, -0) ? "-0" : String(value));
+    }
+    return;
+  }
+  if (typeof value !== "object") {
+    throw new NonSerializableAgentEventError(path, typeof value);
+  }
+  if (ancestors.has(value)) {
+    throw new NonSerializableAgentEventError(path, "circular reference");
+  }
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (let index = 0; index < value.length; index++) {
+        if (!Object.hasOwn(value, index)) {
+          throw new NonSerializableAgentEventError(`${path}[${index}]`, "array hole");
+        }
+        assertJsonSerializable(value[index], `${path}[${index}]`, ancestors);
+      }
+      const extraKey = Object.keys(value).find(
+        (key) => !arrayIndexPattern.test(key) || Number(key) >= value.length,
+      );
+      if (extraKey !== undefined) {
+        throw new NonSerializableAgentEventError(`${path}.${extraKey}`, "array property");
+      }
+      assertNoHiddenKeys(value, path, (key) => key === "length" || arrayIndexPattern.test(key));
+      return;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      const type = (value as { constructor?: { name?: string } }).constructor?.name ?? "object";
+      throw new NonSerializableAgentEventError(path, type);
+    }
+    assertNoHiddenKeys(value, path);
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      assertJsonSerializable(child, `${path}.${key}`, ancestors);
+    }
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+// Every string field of the envelope has the same rule; naming the field in the
+// message is what makes a rejected entry diagnosable.
+function requireNonEmptyString(value: unknown, label: string, qualifier = ""): void {
+  if (typeof value !== "string" || !value) {
+    throw new AgentEventLogError(`Agent event ${label} must be a non-empty string${qualifier}.`);
+  }
+}
+
+/** Validates the complete durable envelope before append/export/replay. */
+export function assertAgentLogEntry(entry: unknown): asserts entry is AgentLogEntry {
+  if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new AgentEventLogError("Agent event entry must be an object.");
+  }
+  assertJsonSerializable(entry);
+  const candidate = entry as Partial<AgentLogEntry>;
+  if (candidate.schemaVersion !== AGENT_EVENT_SCHEMA_VERSION) {
+    throw new AgentEventLogError(
+      `Unsupported agent event schema version '${String(candidate.schemaVersion)}'; ` +
+        `expected '${AGENT_EVENT_SCHEMA_VERSION}'.`,
+    );
+  }
+  if (!Number.isInteger(candidate.index) || candidate.index! < 0) {
+    throw new AgentEventLogError(
+      `Agent event entry.index must be a non-negative integer; got ${String(candidate.index)}.`,
+    );
+  }
+  for (const field of ["id", "machineId", "machineVersion"] as const) {
+    requireNonEmptyString(candidate[field], `entry.${field}`);
+  }
+  if (
+    typeof candidate.recordedAt !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(
+      candidate.recordedAt,
+    ) ||
+    Number.isNaN(Date.parse(candidate.recordedAt))
+  ) {
+    throw new AgentEventLogError(
+      `Agent event entry.recordedAt is not RFC 3339: '${String(candidate.recordedAt)}'.`,
+    );
+  }
+  if (
+    candidate.event === null ||
+    typeof candidate.event !== "object" ||
+    Array.isArray(candidate.event) ||
+    typeof candidate.event.type !== "string" ||
+    !candidate.event.type
+  ) {
+    throw new AgentEventLogError("Agent event entry.event requires a non-empty string type.");
+  }
+  if (candidate.causationId !== undefined) {
+    requireNonEmptyString(candidate.causationId, "entry.causationId", " when present");
+  }
+  if (
+    candidate.metadata !== undefined &&
+    (candidate.metadata === null ||
+      typeof candidate.metadata !== "object" ||
+      Array.isArray(candidate.metadata))
+  ) {
+    throw new AgentEventLogError("Agent event entry.metadata must be an object when present.");
+  }
+  if (
+    candidate.verification !== undefined &&
+    (candidate.verification === null ||
+      typeof candidate.verification !== "object" ||
+      typeof candidate.verification.stateHash !== "string" ||
+      !candidate.verification.stateHash)
+  ) {
+    throw new AgentEventLogError(
+      "Agent event entry.verification requires a non-empty stateHash string.",
+    );
+  }
+}
+
+/**
+ * Replaces `Error` instances with plain `{ name, message, cause? }` objects so
+ * an `xstate.error.actor` payload survives the log's JSON round-trip. Cycles
+ * are preserved by identity; non-plain objects are left alone (and are then
+ * rejected by {@link assertJsonSerializable}).
+ */
+function normalizeEventErrors(
+  value: unknown,
+  seen: WeakMap<object, unknown> = new WeakMap(),
+): unknown {
+  if (value instanceof Error) {
+    const normalized: Record<string, unknown> = {
+      name: value.name,
+      message: value.message,
+    };
+    seen.set(value, normalized);
+    if (value.cause !== undefined) normalized.cause = normalizeEventErrors(value.cause, seen);
+    return normalized;
+  }
+  if (value === null || typeof value !== "object") return value;
+  const existing = seen.get(value);
+  if (existing !== undefined) return existing;
+  if (Array.isArray(value)) {
+    const result: unknown[] = [];
+    seen.set(value, result);
+    for (const item of value) result.push(normalizeEventErrors(item, seen));
+    return result;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return value;
+  const result: Record<string, unknown> = {};
+  seen.set(value, result);
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    result[key] = normalizeEventErrors(item, seen);
+  }
+  return result;
+}
+
+// --- Hashing ---------------------------------------------------------------
+
+// Keys stripped from a persisted snapshot before hashing: they are re-minted on
+// every fold (actor session ids, the actor/timer id counters) and so differ
+// between two runs that are otherwise identical.
+const VOLATILE_SNAPSHOT_KEYS = new Set(["sessionId", "_nextTimerId", "_nextActorIds"]);
+
+function canonicalizeForHash(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+  if (value === undefined) return "[undefined]";
+  if (typeof value === "function") return "[function]";
+  if (typeof value === "bigint") return `[bigint:${String(value)}]`;
+  if (typeof value === "symbol") return `[symbol:${String(value)}]`;
+  if (value === null || typeof value !== "object") return value;
+  if (value instanceof Date) return `[Date:${value.toISOString()}]`;
+  if (value instanceof Error) {
+    return {
+      errorName: value.name,
+      message: value.message,
+      ...(value.cause !== undefined ? { cause: canonicalizeForHash(value.cause, seen) } : {}),
+    };
+  }
+  if (value instanceof Set) {
+    return [...value]
+      .map((item) => canonicalizeForHash(item, seen))
+      .sort((a, b) => stableJson(a).localeCompare(stableJson(b)));
+  }
+  if (value instanceof Map) {
+    return [...value.entries()]
+      .map(([key, item]) => [canonicalizeForHash(key, seen), canonicalizeForHash(item, seen)])
+      .sort(([a], [b]) => stableJson(a).localeCompare(stableJson(b)));
+  }
+  if (seen.has(value)) return "[circular]";
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const result = value.map((item) => canonicalizeForHash(item, seen));
+    seen.delete(value);
+    return result;
+  }
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    if (VOLATILE_SNAPSHOT_KEYS.has(key)) continue;
+    const child = (value as Record<string, unknown>)[key];
+    // Undefined values are dropped rather than encoded: a persisted snapshot
+    // carries `output`/`error` as explicit `undefined` before it is serialized,
+    // and a JSON round-trip drops them, so both forms must hash alike.
+    if (child === undefined) continue;
+    result[key] = canonicalizeForHash(child, seen);
+  }
+  seen.delete(value);
+  return result;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value as Record<string, unknown>)
+        .sort()
+        .map((key) => [key, sortJson((value as Record<string, unknown>)[key])]),
+    );
+  }
+  return value;
+}
+
+/**
+ * The canonical hash of a PERSISTED snapshot (`machine.getPersistedSnapshot()`,
+ * or {@link replay}'s `persistedSnapshot`) — the value recorded in an entry's
+ * `verification.stateHash`.
+ *
+ * Stripped before hashing, because they are re-minted on every fold and would
+ * otherwise make two identical runs hash differently: any `sessionId` (child
+ * actor session identity), `_nextTimerId` and `_nextActorIds` (id counters),
+ * and `undefined`-valued properties (so a snapshot hashes the same before and
+ * after a JSON round-trip). Object keys are sorted, so key order is irrelevant.
+ *
+ * A change detector, not a cryptographic digest.
+ */
+export function getSnapshotStateHash(snapshot: AgentPersistedSnapshot | unknown): string {
+  return djb2Hex(stableJson(canonicalizeForHash(snapshot)));
+}
+
+// --- Entries ---------------------------------------------------------------
+
+/** Options controlling the durable envelope created by {@link createReplayEntry}. */
+export interface CreateReplayEntryOptions {
+  /** Explicit machine version; defaults to the machine's resolved version. */
+  machineVersion?: string;
+  /** Stable entry id; defaults to `evt_` plus the zero-padded index. */
+  id?: string;
+  /** RFC 3339 acceptance time; defaults to the current wall clock. */
+  recordedAt?: string;
+  causationId?: string;
+  metadata?: Record<string, JsonValue>;
+  /** Record `verification.stateHash` (default `true`). */
+  verification?: boolean;
+  /**
+   * The snapshot this entry folds to, when the caller already has it — avoids
+   * re-folding the whole prefix just to compute the hash. Accepts a live or a
+   * persisted snapshot.
+   */
+  snapshot?: AnyMachineSnapshot | AgentPersistedSnapshot;
+}
+
+function machineIdOf(machine: AnyStateMachine): string {
+  return (machine.config as { id?: string }).id ?? machine.id ?? "(machine)";
+}
+
+function toPersisted(
+  machine: AnyStateMachine,
+  snapshot: AnyMachineSnapshot | AgentPersistedSnapshot,
+): AgentPersistedSnapshot {
+  // A live MachineSnapshot carries `machine`/`children` actor refs; the
+  // persisted projection is the hashable one.
+  return typeof (snapshot as AnyMachineSnapshot).matches === "function"
+    ? (machine.getPersistedSnapshot(snapshot as AnyMachineSnapshot) as AgentPersistedSnapshot)
+    : (snapshot as AgentPersistedSnapshot);
+}
+
+/**
+ * Creates a JSON-safe, self-describing entry for `event` appended after
+ * `entries` (which must be the complete prefix, so `index` and the recorded
+ * state hash line up).
+ */
+export function createReplayEntry(
+  machine: AnyStateMachine,
+  entries: readonly AgentLogEntry[],
+  event: EventObject,
+  options: CreateReplayEntryOptions = {},
+): AgentLogEntry {
+  const index = entries.length;
+  const machineVersion = options.machineVersion ?? resolveMachineVersion(machine);
+  const entry: AgentLogEntry = {
+    schemaVersion: AGENT_EVENT_SCHEMA_VERSION,
+    id: options.id ?? `evt_${String(index).padStart(8, "0")}`,
+    index,
+    recordedAt: options.recordedAt ?? new Date().toISOString(),
+    machineId: machineIdOf(machine),
+    machineVersion,
+    event: normalizeEventErrors(event) as EventObject,
+    ...(options.causationId !== undefined ? { causationId: options.causationId } : {}),
+    ...(options.metadata !== undefined ? { metadata: options.metadata } : {}),
+  };
+  assertAgentLogEntry(entry);
+  if (options.verification !== false) {
+    const persisted = options.snapshot
+      ? toPersisted(machine, options.snapshot)
+      : replay(machine, [...entries, entry], { machineVersion, verify: false }).persistedSnapshot;
+    // The only field attached after validation; the hash is always non-empty
+    // hex, so the envelope stays valid.
+    entry.verification = { stateHash: getSnapshotStateHash(persisted) };
+  }
+  return entry;
+}
+
+/** How a log begins: from machine input, or from a persisted snapshot. */
+export type AgentLogInit =
+  | { input?: unknown; snapshot?: never }
+  | {
+      snapshot: AgentPersistedSnapshot;
+      input?: never;
+    };
+
+// A persisted snapshot carries `output`/`error` as explicit `undefined` before
+// serialization; JSON drops those keys, and so does this, so the entry passes
+// `assertJsonSerializable` and hashes identically before and after a round-trip.
+function pruneUndefined(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(pruneUndefined);
+  if (value === null || typeof value !== "object") return value;
+  if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
+    return value;
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (child === undefined) continue;
+    result[key] = pruneUndefined(child);
+  }
+  return result;
+}
+
+/**
+ * The reserved first entry of a log. Pass EXACTLY one of:
+ *
+ * - `{ input }` — a fresh start; replay folds from `initialTransition`.
+ * - `{ snapshot }` — a continuation from a persisted snapshot: a version
+ *   bridge, or a legacy snapshot that predates the log. Replay restores it
+ *   purely (no actors started) and folds the rest of the log onto it.
+ *
+ * `options.metadata.executionId` names the lineage; this library always sets
+ * one, and readers must tolerate its absence in logs written elsewhere.
+ */
+export function initEntry(
+  machine: AnyStateMachine,
+  init: AgentLogInit = {},
+  options: CreateReplayEntryOptions = {},
+): AgentLogEntry {
+  const hasSnapshot = init.snapshot !== undefined;
+  if (hasSnapshot && init.input !== undefined) {
+    throw new AgentEventLogError(
+      "initEntry accepts exactly one of `input` (fresh start) or `snapshot` (continuation).",
+    );
+  }
+  const event: AgentInitEvent = {
+    type: AGENT_INIT_EVENT_TYPE,
+    ...(hasSnapshot
+      ? { snapshot: pruneUndefined(init.snapshot) as AgentPersistedSnapshot }
+      : init.input !== undefined
+        ? { input: init.input }
+        : {}),
+  };
+  return createReplayEntry(machine, [], event, options);
+}
+
+/** Whether `entry` is the reserved init entry. */
+function isInitEntry(entry: AgentLogEntry): boolean {
+  return entry.event.type === AGENT_INIT_EVENT_TYPE;
+}
+
+/** Whether `entry` is the version-bridging init-with-snapshot entry. */
+function isSnapshotInitEntry(entry: AgentLogEntry): boolean {
+  return isInitEntry(entry) && (entry.event as AgentInitEvent).snapshot !== undefined;
+}
+
+/**
+ * The log's execution id: the lineage identity pinned in the init entry's
+ * `metadata.executionId`.
+ *
+ * Minted once per run and inherited verbatim by every resume of that log, so
+ * it names one lineage rather than one process. Entry ids cannot serve this
+ * role — the built-in ids are index-derived, so every log's init entry is
+ * `evt_00000000`. A fork copies the init entry, so it shares its parent's
+ * execution id by construction.
+ *
+ * Returns `undefined` for a log with no init entry and for one written without
+ * the field — callers must treat the id as optional.
+ */
+export function getLogExecutionId(entries: readonly AgentLogEntry[]): string | undefined {
+  const init = entries.find((entry) => isInitEntry(entry));
+  const executionId = (init?.metadata as { executionId?: unknown } | undefined)?.executionId;
+  return typeof executionId === "string" ? executionId : undefined;
+}
+
+/**
+ * Validates a log before replay or append: every envelope well-formed, indices
+ * contiguous from 0, ids unique, the first entry the reserved init entry, and
+ * one consistent machine identity throughout.
+ *
+ * With `machine`, entries are also checked against that machine's id and
+ * resolved version — a mismatch throws {@link AgentMachineVersionMismatchError}.
+ * An init-with-snapshot entry is exempt from the version check: that entry is
+ * itself the bridge from whatever version produced the snapshot.
+ */
+export function validateReplayEntries(
+  entries: readonly AgentLogEntry[],
+  options: { machine?: AnyStateMachine; machineVersion?: string } = {},
+): void {
+  if (entries.length === 0) {
+    return;
+  }
+  const expected = options.machine
+    ? {
+        machineId: machineIdOf(options.machine),
+        machineVersion: options.machineVersion ?? resolveMachineVersion(options.machine),
+      }
+    : {
+        machineId: entries[0]!.machineId,
+        machineVersion: options.machineVersion ?? entries[0]!.machineVersion,
+      };
+  const ids = new Set<string>();
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index]!;
+    assertAgentLogEntry(entry);
+    if (entry.index !== index) {
+      throw new AgentEventLogError(
+        `Event log must be contiguous from index 0; found entry.index ${entry.index} ` +
+          `at position ${index}.`,
+      );
+    }
+    if (ids.has(entry.id)) {
+      throw new AgentEventLogError(`Event log contains duplicate entry id '${entry.id}'.`);
+    }
+    ids.add(entry.id);
+    if (index === 0 && !isInitEntry(entry)) {
+      throw new AgentEventLogError(
+        `Event log must start with the reserved '${AGENT_INIT_EVENT_TYPE}' entry; ` +
+          `found '${entry.event.type}'.`,
+      );
+    }
+    if (index > 0 && isInitEntry(entry)) {
+      throw new AgentEventLogError(
+        `Event log has a second '${AGENT_INIT_EVENT_TYPE}' entry at index ${index}.`,
+      );
+    }
+    const versionMatches = entry.machineVersion === expected.machineVersion;
+    if (
+      entry.machineId !== expected.machineId ||
+      (!versionMatches && !isSnapshotInitEntry(entry))
+    ) {
+      throw new AgentMachineVersionMismatchError(entry.id, entry.index, expected, {
+        machineId: entry.machineId,
+        machineVersion: entry.machineVersion,
+      });
+    }
+  }
+}
+
+/**
+ * The prefix `[0, upToIndex)` of a log, as a new log. `upToIndex` is exclusive
+ * and must leave the init entry in place, so the fork is still self-contained.
+ */
+export function forkEventLog(
+  entries: readonly AgentLogEntry[],
+  upToIndex: number,
+): AgentLogEntry[] {
+  if (!Number.isInteger(upToIndex) || upToIndex < 1 || upToIndex > entries.length) {
+    throw new AgentEventLogError(
+      `forkEventLog: upToIndex must be an integer in [1, ${entries.length}]; got ${String(upToIndex)}.`,
+    );
+  }
+  const forked = entries.slice(0, upToIndex);
+  if (!isInitEntry(forked[0]!)) {
+    throw new AgentEventLogError(
+      `forkEventLog: the forked prefix must start with the reserved '${AGENT_INIT_EVENT_TYPE}' entry.`,
+    );
+  }
+  return forked;
+}
+
+// --- Occurrence + usage ----------------------------------------------------
+
+const DONE_ACTOR_EVENT_TYPE = "xstate.done.actor";
+const ERROR_ACTOR_EVENT_TYPE = "xstate.error.actor";
+
+/** Normalizes a mixed `EventObject | AgentLogEntry` history into bare events. */
+function toEvents(history: readonly (EventObject | AgentLogEntry)[] | undefined): EventObject[] {
+  if (!history) {
+    return [];
+  }
+  return history.map((entry) => {
+    const candidate = entry as AgentLogEntry;
+    return candidate && typeof candidate === "object" && "event" in candidate && candidate.event
+      ? candidate.event
+      : (entry as EventObject);
+  });
+}
+
+/**
+ * The 1-based occurrence `n` for the NEXT call at invoke site `siteId`:
+ * `1 + completions`, where a completion is a journaled `xstate.done.actor` OR
+ * `xstate.error.actor` for that `actorId` (an error is a semantic completion).
+ * The one counting rule behind every `${siteId}#${n}` call key, so a live run
+ * and a replay derive the same `n` by construction.
+ */
+export function agentCallOccurrence(
+  history: readonly (EventObject | AgentLogEntry)[] | undefined,
+  siteId: string,
+): number {
+  let count = 0;
+  for (const event of toEvents(history)) {
+    if (
+      (event.type === DONE_ACTOR_EVENT_TYPE || event.type === ERROR_ACTOR_EVENT_TYPE) &&
+      (event as EventObject & { actorId?: unknown }).actorId === siteId
+    ) {
+      count++;
+    }
+  }
+  return count + 1;
+}
+
+/**
+ * Folds the reserved `@agent.usage` entries of a log into one cumulative usage
+ * total. The log is the source of truth, so the totals are a pure projection of
+ * it: replay a log, fold it, and you get the numbers the run reported with no
+ * host-side accumulator in between.
+ *
+ * Accepts entries or bare events. Token fields are partial sums: a field stays
+ * `undefined` until some entry reports it, and non-finite values are ignored.
+ */
+export function getUsageFromEvents(
+  entries: readonly (EventObject | AgentLogEntry)[],
+): AgentCallUsage {
+  const totals: AgentCallUsage = {};
+  for (const event of toEvents(entries)) {
+    if (event.type !== AGENT_USAGE_EVENT_TYPE) {
+      continue;
+    }
+    const usage = (event as { usage?: unknown }).usage;
+    if (!usage || typeof usage !== "object") {
+      continue;
+    }
+    for (const field of AGENT_USAGE_TOKEN_FIELDS) {
+      const value = (usage as Record<string, unknown>)[field];
+      if (typeof value === "number" && Number.isFinite(value)) {
+        totals[field] = (totals[field] ?? 0) + value;
+      }
+    }
+  }
+  return totals;
+}
+
+// --- Replay ----------------------------------------------------------------
+
+/**
+ * Rewrites a journaled `xstate.done.actor`/`xstate.error.actor` event's
+ * `sessionId` to the session the CURRENT fold minted for that `actorId`.
+ *
+ * Session ids are re-minted on every fold, and XState drops a completion event
+ * whose `sessionId` does not match the live child — silently, as a no-op
+ * transition. Rebinding is what makes a journaled completion replayable at all.
+ * `sessions` caches the mapping per fold, so a later event referring to the
+ * recorded session of an already-stopped child still resolves.
+ */
+export function rebindActorSession(
+  event: EventObject,
+  snapshot: AnyMachineSnapshot,
+  sessions: Map<string, string>,
+): EventObject {
+  const actorEvent = event as EventObject & { actorId?: unknown; sessionId?: unknown };
+  if (typeof actorEvent.actorId !== "string" || typeof actorEvent.sessionId !== "string") {
+    return event;
+  }
+
+  const key = `${actorEvent.actorId}\0${actorEvent.sessionId}`;
+  let sessionId = sessions.get(key);
+  if (!sessionId) {
+    const child = (snapshot.children as Record<string, { sessionId?: unknown }>)[
+      actorEvent.actorId
+    ];
+    if (typeof child?.sessionId !== "string") {
+      return event;
+    }
+    sessionId = child.sessionId;
+    sessions.set(key, sessionId);
+  }
+
+  return { ...event, sessionId } as EventObject;
+}
+
+/** Options for {@link replay}. */
+export interface ReplayOptions {
+  /** Explicit expected machine version; defaults to the machine's resolved version. */
+  machineVersion?: string;
+  /**
+   * `true` (default) checks the entries that carry a `verification.stateHash`;
+   * `'strict'` additionally requires every entry to carry one; `false` skips
+   * verification entirely.
+   */
+  verify?: boolean | "strict";
+}
+
+/** The result of a {@link replay}. */
+export interface ReplayResult<TMachine extends AnyStateMachine> {
+  /** The folded live snapshot (no actors started, no effects run). */
+  snapshot: SnapshotFrom<TMachine>;
+  /** Its persisted projection — what a host stores, and what hashes. */
+  persistedSnapshot: AgentPersistedSnapshot;
+}
+
+function verifyEntry(
+  entry: AgentLogEntry,
+  persisted: AgentPersistedSnapshot,
+  mode: ReplayOptions["verify"],
+): void {
+  if (mode === false) {
+    return;
+  }
+  if (!entry.verification) {
+    if (mode === "strict") {
+      throw new AgentReplayDivergenceError(entry.id, entry.index, "missing-verification");
+    }
+    return;
+  }
+  const actual = getSnapshotStateHash(persisted);
+  if (actual !== entry.verification.stateHash) {
+    throw new AgentReplayDivergenceError(
+      entry.id,
+      entry.index,
+      "state",
+      entry.verification.stateHash,
+      actual,
+    );
+  }
+}
+
+/**
+ * Folds a log through XState's pure `initialTransition`/`transition` WITHOUT
+ * executing anything: no actor is started, no action runs, no model is called.
+ * A journaled `xstate.done.actor` entry carries the completed actor's output
+ * inline, so the invoke it belongs to is never re-run. Crash recovery, fork
+ * resume, and time travel in one call.
+ *
+ * The first entry is the reserved {@link initEntry}: `input` folds from
+ * `initialTransition`, `snapshot` restores the persisted snapshot purely
+ * (`machine.restoreSnapshot`) and folds the rest of the log onto it.
+ */
+export function replay<TMachine extends AnyStateMachine>(
+  machine: TMachine,
+  entries: readonly AgentLogEntry[],
+  options: ReplayOptions = {},
+): ReplayResult<TMachine> {
+  const machineVersion = options.machineVersion ?? resolveMachineVersion(machine);
+  validateReplayEntries(entries, { machine, machineVersion });
+  if (entries.length === 0) {
+    throw new AgentEventLogError(
+      `Cannot replay an empty event log; it must start with a '${AGENT_INIT_EVENT_TYPE}' entry.`,
+    );
+  }
+  const initEvent = entries[0]!.event as AgentInitEvent;
+  let snapshot = (
+    initEvent.snapshot !== undefined
+      ? (
+          machine as unknown as {
+            restoreSnapshot(persisted: AgentPersistedSnapshot): AnyMachineSnapshot;
+          }
+        ).restoreSnapshot(initEvent.snapshot)
+      : initialTransition(machine, initEvent.input as never)[0]
+  ) as AnyMachineSnapshot;
+  let persisted = machine.getPersistedSnapshot(snapshot) as AgentPersistedSnapshot;
+  verifyEntry(entries[0]!, persisted, options.verify);
+
+  const sessions = new Map<string, string>();
+  for (let index = 1; index < entries.length; index++) {
+    const entry = entries[index]!;
+    const event = rebindActorSession(entry.event, snapshot, sessions);
+    [snapshot] = transition(machine, snapshot as never, event as never) as [
+      AnyMachineSnapshot,
+      unknown,
+    ];
+    persisted = machine.getPersistedSnapshot(snapshot) as AgentPersistedSnapshot;
+    verifyEntry(entry, persisted, options.verify);
+  }
+
+  return { snapshot: snapshot as SnapshotFrom<TMachine>, persistedSnapshot: persisted };
+}

--- a/src/event-log.ts
+++ b/src/event-log.ts
@@ -396,13 +396,19 @@ function canonicalizeForHash(
   if (value === null || typeof value !== "object") return value;
   if (value instanceof Date) return `[Date:${value.toISOString()}]`;
   if (value instanceof Error) {
-    return {
-      errorName: value.name,
-      message: value.message,
-      ...(value.cause !== undefined
-        ? { cause: canonicalizeForHash(value.cause, seen, "data") }
-        : {}),
-    };
+    if (seen.has(value)) return "[circular]";
+    seen.add(value);
+    try {
+      return {
+        errorName: value.name,
+        message: value.message,
+        ...(value.cause !== undefined
+          ? { cause: canonicalizeForHash(value.cause, seen, "data") }
+          : {}),
+      };
+    } finally {
+      seen.delete(value);
+    }
   }
   if (seen.has(value)) return "[circular]";
   seen.add(value);
@@ -443,6 +449,16 @@ function canonicalizeForHash(
   } finally {
     seen.delete(value);
   }
+}
+
+/**
+ * Key-sorted JSON for comparing two events by content: key insertion order
+ * does not count, so an entry read back from storage equals the one that was
+ * appended.
+ * @internal
+ */
+export function canonicalEventJson(event: unknown): string {
+  return stableJson(canonicalizeForHash(event, new Set(), "data"));
 }
 
 function stableJson(value: unknown): string {

--- a/src/event-log.ts
+++ b/src/event-log.ts
@@ -356,11 +356,39 @@ function normalizeEventErrors(
 // --- Hashing ---------------------------------------------------------------
 
 // Keys stripped from a persisted snapshot before hashing: they are re-minted on
-// every fold (actor session ids, the actor/timer id counters) and so differ
-// between two runs that are otherwise identical.
-const VOLATILE_SNAPSHOT_KEYS = new Set(["sessionId", "_nextTimerId", "_nextActorIds"]);
+// every fold (actor session identity, the actor/timer id counters) and so
+// differ between two runs that are otherwise identical.
+//
+// Stripping is POSITION-AWARE. A persisted snapshot nests application data
+// (`context`, `output`, `error`, event payloads) that may legitimately own a
+// key called `sessionId`; erasing it there would let a mutated snapshot verify
+// against an unchanged hash. So the walk tracks where it is in the persisted
+// shape and only strips at the structural positions XState itself writes:
+// the snapshot root, and each `children[*]` entry (whose `snapshot` is itself
+// a persisted snapshot).
+const SNAPSHOT_VOLATILE_KEYS = new Set(["sessionId", "_nextTimerId", "_nextActorIds"]);
+const CHILD_VOLATILE_KEYS = new Set(["sessionId"]);
 
-function canonicalizeForHash(value: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+/**
+ * Where the walk is inside a persisted snapshot: the snapshot object itself,
+ * its `children` record, one child entry, or plain application data (where no
+ * key is ever reserved).
+ */
+type HashPosition = "snapshot" | "children" | "child" | "data";
+
+// The position a value occupies, given its parent's position and its key.
+function positionOf(parent: HashPosition, key: string): HashPosition {
+  if (parent === "snapshot") return key === "children" ? "children" : "data";
+  if (parent === "children") return "child";
+  if (parent === "child") return key === "snapshot" ? "snapshot" : "data";
+  return "data";
+}
+
+function canonicalizeForHash(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+  position: HashPosition = "snapshot",
+): unknown {
   if (value === undefined) return "[undefined]";
   if (typeof value === "function") return "[function]";
   if (typeof value === "bigint") return `[bigint:${String(value)}]`;
@@ -371,38 +399,50 @@ function canonicalizeForHash(value: unknown, seen: WeakSet<object> = new WeakSet
     return {
       errorName: value.name,
       message: value.message,
-      ...(value.cause !== undefined ? { cause: canonicalizeForHash(value.cause, seen) } : {}),
+      ...(value.cause !== undefined
+        ? { cause: canonicalizeForHash(value.cause, seen, "data") }
+        : {}),
     };
-  }
-  if (value instanceof Set) {
-    return [...value]
-      .map((item) => canonicalizeForHash(item, seen))
-      .sort((a, b) => stableJson(a).localeCompare(stableJson(b)));
-  }
-  if (value instanceof Map) {
-    return [...value.entries()]
-      .map(([key, item]) => [canonicalizeForHash(key, seen), canonicalizeForHash(item, seen)])
-      .sort(([a], [b]) => stableJson(a).localeCompare(stableJson(b)));
   }
   if (seen.has(value)) return "[circular]";
   seen.add(value);
-  if (Array.isArray(value)) {
-    const result = value.map((item) => canonicalizeForHash(item, seen));
-    seen.delete(value);
+  try {
+    if (value instanceof Set) {
+      return [...value]
+        .map((item) => canonicalizeForHash(item, seen, "data"))
+        .sort((a, b) => stableJson(a).localeCompare(stableJson(b)));
+    }
+    if (value instanceof Map) {
+      return [...value.entries()]
+        .map(([key, item]) => [
+          canonicalizeForHash(key, seen, "data"),
+          canonicalizeForHash(item, seen, "data"),
+        ])
+        .sort(([a], [b]) => stableJson(a).localeCompare(stableJson(b)));
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => canonicalizeForHash(item, seen, "data"));
+    }
+    const volatileKeys =
+      position === "snapshot"
+        ? SNAPSHOT_VOLATILE_KEYS
+        : position === "child"
+          ? CHILD_VOLATILE_KEYS
+          : undefined;
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      if (volatileKeys?.has(key)) continue;
+      const child = (value as Record<string, unknown>)[key];
+      // Undefined values are dropped rather than encoded: a persisted snapshot
+      // carries `output`/`error` as explicit `undefined` before it is serialized,
+      // and a JSON round-trip drops them, so both forms must hash alike.
+      if (child === undefined) continue;
+      result[key] = canonicalizeForHash(child, seen, positionOf(position, key));
+    }
     return result;
+  } finally {
+    seen.delete(value);
   }
-  const result: Record<string, unknown> = {};
-  for (const key of Object.keys(value).sort()) {
-    if (VOLATILE_SNAPSHOT_KEYS.has(key)) continue;
-    const child = (value as Record<string, unknown>)[key];
-    // Undefined values are dropped rather than encoded: a persisted snapshot
-    // carries `output`/`error` as explicit `undefined` before it is serialized,
-    // and a JSON round-trip drops them, so both forms must hash alike.
-    if (child === undefined) continue;
-    result[key] = canonicalizeForHash(child, seen);
-  }
-  seen.delete(value);
-  return result;
 }
 
 function stableJson(value: unknown): string {
@@ -427,10 +467,14 @@ function sortJson(value: unknown): unknown {
  * `verification.stateHash`.
  *
  * Stripped before hashing, because they are re-minted on every fold and would
- * otherwise make two identical runs hash differently: any `sessionId` (child
- * actor session identity), `_nextTimerId` and `_nextActorIds` (id counters),
- * and `undefined`-valued properties (so a snapshot hashes the same before and
- * after a JSON round-trip). Object keys are sorted, so key order is irrelevant.
+ * otherwise make two identical runs hash differently: `sessionId`,
+ * `_nextTimerId` and `_nextActorIds` at the snapshot root, `sessionId` on each
+ * `children[*]` entry (recursively, through nested child snapshots), and
+ * `undefined`-valued properties (so a snapshot hashes the same before and
+ * after a JSON round-trip). Stripping is confined to those structural
+ * positions: a `sessionId` inside `context`, `output`, `error` or an event
+ * payload is application data and is hashed. Object keys are sorted, so key
+ * order is irrelevant.
  *
  * A change detector, not a cryptographic digest.
  */
@@ -571,7 +615,7 @@ export function initEntry(
 
 /** Whether `entry` is the reserved init entry. */
 function isInitEntry(entry: AgentLogEntry): boolean {
-  return entry.event.type === AGENT_INIT_EVENT_TYPE;
+  return (entry as Partial<AgentLogEntry>)?.event?.type === AGENT_INIT_EVENT_TYPE;
 }
 
 /** Whether `entry` is the version-bridging init-with-snapshot entry. */
@@ -615,14 +659,19 @@ export function validateReplayEntries(
   if (entries.length === 0) {
     return;
   }
+  // Without a machine to compare against, the log describes its own identity.
+  // An init-with-snapshot entry is the wrong reference: it carries the OLD
+  // version it bridges FROM, so deriving from it would reject every entry after
+  // it. Take the first entry that is not that bridge.
+  const reference = entries.find((entry) => !isSnapshotInitEntry(entry)) ?? entries[0]!;
   const expected = options.machine
     ? {
         machineId: machineIdOf(options.machine),
         machineVersion: options.machineVersion ?? resolveMachineVersion(options.machine),
       }
     : {
-        machineId: entries[0]!.machineId,
-        machineVersion: options.machineVersion ?? entries[0]!.machineVersion,
+        machineId: reference.machineId,
+        machineVersion: options.machineVersion ?? reference.machineVersion,
       };
   const ids = new Set<string>();
   for (let index = 0; index < entries.length; index++) {
@@ -694,11 +743,17 @@ function toEvents(history: readonly (EventObject | AgentLogEntry)[] | undefined)
   if (!history) {
     return [];
   }
-  return history.map((entry) => {
-    const candidate = entry as AgentLogEntry;
-    return candidate && typeof candidate === "object" && "event" in candidate && candidate.event
-      ? candidate.event
-      : (entry as EventObject);
+  return history.map((item) => {
+    // Discriminate on the durable envelope's own fields, not on the presence of
+    // an `event` key: a bare machine event may legitimately carry an `event`
+    // payload of its own, and unwrapping it would shift every occurrence count.
+    const candidate = item as Partial<AgentLogEntry> | null;
+    return candidate?.schemaVersion === AGENT_EVENT_SCHEMA_VERSION &&
+      typeof candidate.index === "number" &&
+      candidate.event !== null &&
+      typeof candidate.event === "object"
+      ? (candidate.event as EventObject)
+      : (item as EventObject);
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,9 +84,46 @@ export type { AgentRequest, AgentStepRequest } from "./steps.js";
 export { AGENT_USAGE_EVENT_TYPE } from "./usage.js";
 export type { AgentUsageEvent } from "./usage.js";
 export {
+  AGENT_EVENT_SCHEMA_VERSION,
+  AGENT_INIT_EVENT_TYPE,
+  AgentEventLogError,
+  AgentMachineVersionMismatchError,
+  AgentReplayDivergenceError,
+  NonSerializableAgentEventError,
+  agentCallOccurrence,
+  assertAgentLogEntry,
+  assertJsonSerializable,
+  createReplayEntry,
+  forkEventLog,
+  getLogExecutionId,
+  getSnapshotStateHash,
+  getUsageFromEvents,
+  initEntry,
+  rebindActorSession,
+  replay,
+  validateReplayEntries,
+} from "./event-log.js";
+export type {
+  AgentInitEvent,
+  AgentLogEntry,
+  AgentLogInit,
+  AgentLogVerification,
+  AgentPersistedSnapshot,
+  CreateReplayEntryOptions,
+  JsonValue,
+  ReplayOptions,
+  // Named return type of `replay`, so declaration emit can name it.
+  ReplayResult,
+} from "./event-log.js";
+export { AgentEventLogConflictError, createInMemoryEventLogStore } from "./event-log-store.js";
+export type { AgentEventLogStore } from "./event-log-store.js";
+export { assertEventLogStoreConformance } from "./event-log-store-conformance.js";
+export type { EventLogStoreConformanceHarness } from "./event-log-store-conformance.js";
+export {
   AGENT_TRACE_SCHEMA_VERSION,
   AgentIllegalResumeEventError,
   AgentMaxModelCallsExceededError,
+  AgentSnapshotDivergedError,
   inspectTransitions,
   isAgentIdle,
   runAgent,
@@ -99,6 +136,7 @@ export { runAgentLoop } from "./run-loop.js";
 export type { RunAgentLoopOptions } from "./run-loop.js";
 export type {
   AgentInputFrom,
+  AgentRunMeta,
   AgentTransitionHandler,
   AgentTraceEvent,
   AgentUserInputExecutor,

--- a/src/run-agent.test.ts
+++ b/src/run-agent.test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
-import { createActor, createAsyncLogic, setup, toPromise, type Snapshot } from "xstate";
+import {
+  createActor,
+  createAsyncLogic,
+  setup,
+  toPromise,
+  type AnyMachineSnapshot,
+  type Snapshot,
+} from "xstate";
 import { createDecisionLogic } from "./decision.js";
 import {
+  AGENT_INIT_EVENT_TYPE,
   AGENT_TRACE_SCHEMA_VERSION,
+  AGENT_USAGE_EVENT_TYPE,
   AgentError,
+  AgentMachineVersionMismatchError,
+  AgentSnapshotDivergedError,
+  getLogExecutionId,
+  getUsageFromEvents,
+  replay,
   createAgentSchemas,
   createTextLogic,
   AgentIllegalResumeEventError,
@@ -13,6 +27,7 @@ import {
   runAgent,
   setupAgent,
   type AgentDecisionRequest,
+  type AgentLogEntry,
   type AgentTextRequest,
   type AgentTools,
   type AgentTraceEvent,
@@ -3469,5 +3484,398 @@ describe("machine input validation", () => {
 
     if (result.status !== "done") throw new Error("expected done");
     expect(result.output).toEqual({ anything: 1 });
+  });
+});
+
+describe("runAgent event log", () => {
+  const answer = createTextLogic({ model: "test-model", prompt: () => "hello" });
+
+  /** asking --(model)--> waiting --APPROVE--> wrapping --(raised)--> done */
+  const makeLoggedMachine = (
+    overrides: { version?: string; migrate?: (snapshot: unknown) => unknown } = {},
+  ) =>
+    setup({ actors: { answer } }).createMachine({
+      id: "logged",
+      ...(overrides.version !== undefined ? { version: overrides.version } : {}),
+      ...(overrides.migrate ? { migrate: overrides.migrate } : {}),
+      context: () => ({ answer: null as string | null }),
+      initial: "asking",
+      states: {
+        asking: {
+          invoke: {
+            id: "ask",
+            src: "answer",
+            input: () => ({}),
+            onDone: ({ output }: { output: string }) => ({
+              target: "waiting",
+              context: { answer: output },
+            }),
+          } as never,
+        },
+        waiting: { on: { APPROVE: { target: "wrapping" } } },
+        wrapping: {
+          entry: (_args: never, enqueue: { raise: (event: { type: string }) => void }) =>
+            enqueue.raise({ type: "CONTINUE" }),
+          on: { CONTINUE: { target: "done" } },
+        },
+        done: { type: "final", output: () => ({ ok: true }) },
+      },
+    } as never);
+
+  const executors = () => ({
+    generateText: async () => ({ output: "42", usage: { totalTokens: 7 } }),
+  });
+
+  const types = (entries: readonly AgentLogEntry[]) => entries.map((entry) => entry.event.type);
+
+  test("a fresh run yields a self-contained log of external inputs only", async () => {
+    const machine = makeLoggedMachine();
+    const streamed: AgentLogEntry[] = [];
+
+    const first = await runAgent(machine, {
+      input: undefined,
+      executors: executors(),
+      onEvent: (entry) => streamed.push(entry),
+    });
+
+    expect(first.status).toBe("idle");
+    // The reserved init entry comes first and names the lineage.
+    expect(first.events[0]!.event.type).toBe(AGENT_INIT_EVENT_TYPE);
+    expect(typeof getLogExecutionId(first.events)).toBe("string");
+    // External inputs are journaled: the invoke's completion and the reserved
+    // usage record. Nothing else — no `@xstate.init`.
+    expect(types(first.events)).toEqual([
+      AGENT_INIT_EVENT_TYPE,
+      AGENT_USAGE_EVENT_TYPE,
+      "xstate.done.actor",
+    ]);
+    // `onEvent` streamed exactly the same entries, in order, init first.
+    expect(streamed).toEqual(first.events);
+    // Every entry carries a verification hash, and the whole log folds back to
+    // the state the run reached.
+    expect(first.events.every((entry) => typeof entry.verification?.stateHash === "string")).toBe(
+      true,
+    );
+    const folded = replay(machine, first.events);
+    expect((folded.snapshot as AnyMachineSnapshot).matches("waiting")).toBe(true);
+
+    // Resuming continues the SAME log: same lineage, contiguous indices.
+    const second = await runAgent(machine, {
+      events: first.events,
+      snapshot: first.persist(),
+      event: { type: "APPROVE" } as never,
+      executors: executors(),
+    });
+    expect(second.status).toBe("done");
+    expect(getLogExecutionId(second.events)).toBe(getLogExecutionId(first.events));
+    expect(second.events.map((entry) => entry.index)).toEqual(
+      second.events.map((_entry, index) => index),
+    );
+    // The host's APPROVE is journaled; the machine's own raised CONTINUE is not
+    // (replay re-derives it).
+    expect(types(second.events)).toContain("APPROVE");
+    expect(types(second.events)).not.toContain("CONTINUE");
+    expect(replay(machine, second.events).snapshot.status).toBe("done");
+  });
+
+  test("verification: false omits the recorded state hashes", async () => {
+    const machine = makeLoggedMachine();
+    const result = await runAgent(machine, {
+      input: undefined,
+      executors: executors(),
+      verification: false,
+    });
+    expect(result.events.length).toBeGreaterThan(1);
+    expect(result.events.every((entry) => entry.verification === undefined)).toBe(true);
+  });
+
+  test("events-only crash recovery: journaled calls are not re-run, and the in-flight call keeps its callKey", async () => {
+    const twoCallMachine = setup({ actors: { answer } }).createMachine({
+      id: "two-calls",
+      context: () => ({}),
+      initial: "a",
+      states: {
+        a: {
+          invoke: { id: "a", src: "answer", input: () => ({}), onDone: { target: "b" } } as never,
+        },
+        b: {
+          invoke: {
+            id: "b",
+            src: "answer",
+            input: () => ({}),
+            onDone: { target: "waiting" },
+          } as never,
+        },
+        waiting: { on: { GO: { target: "done" } } },
+        done: { type: "final" },
+      },
+    } as never);
+
+    const firstCalls: Array<{ requestId?: string; callKey?: string }> = [];
+    const crashed = await runAgent(twoCallMachine, {
+      input: undefined,
+      signal: AbortSignal.timeout(30),
+      executors: {
+        generateText: async (_request, info) => {
+          firstCalls.push({ requestId: info?.requestId, callKey: info?.callKey });
+          // The second call is the one that was still in flight at the crash.
+          return firstCalls.length === 1 ? { output: "one" } : await new Promise<never>(() => {});
+        },
+      },
+    });
+
+    expect(crashed.status).toBe("error");
+    expect(firstCalls.map((call) => call.requestId)).toEqual(["a", "b"]);
+    expect(types(crashed.events)).toContain("xstate.done.actor");
+
+    const secondCalls: Array<{ requestId?: string; callKey?: string }> = [];
+    const recovered = await runAgent(twoCallMachine, {
+      // Log only — no snapshot survived the crash.
+      events: crashed.events,
+      executors: {
+        generateText: async (_request, info) => {
+          secondCalls.push({ requestId: info?.requestId, callKey: info?.callKey });
+          return { output: "two" };
+        },
+      },
+    });
+
+    expect(recovered.status).toBe("idle");
+    // `a` completed before the crash and folds back in from the log.
+    expect(secondCalls.map((call) => call.requestId)).toEqual(["b"]);
+    // Identical key across the crash: an executor-level cache can dedupe it.
+    expect(secondCalls[0]!.callKey).toBe(firstCalls[1]!.callKey);
+    expect(secondCalls[0]!.callKey).toMatch(/^[0-9a-f-]+:b#1$/);
+  });
+
+  test("resume precedence: a tail-stamped snapshot is trusted, a stale one is not", async () => {
+    const machine = makeLoggedMachine();
+    const first = await runAgent(machine, {
+      input: undefined,
+      executors: executors(),
+    });
+    const cached = JSON.parse(JSON.stringify(first.persist())) as Snapshot<unknown>;
+
+    // Corrupt a MIDDLE entry's recorded hash: replaying this log throws, so a
+    // resume that succeeds proves the cached snapshot was trusted as-is.
+    const poisoned = (JSON.parse(JSON.stringify(first.events)) as AgentLogEntry[]).map((entry) =>
+      entry.index === 1 ? { ...entry, verification: { stateHash: "deadbeef" } } : entry,
+    );
+    expect(() => replay(machine, poisoned)).toThrow(/Replay diverged/);
+
+    const fastPath = await runAgent(machine, {
+      events: poisoned,
+      snapshot: cached,
+      event: { type: "APPROVE" } as never,
+      executors: executors(),
+    });
+    expect(fastPath.status).toBe("done");
+
+    // The same poisoned log with no cache to trust must replay — and throw.
+    await expect(
+      runAgent(machine, {
+        events: poisoned,
+        executors: executors(),
+      }),
+    ).rejects.toThrow(/Replay diverged/);
+  });
+
+  test("a stale snapshot loses to the log, and a divergent one throws", async () => {
+    const machine = makeLoggedMachine();
+    const first = await runAgent(machine, {
+      input: undefined,
+      executors: executors(),
+    });
+    const staleSnapshot = JSON.parse(JSON.stringify(first.persist())) as Snapshot<unknown>;
+    const second = await runAgent(machine, {
+      events: first.events,
+      snapshot: staleSnapshot,
+      event: { type: "APPROVE" } as never,
+      executors: executors(),
+    });
+    expect(second.status).toBe("done");
+
+    // `staleSnapshot` caches index 3 of a log that is now 5 entries long. It
+    // still agrees with the log at index 3, so the log simply wins.
+    expect(second.events.length).toBeGreaterThan(first.events.length);
+    const resumedFromStale = await runAgent(machine, {
+      events: second.events,
+      snapshot: staleSnapshot,
+      executors: executors(),
+    });
+    expect(resumedFromStale.status).toBe("done");
+
+    // A snapshot from another lineage that claims a position in THIS log is a
+    // host bug, not a resume.
+    const otherRun = await runAgent(machine, {
+      input: undefined,
+      executors: { generateText: async () => ({ output: "different" }) },
+    });
+    await expect(
+      runAgent(machine, {
+        events: first.events,
+        snapshot: JSON.parse(JSON.stringify(otherRun.persist())) as Snapshot<unknown>,
+        executors: executors(),
+      }),
+    ).rejects.toBeInstanceOf(AgentSnapshotDivergedError);
+  });
+
+  test("version bridge: a snapshot opens a new log segment, and its absence throws", async () => {
+    const v1 = makeLoggedMachine({ version: "1" });
+    const first = await runAgent(v1, {
+      input: undefined,
+      executors: executors(),
+    });
+    expect(first.status).toBe("idle");
+    const persisted = JSON.parse(JSON.stringify(first.persist())) as Snapshot<unknown>;
+
+    const v2 = makeLoggedMachine({
+      version: "2",
+      migrate: (snapshot) => ({ ...(snapshot as object), version: "2" }),
+    });
+
+    const bridged = await runAgent(v2, {
+      events: first.events,
+      snapshot: persisted,
+      event: { type: "APPROVE" } as never,
+      executors: executors(),
+    });
+    expect(bridged.status).toBe("done");
+    const init = bridged.events[0]!;
+    expect(init.event.type).toBe(AGENT_INIT_EVENT_TYPE);
+    expect((init.event as { snapshot?: unknown }).snapshot).toBeDefined();
+    expect(init.machineVersion).toBe("2");
+    expect(init.metadata?.executionId).toBe(getLogExecutionId(first.events));
+    expect(init.metadata?.migratedFrom).toEqual({
+      machineVersion: "1",
+      logIndex: first.events.length,
+    });
+
+    await expect(
+      runAgent(v2, {
+        events: first.events,
+        executors: executors(),
+      }),
+    ).rejects.toBeInstanceOf(AgentMachineVersionMismatchError);
+  });
+
+  test("snapshot-only resume starts a replayable log from that snapshot", async () => {
+    const machine = makeLoggedMachine();
+    const first = await runAgent(machine, {
+      input: undefined,
+      executors: executors(),
+    });
+    const second = await runAgent(machine, {
+      snapshot: JSON.parse(JSON.stringify(first.persist())) as Snapshot<unknown>,
+      event: { type: "APPROVE" } as never,
+      executors: executors(),
+    });
+    expect(second.status).toBe("done");
+    expect(second.events[0]!.event.type).toBe(AGENT_INIT_EVENT_TYPE);
+    expect((second.events[0]!.event as { snapshot?: unknown }).snapshot).toBeDefined();
+    // A NEW lineage: the snapshot carried no log with it.
+    expect(getLogExecutionId(second.events)).not.toBe(getLogExecutionId(first.events));
+    expect(replay(machine, second.events).snapshot.status).toBe("done");
+  });
+
+  test("usage is journaled even when the machine declares no transition for it, and result.usage folds the log", async () => {
+    const machine = makeLoggedMachine();
+    const result = await runAgent(machine, {
+      input: undefined,
+      executors: {
+        generateText: async () => ({ output: "42", usage: { totalTokens: 7, inputTokens: 3 } }),
+      },
+    });
+    const usageEntries = result.events.filter(
+      (entry) => entry.event.type === AGENT_USAGE_EVENT_TYPE,
+    );
+    expect(usageEntries).toHaveLength(1);
+    expect(result.usage).toEqual({ totalTokens: 7, inputTokens: 3, modelCalls: 1 });
+    expect(getUsageFromEvents(result.events)).toEqual({ totalTokens: 7, inputTokens: 3 });
+    // The machine never reacted to it, so the log still folds cleanly.
+    expect(replay(machine, result.events).snapshot.status).toBe("active");
+  });
+
+  test("a call that settles after the run is still appended to the log", async () => {
+    const machine = makeLoggedMachine();
+    const streamed: AgentLogEntry[] = [];
+    let release: (() => void) | undefined;
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const result = await runAgent(machine, {
+      input: undefined,
+      signal: AbortSignal.timeout(20),
+      onEvent: (entry) => streamed.push(entry),
+      executors: {
+        generateText: async () => {
+          await pending;
+          return { output: "late", usage: { totalTokens: 11 } };
+        },
+      },
+    });
+
+    expect(result.status).toBe("error");
+    const atSettle = streamed.length;
+    expect(result.events).toHaveLength(atSettle);
+    release!();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    // The tokens were spent, so the record is appended (and streamed) even
+    // though the run had already returned.
+    const straggler = streamed[streamed.length - 1]!;
+    expect(streamed.length).toBe(atSettle + 1);
+    expect(straggler.event.type).toBe(AGENT_USAGE_EVENT_TYPE);
+  });
+
+  test("timers are journaled and raised events are not; both round-trip through replay", async () => {
+    const timerMachine = setup({}).createMachine({
+      id: "timer-log",
+      context: () => ({}),
+      initial: "waiting",
+      states: {
+        waiting: { after: { 5: { target: "beeped" } } },
+        beeped: {
+          entry: (_args: never, enqueue: { raise: (event: { type: string }) => void }) =>
+            enqueue.raise({ type: "CONTINUE" }),
+          on: { CONTINUE: { target: "done" } },
+        },
+        done: { type: "final" },
+      },
+    } as never);
+
+    const result = await runAgent(timerMachine, { input: undefined, executors: {} });
+    expect(result.status).toBe("done");
+    expect(types(result.events)).toContain("xstate.timer");
+    expect(types(result.events)).not.toContain("CONTINUE");
+    expect(replay(timerMachine, result.events).snapshot.status).toBe("done");
+  });
+
+  test("a log whose last entry reached a final state settles immediately on resume", async () => {
+    const machine = makeLoggedMachine();
+    const first = await runAgent(machine, {
+      input: undefined,
+      executors: executors(),
+    });
+    const finished = await runAgent(machine, {
+      events: first.events,
+      snapshot: first.persist(),
+      event: { type: "APPROVE" } as never,
+      executors: executors(),
+    });
+    expect(finished.status).toBe("done");
+
+    let called = 0;
+    const replayed = await runAgent(machine, {
+      events: finished.events,
+      executors: {
+        generateText: async () => {
+          called++;
+          return { output: "should not happen" };
+        },
+      },
+    });
+    expect(replayed.status).toBe("done");
+    expect(called).toBe(0);
   });
 });

--- a/src/run-agent.test.ts
+++ b/src/run-agent.test.ts
@@ -4317,6 +4317,34 @@ describe("runAgent write-ahead store", () => {
     expect(resumed.status).toBe("done");
   });
 
+  test("`events` whose payload keys are merely reordered still match the thread", async () => {
+    const store = createInMemoryEventLogStore();
+    const first = await runAgent(makeMachine(), {
+      input: undefined,
+      store,
+      threadId: "main",
+      executors: executors(),
+    });
+
+    // Same content, different key insertion order: a host that rebuilt the
+    // entries from a database row must not be told its own log diverged.
+    const reordered = (JSON.parse(JSON.stringify(first.events)) as AgentLogEntry[]).map(
+      (entry) => ({
+        ...entry,
+        event: Object.fromEntries(Object.entries(entry.event).reverse()) as AgentLogEntry["event"],
+      }),
+    );
+    const resumed = await runAgent(makeMachine(), {
+      store,
+      threadId: "main",
+      events: reordered,
+      snapshot: first.persist(),
+      event: { type: "APPROVE" } as never,
+      executors: executors(),
+    });
+    expect(resumed.status).toBe("done");
+  });
+
   test("result.drain() waits for a straggler's write; the result itself does not", async () => {
     const inner = createInMemoryEventLogStore();
     const slowStore: AgentEventLogStore = {

--- a/src/run-agent.test.ts
+++ b/src/run-agent.test.ts
@@ -38,6 +38,18 @@ import {
 } from "./index.js";
 import { getMachineStructuralHash } from "./index.js";
 
+/**
+ * A promise plus its resolver. Tests drive a run's timing off these instead of
+ * wall-clock sleeps, so a slow machine cannot turn a race into a flake.
+ */
+function deferred<T = void>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 describe("runAgent", () => {
   test("done path: completes with typed output from a TextLogic invoke", async () => {
     const schemas = createAgentSchemas({
@@ -3495,10 +3507,10 @@ describe("runAgent event log", () => {
 
   /** asking --(model)--> waiting --APPROVE--> wrapping --(raised)--> done */
   const makeLoggedMachine = (
-    overrides: { version?: string; migrate?: (snapshot: unknown) => unknown } = {},
+    overrides: { id?: string; version?: string; migrate?: (snapshot: unknown) => unknown } = {},
   ) =>
     setup({ actors: { answer } }).createMachine({
-      id: "logged",
+      id: overrides.id ?? "logged",
       ...(overrides.version !== undefined ? { version: overrides.version } : {}),
       ...(overrides.migrate ? { migrate: overrides.migrate } : {}),
       context: () => ({ answer: null as string | null }),
@@ -3615,17 +3627,28 @@ describe("runAgent event log", () => {
     } as never);
 
     const firstCalls: Array<{ requestId?: string; callKey?: string }> = [];
-    const crashed = await runAgent(twoCallMachine, {
-      input: undefined,
-      signal: AbortSignal.timeout(30),
-      executors: {
-        generateText: async (_request, info) => {
-          firstCalls.push({ requestId: info?.requestId, callKey: info?.callKey });
-          // The second call is the one that was still in flight at the crash.
-          return firstCalls.length === 1 ? { output: "one" } : await new Promise<never>(() => {});
+    // The crash is driven by the run itself, not by the clock: abort only once
+    // the second call is actually in flight.
+    const controller = new AbortController();
+    const inFlight = deferred();
+    const crashed = await (async () => {
+      const running = runAgent(twoCallMachine, {
+        input: undefined,
+        signal: controller.signal,
+        executors: {
+          generateText: async (_request, info) => {
+            firstCalls.push({ requestId: info?.requestId, callKey: info?.callKey });
+            if (firstCalls.length === 1) return { output: "one" };
+            // The second call is the one still in flight at the crash.
+            inFlight.resolve();
+            return await new Promise<never>(() => {});
+          },
         },
-      },
-    });
+      });
+      await inFlight.promise;
+      controller.abort();
+      return running;
+    })();
 
     expect(crashed.status).toBe("error");
     expect(firstCalls.map((call) => call.requestId)).toEqual(["a", "b"]);
@@ -3649,6 +3672,64 @@ describe("runAgent event log", () => {
     // Identical key across the crash: an executor-level cache can dedupe it.
     expect(secondCalls[0]!.callKey).toBe(firstCalls[1]!.callKey);
     expect(secondCalls[0]!.callKey).toMatch(/^[0-9a-f-]+:b#1$/);
+  });
+
+  test("decision retries get distinct, replay-stable callKeys", async () => {
+    const schemas = createAgentSchemas({
+      context: z.object({}),
+      input: z.object({}),
+      events: { ATTACK: z.object({}) },
+    });
+    const chooseMove = createDecisionLogic({
+      model: "test-model",
+      prompt: "Choose a move.",
+      allowedEvents: ["ATTACK"] as const,
+    });
+    const agent = setupAgent({ schemas, actors: { chooseMove } });
+    const machine = agent.createMachine({
+      context: {},
+      initial: "choosing",
+      states: {
+        choosing: {
+          invoke: { id: "choosing", src: "chooseMove", input: {} },
+          on: { ATTACK: { target: "attacked" } },
+        },
+        attacked: { type: "final" },
+      },
+    });
+
+    const run = async () => {
+      const keys: Array<string | undefined> = [];
+      const result = await runAgent(machine, {
+        input: {},
+        executors: {
+          decide: async (request, info) => {
+            keys.push(info?.callKey);
+            // The first attempt picks an event that is not a candidate, so
+            // `resolveDecision` rejects it and retries with feedback.
+            return request.attempts.length === 0
+              ? { event: { type: "NOPE" } as never }
+              : { event: { type: "ATTACK" } as never };
+          },
+        },
+      });
+      return { keys, result };
+    };
+
+    const first = await run();
+    expect(first.result.status).toBe("done");
+    expect(first.keys).toHaveLength(2);
+    // Same invoke, same occurrence — but the attempt ordinal keeps a compliant
+    // cache from returning the rejected first attempt for the retry.
+    expect(first.keys[0]).toMatch(/^[0-9a-f-]+:choosing#\d+\.0$/);
+    expect(first.keys[1]).toBe(`${first.keys[0]!.slice(0, -2)}.1`);
+
+    // The ordinal comes from `request.attempts.length`, so re-executing an
+    // attempt derives the same key rather than a fresh one.
+    const second = await run();
+    expect(second.keys.map((key) => key?.split(":")[1])).toEqual(
+      first.keys.map((key) => key?.split(":")[1]),
+    );
   });
 
   test("resume precedence: a tail-stamped snapshot is trusted, a stale one is not", async () => {
@@ -3762,6 +3843,96 @@ describe("runAgent event log", () => {
     ).rejects.toBeInstanceOf(AgentMachineVersionMismatchError);
   });
 
+  test("version bridge: only the log's own tail snapshot is accepted", async () => {
+    const v1 = makeLoggedMachine({ version: "1" });
+    const first = await runAgent(v1, { input: undefined, executors: executors() });
+    const tailOfFirst = JSON.parse(JSON.stringify(first.persist())) as Snapshot<unknown>;
+
+    // The thread moves on, so `tailOfFirst` now caches an INTERIOR index.
+    const second = await runAgent(v1, {
+      events: first.events,
+      snapshot: tailOfFirst,
+      event: { type: "APPROVE" } as never,
+      executors: executors(),
+    });
+    expect(second.events.length).toBeGreaterThan(first.events.length);
+
+    const v2 = makeLoggedMachine({
+      version: "2",
+      migrate: (snapshot) => ({ ...(snapshot as object), version: "2" }),
+    });
+
+    // Bridging with it would roll the thread back past logged entries.
+    await expect(
+      runAgent(v2, {
+        events: second.events,
+        snapshot: tailOfFirst,
+        executors: executors(),
+      }),
+    ).rejects.toBeInstanceOf(AgentSnapshotDivergedError);
+
+    // Right index, wrong state: the tail entry's recorded hash catches it.
+    const tampered = JSON.parse(JSON.stringify(first.persist())) as Snapshot<unknown> & {
+      context: { answer: string };
+    };
+    tampered.context.answer = "tampered";
+    await expect(
+      runAgent(v2, { events: first.events, snapshot: tampered, executors: executors() }),
+    ).rejects.toBeInstanceOf(AgentSnapshotDivergedError);
+
+    // The genuine tail still bridges.
+    const bridged = await runAgent(v2, {
+      events: first.events,
+      snapshot: tailOfFirst,
+      event: { type: "APPROVE" } as never,
+      executors: executors(),
+    });
+    expect(bridged.status).toBe("done");
+  });
+
+  test("a log written by another machine is never a resume", async () => {
+    const machine = makeLoggedMachine({ version: "1" });
+    const other = makeLoggedMachine({ version: "1", id: "other-logged" });
+    const first = await runAgent(machine, { input: undefined, executors: executors() });
+
+    // Same version, different artifact: the entries fold against states this
+    // machine does not have.
+    await expect(
+      runAgent(other, {
+        events: first.events,
+        snapshot: JSON.parse(JSON.stringify(first.persist())) as Snapshot<unknown>,
+        event: { type: "APPROVE" } as never,
+        executors: executors(),
+      }),
+    ).rejects.toBeInstanceOf(AgentMachineVersionMismatchError);
+  });
+
+  test("an unverified log outranks a snapshot that merely claims to cache it", async () => {
+    const machine = makeLoggedMachine();
+    const first = await runAgent(machine, {
+      input: undefined,
+      executors: executors(),
+      verification: false,
+    });
+    expect(first.events.every((entry) => entry.verification === undefined)).toBe(true);
+
+    // Correct `agentMeta`, wrong state: with no recorded hash to check it
+    // against, the log is replayed rather than the snapshot trusted.
+    const tampered = JSON.parse(JSON.stringify(first.persist())) as Snapshot<unknown> & {
+      context: { answer: string };
+    };
+    tampered.context.answer = "tampered";
+    const resumed = await runAgent(machine, {
+      events: first.events,
+      snapshot: tampered,
+      event: { type: "APPROVE" } as never,
+      executors: executors(),
+      verification: false,
+    });
+    expect(resumed.status).toBe("done");
+    expect((resumed.snapshot as AnyMachineSnapshot).context).toEqual({ answer: "42" });
+  });
+
   test("snapshot-only resume starts a replayable log from that snapshot", async () => {
     const machine = makeLoggedMachine();
     const first = await runAgent(machine, {
@@ -3802,31 +3973,41 @@ describe("runAgent event log", () => {
   test("a call that settles after the run is still appended to the log", async () => {
     const machine = makeLoggedMachine();
     const streamed: AgentLogEntry[] = [];
-    let release: (() => void) | undefined;
-    const pending = new Promise<void>((resolve) => {
-      release = resolve;
-    });
+    const controller = new AbortController();
+    const inFlight = deferred();
+    const release = deferred();
+    const stragglerEntry = deferred<AgentLogEntry>();
+    let atSettle: number | undefined;
 
-    const result = await runAgent(machine, {
+    const running = runAgent(machine, {
       input: undefined,
-      signal: AbortSignal.timeout(20),
-      onEvent: (entry) => streamed.push(entry),
+      signal: controller.signal,
+      onEvent: (entry) => {
+        streamed.push(entry);
+        // Anything past the settle boundary is the straggler.
+        if (atSettle !== undefined && streamed.length > atSettle) {
+          stragglerEntry.resolve(entry);
+        }
+      },
       executors: {
         generateText: async () => {
-          await pending;
+          inFlight.resolve();
+          await release.promise;
           return { output: "late", usage: { totalTokens: 11 } };
         },
       },
     });
+    await inFlight.promise;
+    controller.abort();
+    const result = await running;
 
     expect(result.status).toBe("error");
-    const atSettle = streamed.length;
+    atSettle = streamed.length;
     expect(result.events).toHaveLength(atSettle);
-    release!();
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    release.resolve();
     // The tokens were spent, so the record is appended (and streamed) even
     // though the run had already returned.
-    const straggler = streamed[streamed.length - 1]!;
+    const straggler = await stragglerEntry.promise;
     expect(streamed.length).toBe(atSettle + 1);
     expect(straggler.event.type).toBe(AGENT_USAGE_EVENT_TYPE);
   });
@@ -4001,18 +4182,25 @@ describe("runAgent write-ahead store", () => {
 
     const store = createInMemoryEventLogStore();
     const firstCalls: Array<{ requestId?: string; callKey?: string }> = [];
-    const crashed = await runAgent(twoCallMachine, {
+    const controller = new AbortController();
+    const inFlight = deferred();
+    const running = runAgent(twoCallMachine, {
       input: undefined,
       store,
       threadId: "main",
-      signal: AbortSignal.timeout(30),
+      signal: controller.signal,
       executors: {
         generateText: async (_request, info) => {
           firstCalls.push({ requestId: info?.requestId, callKey: info?.callKey });
-          return firstCalls.length === 1 ? { output: "one" } : await new Promise<never>(() => {});
+          if (firstCalls.length === 1) return { output: "one" };
+          inFlight.resolve();
+          return await new Promise<never>(() => {});
         },
       },
     });
+    await inFlight.promise;
+    controller.abort();
+    const crashed = await running;
     expect(crashed.status).toBe("error");
 
     const secondCalls: Array<{ requestId?: string; callKey?: string }> = [];
@@ -4093,5 +4281,96 @@ describe("runAgent write-ahead store", () => {
         executors: executors(),
       }),
     ).rejects.toBeInstanceOf(AgentEventLogConflictError);
+  });
+
+  test("`events` of the right length but the wrong content are rejected", async () => {
+    const store = createInMemoryEventLogStore();
+    const first = await runAgent(makeMachine(), {
+      input: undefined,
+      store,
+      threadId: "main",
+      executors: executors(),
+    });
+
+    // Same length, one entry from somewhere else: appending onto this thread
+    // would splice two lineages together.
+    const altered = JSON.parse(JSON.stringify(first.events)) as AgentLogEntry[];
+    altered[1] = { ...altered[1]!, id: `${altered[1]!.id}_other` };
+    await expect(
+      runAgent(makeMachine(), {
+        store,
+        threadId: "main",
+        events: altered,
+        executors: executors(),
+      }),
+    ).rejects.toMatchObject({ code: "event-log-conflict" });
+
+    // The thread's own log still resumes.
+    const resumed = await runAgent(makeMachine(), {
+      store,
+      threadId: "main",
+      events: first.events,
+      snapshot: first.persist(),
+      event: { type: "APPROVE" } as never,
+      executors: executors(),
+    });
+    expect(resumed.status).toBe("done");
+  });
+
+  test("result.drain() waits for a straggler's write; the result itself does not", async () => {
+    const inner = createInMemoryEventLogStore();
+    const slowStore: AgentEventLogStore = {
+      ...inner,
+      append: async (input) => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        await inner.append(input);
+      },
+    };
+
+    const controller = new AbortController();
+    const inFlight = deferred();
+    const release = deferred();
+    const stragglerAppended = deferred();
+    let atSettle: number | undefined;
+    let streamed = 0;
+
+    const running = runAgent(makeMachine(), {
+      input: undefined,
+      store: slowStore,
+      threadId: "main",
+      signal: controller.signal,
+      onEvent: () => {
+        streamed++;
+        if (atSettle !== undefined && streamed > atSettle) {
+          stragglerAppended.resolve();
+        }
+      },
+      executors: {
+        generateText: async () => {
+          inFlight.resolve();
+          await release.promise;
+          return { output: "42", usage: { totalTokens: 5 } };
+        },
+      },
+    });
+    await inFlight.promise;
+    controller.abort();
+    const result = await running;
+    expect(result.status).toBe("error");
+
+    atSettle = streamed;
+    expect(await inner.read("main")).toHaveLength(atSettle);
+
+    // The straggler's usage entry is appended after the run returned, so its
+    // write is outside the result's own barrier...
+    release.resolve();
+    await stragglerAppended.promise;
+    expect(await inner.read("main")).toHaveLength(atSettle);
+
+    // ...and `drain()` is what waits for it.
+    await result.drain();
+    const stored = await inner.read("main");
+    expect(stored).toHaveLength(atSettle + 1);
+    expect(stored[stored.length - 1]!.event.type).toBe(AGENT_USAGE_EVENT_TYPE);
   });
 });

--- a/src/run-agent.test.ts
+++ b/src/run-agent.test.ts
@@ -14,12 +14,14 @@ import {
   AGENT_TRACE_SCHEMA_VERSION,
   AGENT_USAGE_EVENT_TYPE,
   AgentError,
+  AgentEventLogConflictError,
   AgentMachineVersionMismatchError,
   AgentSnapshotDivergedError,
   getLogExecutionId,
   getUsageFromEvents,
   replay,
   createAgentSchemas,
+  createInMemoryEventLogStore,
   createTextLogic,
   AgentIllegalResumeEventError,
   inspectTransitions,
@@ -27,6 +29,7 @@ import {
   runAgent,
   setupAgent,
   type AgentDecisionRequest,
+  type AgentEventLogStore,
   type AgentLogEntry,
   type AgentTextRequest,
   type AgentTools,
@@ -3877,5 +3880,218 @@ describe("runAgent event log", () => {
     });
     expect(replayed.status).toBe("done");
     expect(called).toBe(0);
+  });
+});
+
+describe("runAgent write-ahead store", () => {
+  const answer = createTextLogic({ model: "test-model", prompt: () => "hello" });
+
+  /** asking --(model)--> waiting --APPROVE--> done */
+  const makeMachine = () =>
+    setup({ actors: { answer } }).createMachine({
+      id: "stored",
+      context: () => ({}),
+      initial: "asking",
+      states: {
+        asking: {
+          invoke: { id: "ask", src: "answer", input: () => ({}), onDone: { target: "waiting" } },
+        },
+        waiting: { on: { APPROVE: { target: "done" } } },
+        done: { type: "final" },
+      },
+    } as never);
+
+  const executors = () => ({ generateText: async () => ({ output: "42" }) });
+
+  test("a fresh run writes every entry to the store, in index order", async () => {
+    const store = createInMemoryEventLogStore();
+    const result = await runAgent(makeMachine(), {
+      input: undefined,
+      store,
+      threadId: "main",
+      executors: executors(),
+    });
+
+    expect(result.status).toBe("idle");
+    const stored = await store.read("main");
+    expect(stored).toEqual(result.events);
+    expect(stored.map((entry) => entry.index)).toEqual(stored.map((_entry, index) => index));
+    expect(stored[0]!.event.type).toBe(AGENT_INIT_EVENT_TYPE);
+  });
+
+  test("the result resolves only after the last write lands", async () => {
+    const inner = createInMemoryEventLogStore();
+    let inFlight = 0;
+    const store: AgentEventLogStore = {
+      ...inner,
+      append: async (input) => {
+        inFlight++;
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        await inner.append(input);
+        inFlight--;
+      },
+    };
+
+    const result = await runAgent(makeMachine(), {
+      input: undefined,
+      store,
+      threadId: "main",
+      executors: executors(),
+    });
+
+    expect(inFlight).toBe(0);
+    expect(await store.read("main")).toEqual(result.events);
+  });
+
+  test("no model call is made until the preceding entry is durable", async () => {
+    const inner = createInMemoryEventLogStore();
+    const gates: Array<() => void> = [];
+    let holding = true;
+    const store: AgentEventLogStore = {
+      ...inner,
+      append: async (input) => {
+        if (holding) {
+          await new Promise<void>((resolve) => gates.push(resolve));
+        }
+        await inner.append(input);
+      },
+    };
+
+    let calls = 0;
+    const settled = runAgent(makeMachine(), {
+      input: undefined,
+      store,
+      threadId: "main",
+      executors: {
+        generateText: async () => {
+          calls++;
+          return { output: "42" };
+        },
+      },
+    });
+
+    // Several turns of the loop: the run is blocked on the init entry's write.
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(calls).toBe(0);
+
+    holding = false;
+    for (const release of gates.splice(0)) {
+      release();
+    }
+    const result = await settled;
+    expect(calls).toBe(1);
+    expect(result.status).toBe("idle");
+  });
+
+  test("resuming from the store alone continues the log without re-executing", async () => {
+    const twoCallMachine = setup({ actors: { answer } }).createMachine({
+      id: "two-calls",
+      context: () => ({}),
+      initial: "a",
+      states: {
+        a: { invoke: { id: "a", src: "answer", input: () => ({}), onDone: { target: "b" } } },
+        b: { invoke: { id: "b", src: "answer", input: () => ({}), onDone: { target: "waiting" } } },
+        waiting: { on: { GO: { target: "done" } } },
+        done: { type: "final" },
+      },
+    } as never);
+
+    const store = createInMemoryEventLogStore();
+    const firstCalls: Array<{ requestId?: string; callKey?: string }> = [];
+    const crashed = await runAgent(twoCallMachine, {
+      input: undefined,
+      store,
+      threadId: "main",
+      signal: AbortSignal.timeout(30),
+      executors: {
+        generateText: async (_request, info) => {
+          firstCalls.push({ requestId: info?.requestId, callKey: info?.callKey });
+          return firstCalls.length === 1 ? { output: "one" } : await new Promise<never>(() => {});
+        },
+      },
+    });
+    expect(crashed.status).toBe("error");
+
+    const secondCalls: Array<{ requestId?: string; callKey?: string }> = [];
+    // No `events`, no snapshot: the thread's log in the store IS the resume.
+    const recovered = await runAgent(twoCallMachine, {
+      store,
+      threadId: "main",
+      executors: {
+        generateText: async (_request, info) => {
+          secondCalls.push({ requestId: info?.requestId, callKey: info?.callKey });
+          return { output: "two" };
+        },
+      },
+    });
+
+    expect(recovered.status).toBe("idle");
+    expect(secondCalls.map((call) => call.requestId)).toEqual(["b"]);
+    expect(secondCalls[0]!.callKey).toBe(firstCalls[1]!.callKey);
+    expect(recovered.events.slice(0, crashed.events.length)).toEqual(crashed.events);
+    expect(await store.read("main")).toEqual(recovered.events);
+  });
+
+  test("a conflicting writer stops the run with cause 'journal'", async () => {
+    const inner = createInMemoryEventLogStore();
+    let stolen = false;
+    const store: AgentEventLogStore = {
+      ...inner,
+      append: async (input) => {
+        if (!stolen) {
+          // A concurrent writer takes this index first.
+          stolen = true;
+          await inner.append({
+            ...input,
+            entries: input.entries.map((entry) => ({ ...entry, id: `${entry.id}_other` })),
+          });
+        }
+        await inner.append(input);
+      },
+    };
+
+    let calls = 0;
+    const result = await runAgent(makeMachine(), {
+      input: undefined,
+      store,
+      threadId: "main",
+      executors: {
+        generateText: async () => {
+          calls++;
+          return { output: "42" };
+        },
+      },
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.status === "error" && result.cause).toBe("journal");
+    expect(result.status === "error" && result.error).toBeInstanceOf(AgentEventLogConflictError);
+    // The barrier held the model call back until the write failed.
+    expect(calls).toBe(0);
+  });
+
+  test("`store` without `threadId` throws, and `events` must match the thread's length", async () => {
+    const store = createInMemoryEventLogStore();
+    await expect(
+      runAgent(makeMachine(), { input: undefined, store, executors: executors() }),
+    ).rejects.toMatchObject({ code: "missing-thread-id" });
+
+    const first = await runAgent(makeMachine(), {
+      input: undefined,
+      store,
+      threadId: "main",
+      executors: executors(),
+    });
+    await expect(
+      runAgent(makeMachine(), {
+        store,
+        threadId: "main",
+        events: first.events.slice(0, 1),
+        executors: executors(),
+      }),
+    ).rejects.toBeInstanceOf(AgentEventLogConflictError);
   });
 });

--- a/src/run-agent.ts
+++ b/src/run-agent.ts
@@ -9,6 +9,7 @@ import {
   type AnyStateMachine,
   type EmittedFrom,
   type EventFromLogic,
+  type EventObject,
   type InputFrom,
   type InspectionEvent,
   type OutputFrom,
@@ -31,7 +32,6 @@ import {
 } from "./utils.js";
 import { getAcceptedEvents, type AgentSchemas } from "./events.js";
 import {
-  AGENT_USAGE_TOKEN_FIELDS,
   GENERATE_TEXT_ACTOR,
   getCallUsage,
   isTextLogic,
@@ -66,6 +66,21 @@ import {
 } from "./internal/registry.js";
 import { AGENT_USAGE_EVENT_TYPE, type AgentUsageEvent } from "./usage.js";
 import { AGENT_MESSAGES_EVENT_TYPE } from "./messages.js";
+import {
+  AgentMachineVersionMismatchError,
+  agentCallOccurrence,
+  createReplayEntry,
+  getLogExecutionId,
+  getSnapshotStateHash,
+  getUsageFromEvents,
+  initEntry,
+  replay,
+  validateReplayEntries,
+  type AgentLogEntry,
+  type AgentLogInit,
+  type AgentPersistedSnapshot,
+  type JsonValue as AgentLogJsonValue,
+} from "./event-log.js";
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 
@@ -99,6 +114,66 @@ export class AgentIllegalResumeEventError extends AgentError {
     this.eventType = eventType;
     this.acceptedTypes = acceptedTypes;
   }
+}
+
+/**
+ * Thrown by {@link runAgent} when a resume is given BOTH an `events` log and a
+ * `snapshot` that claims a position in that log (`agentMeta.logIndex`), and the
+ * two disagree about the state at that position. The log is the source of
+ * truth, so this is a host bug (a snapshot cached from a different lineage, or
+ * a snapshot mutated out of band), not a recoverable resume: pass the log
+ * alone, or the matching snapshot.
+ */
+export class AgentSnapshotDivergedError extends AgentError {
+  constructor(
+    readonly expected: string,
+    readonly actual: string,
+    readonly logIndex: number,
+  ) {
+    super(
+      "snapshot-diverged",
+      `runAgent: the resume snapshot disagrees with the event log at index ${logIndex}: ` +
+        `the log replays to state hash '${expected}', the snapshot hashes '${actual}'.`,
+    );
+    this.name = "AgentSnapshotDivergedError";
+  }
+}
+
+/**
+ * The stamp {@link RunAgentResult.persist} writes onto the persisted snapshot:
+ * the machine identity that produced it plus the position in the event log it
+ * caches. Read back by the next resume to decide whether the snapshot can be
+ * trusted without replaying the log (see {@link RunAgentOptions.events}).
+ */
+export interface AgentRunMeta {
+  machineId: string;
+  version: string;
+  /** The log's `executionId` lineage, when the log carries one. */
+  logId?: string;
+  /** The log's length at the moment this snapshot was taken. */
+  logIndex: number;
+}
+
+// The recorded `verification.stateHash` of a log entry is taken from a
+// persisted snapshot BEFORE `persist()` stamps `agentMeta` onto it, so the
+// stamp must come back off before a cached snapshot is compared against the
+// log.
+function hashResumeSnapshot(snapshot: unknown): string {
+  if (snapshot !== null && typeof snapshot === "object" && "agentMeta" in snapshot) {
+    const rest: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(snapshot as Record<string, unknown>)) {
+      if (key !== "agentMeta") {
+        rest[key] = value;
+      }
+    }
+    return getSnapshotStateHash(rest);
+  }
+  return getSnapshotStateHash(snapshot);
+}
+
+function readAgentMeta(snapshot: unknown): Partial<AgentRunMeta> | undefined {
+  const meta = (snapshot as { agentMeta?: unknown } | undefined)?.agentMeta;
+  return meta !== null && typeof meta === "object" ? (meta as Partial<AgentRunMeta>) : undefined;
 }
 
 /** Handler for `agent.userInput` invokes passed as {@link RunAgentOptions.userInput}. Resolves to what the human typed. */
@@ -404,6 +479,37 @@ export interface RunAgentOptions<TMachine extends AnyStateMachine> {
   snapshot?: Snapshot<unknown>;
   /** An event to send immediately after starting/resuming the actor (e.g. the human's answer to an idle-state prompt). */
   event?: EventFromLogic<TMachine>;
+  /**
+   * A prior run's `result.events` — the replayable log to resume from and keep
+   * appending to. THE LOG IS THE SOURCE OF TRUTH: journaled model/tool results
+   * are folded back in rather than re-executed, so a crashed run resumes from
+   * its log alone.
+   *
+   * A `snapshot` passed alongside is a CACHE of that log: it is trusted only
+   * when it is stamped (see {@link AgentRunMeta}) at the log's current tail and
+   * hashes to what the tail entry recorded; otherwise the log is replayed and
+   * the cache is verified against the position it claims (a genuine
+   * disagreement throws {@link AgentSnapshotDivergedError}).
+   *
+   * When the log was written by a DIFFERENT machine version, a `snapshot` is
+   * required (XState's own `migrate` applies on restore) and the run starts a
+   * NEW log segment whose init entry records where it bridged from; without one
+   * it throws `AgentMachineVersionMismatchError`.
+   */
+  events?: readonly AgentLogEntry[];
+  /**
+   * Called synchronously as each log entry is appended, init entry first. The
+   * host persistence seam: append the entry to durable storage here and a crash
+   * mid-run loses nothing but the in-flight call.
+   */
+  onEvent?: (entry: AgentLogEntry) => void;
+  /**
+   * Record a `verification.stateHash` on every appended entry (default `true`).
+   * The hash is taken O(1) from the live actor's persisted snapshot right after
+   * that entry's transition, so `replay(machine, events)` can prove it lands on
+   * the same state. Set `false` for a smaller, unverifiable log.
+   */
+  verification?: boolean;
   // actor sources — sugar for machine.provide({ actors }) before the run
   /** Actor source implementations, merged onto the machine before binding — sugar for `machine.provide({ actors })` ahead of the run. */
   actors?: Record<string, AnyActorLogic>;
@@ -526,10 +632,24 @@ type RunAgentOutcome<TMachine extends AnyStateMachine> =
 
 export type RunAgentResult<TMachine extends AnyStateMachine> = RunAgentOutcome<TMachine> & {
   /**
+   * The complete, self-contained replayable log for this run — the resumed
+   * prefix (if any) plus every entry this run appended, starting with the
+   * reserved `@agent.init` entry. Pass it back as
+   * {@link RunAgentOptions.events} to resume; fold it with
+   * `getUsageFromEvents` for cumulative spend; hand it to `replay` for
+   * crash recovery or time travel.
+   */
+  events: AgentLogEntry[];
+  /**
    * Returns XState's persisted snapshot while the run-owned actor is still
    * available, including active child state. Store this value and pass it back
    * as `snapshot` to resume. Persistence, migration, and retries remain XState
    * and host responsibilities.
+   *
+   * The returned object carries an {@link AgentRunMeta} stamp under
+   * `agentMeta`, naming the log position it caches — that is what lets a resume
+   * skip replaying the log. Only the persisted object is stamped; the live
+   * `snapshot` on the result is untouched.
    */
   persist(): Snapshot<unknown>;
   /**
@@ -924,6 +1044,13 @@ interface RunAgentBindContext {
   ) => void;
   /** The owning run's id (`run_<n>`), threaded to executors as `info.runId`. Unset off the runAgent path. */
   runId?: string;
+  /**
+   * Mints the per-call idempotency key threaded to executors as
+   * `info.callKey` (`${executionId}:${siteId}#${n}`). Memoized per invoked
+   * leaf actor (`self`), so a decision's retries within one invoke share one
+   * key. Unset off the runAgent path, and when the log has no `executionId`.
+   */
+  callKey?: (siteId: string, self?: object) => string | undefined;
   /** Assigned right after createActor (§2.6); read lazily by decision wraps. */
   actorHolder: { actorRef: AnyActorRef | undefined };
   /** Registered `setupAgent` schemas (for event `inputSchema`s), if any. */
@@ -1073,6 +1200,7 @@ function bindTextLogic(logic: TextLogic, runCtx: RunAgentBindContext): TextLogic
     runCtx.consumeModelCall();
     runCtx.emitTrace?.({ type: "request.start", request: agentRequest }, self);
     try {
+      const callKey = id !== "" ? runCtx.callKey?.(id, self) : undefined;
       const raw = await executor(requestWithTools as AgentExecutorTextRequest, {
         onChunk: (chunk: string) => {
           runCtx.emitTrace?.({ type: "stream.chunk", request: agentRequest, chunk }, self);
@@ -1080,6 +1208,7 @@ function bindTextLogic(logic: TextLogic, runCtx: RunAgentBindContext): TextLogic
         signal,
         ...(runCtx.runId !== undefined ? { runId: runCtx.runId } : {}),
         ...(id !== "" ? { requestId: id } : {}),
+        ...(callKey !== undefined ? { callKey } : {}),
       });
       const output = await normalizeGeneratorResult(raw, id, {
         request,
@@ -1159,6 +1288,9 @@ function createCountingDecide(
     runCtx.emitTrace?.({ type: "request.start", request: attemptRequest }, self);
     try {
       const { id } = selfIdAndSrc(self);
+      // One key per invoke, not per decision attempt: `callKey` is memoized on
+      // `self`, so a retried decision keeps the key its first attempt used.
+      const callKey = id !== "" ? runCtx.callKey?.(id, self) : undefined;
       // `runId` rides on the request like `signal` does: host-injected
       // correlation, never serialized into machine state. It also rides on the
       // `info` second argument, where generateText/streamText carry it.
@@ -1168,6 +1300,7 @@ function createCountingDecide(
           ...info,
           ...(runCtx.runId !== undefined ? { runId: runCtx.runId } : {}),
           ...(info?.requestId === undefined && id !== "" ? { requestId: id } : {}),
+          ...(info?.callKey === undefined && callKey !== undefined ? { callKey } : {}),
         },
       );
       const usage = getCallUsage(result);
@@ -1427,7 +1560,7 @@ function provideBindContext(
         : undefined,
     consumeModelCall: () => {},
     recordUsage: (usage, source, self) => {
-      deliverUsageEvent(usage, source ?? {}, () => self?._parent);
+      deliverUsageEvent({ type: AGENT_USAGE_EVENT_TYPE, ...source, usage }, () => self?._parent);
     },
     actorHolder: { actorRef: undefined },
     schemas: getRegisteredAgentExecutionOptions(machine).schemas,
@@ -1435,11 +1568,14 @@ function provideBindContext(
 }
 
 /**
- * The single reserved-`@agent.usage` delivery seam, shared by both bind paths:
- * after a bound call settles with reported usage, send the event to the machine
- * actor `resolveActorRef` names — the run's root actor on the `runAgent` path,
+ * The single reserved-`@agent.usage` DELIVERY seam, shared by both bind paths:
+ * after a bound call settles with reported usage, send the prebuilt `event` to
+ * the machine actor `resolveActorRef` names — the run's root actor on the `runAgent` path,
  * the settling request actor's `self._parent` (always the invoking machine
  * under a live `createActor` tree) on the `provideExecutors` path.
+ *
+ * Journaling is separate and unconditional (see `recordUsage`): a call's tokens
+ * are recorded in the event log whether or not the machine reacts to them.
  *
  * Gating is identical on both: the target snapshot must be active, must declare
  * an `'@agent.usage'` transition — explicitly, or through a catch-all
@@ -1454,8 +1590,7 @@ function provideBindContext(
  * `provideExecutors` reports nothing. @internal
  */
 function deliverUsageEvent(
-  usage: AgentCallUsage,
-  source: AgentUsageEventSource,
+  event: AgentUsageEvent,
   resolveActorRef: () => AnyActorRef | undefined,
   onDropped?: (event: AgentUsageEvent) => boolean,
 ): void {
@@ -1467,7 +1602,6 @@ function deliverUsageEvent(
   if (snapshot?.status !== "active" || !declaresUsageTransition(snapshot)) {
     return;
   }
-  const event: AgentUsageEvent = { type: AGENT_USAGE_EVENT_TYPE, ...source, usage };
   if (onDropped?.(event)) {
     return;
   }
@@ -1749,12 +1883,75 @@ function createAgentSession<TMachine extends AnyStateMachine>(
     modelCallCount += 1;
   };
 
-  const tokenTotals: Partial<Record<keyof AgentCallUsage, number>> = {};
-
   // Bridges the session closure's `settled` flag (declared further down, once
   // the actor exists) to the usage delivery below, which is defined before it.
   // Nothing has resolved before the run starts.
   const cycleGate = { isResolved: () => false };
+
+  // ─── The replayable event log ───
+  //
+  // `logEntries` is this run's complete log segment: the resumed prefix (if
+  // any) plus every external input the root actor consumed, appended in order
+  // by the inspect handler below. It is the value returned as `result.events`,
+  // and the value `options.onEvent` streams entry by entry.
+  const logEntries: AgentLogEntry[] = [];
+  // Where THIS run's own entries begin — the fold boundary for `runUsage`.
+  let resumedLogLength = 0;
+  // The lineage id pinned in the log's init entry metadata; also the prefix of
+  // every `callKey`.
+  let logExecutionId: string | undefined;
+  const verificationEnabled = options.verification !== false;
+  // The most recent ROOT snapshot this run observed, used to stamp an entry's
+  // verification hash in O(1) instead of re-folding the whole prefix.
+  let lastRootSnapshot: AnyMachineSnapshot | undefined;
+  // The machine the log is folded against: the authored machine with
+  // `options.actors` merged in, so every invoke src resolves. Assigned once
+  // `provided` exists, below; nothing folds before then. NOT the
+  // executor-bound machine — the log must fold the same way for a caller who
+  // calls `replay(machine, events)` with no host executors at all.
+  let logMachine: AnyStateMachine = machine;
+
+  // Cleared when this run cannot produce a self-contained log at all — a
+  // snapshot that is not JSON-safe, or a machine whose init entry cannot be
+  // built (see `appendInitEntry`). Journaling a suffix with no `@agent.init`
+  // entry would produce a log `replay` rejects, so nothing is journaled.
+  let loggingEnabled = true;
+
+  const appendLogEntry = (
+    event: EventObject,
+    snapshot?: AnyMachineSnapshot | AgentPersistedSnapshot,
+  ): AgentLogEntry | undefined => {
+    if (!loggingEnabled) {
+      return undefined;
+    }
+    const entry = createReplayEntry(logMachine, logEntries, event, {
+      machineVersion,
+      verification: verificationEnabled,
+      // With no snapshot, `createReplayEntry` re-folds the whole prefix to get
+      // the hash. Every journaled transition has one to hand, so that fallback
+      // is reserved for the rare out-of-band append (see `usageEntrySnapshot`).
+      ...(verificationEnabled && snapshot !== undefined ? { snapshot } : {}),
+    });
+    logEntries.push(entry);
+    options.onEvent?.(entry);
+    return entry;
+  };
+
+  // The snapshot an `@agent.usage` entry that was NOT delivered folds to.
+  // Replay feeds every journaled entry through `transition`, so the recorded
+  // hash must be the POST-transition state. When the live configuration
+  // declares no `@agent.usage` transition (the common case) that transition is
+  // a no-op and the current snapshot is exactly right. Otherwise the event was
+  // withheld from a machine that would have reacted (a guard, or a straggler
+  // after settle), so the live snapshot is NOT what replay produces — fall back
+  // to `createReplayEntry`'s own fold, which is correct by construction.
+  const usageEntrySnapshot = (): AnyMachineSnapshot | undefined => {
+    const current = lastRootSnapshot;
+    if (current && (current.status !== "active" || !declaresUsageTransition(current))) {
+      return current;
+    }
+    return undefined;
+  };
 
   // Reserved `@agent.usage` delivery — the seam that puts a settled call's
   // tokens in reach of the machine's own context and guards (see
@@ -1782,26 +1979,41 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   // in here (see AgentUsage). Token fields are partial sums — a field stays
   // undefined until some call reports it. Scoped to THIS run only.
   const recordUsage = (usage: AgentCallUsage, source: AgentUsageEventSource = {}) => {
-    for (const field of AGENT_USAGE_TOKEN_FIELDS) {
-      const value = usage[field];
-      if (typeof value === "number" && Number.isFinite(value)) {
-        tokenTotals[field] = (tokenTotals[field] ?? 0) + value;
-      }
+    const event: AgentUsageEvent = { type: AGENT_USAGE_EVENT_TYPE, ...source, usage };
+    // Set for the duration of the delivery attempt below: if the machine takes
+    // the event, the inspect handler journals it (with the post-transition
+    // snapshot) and records the entry here, so this function does not append a
+    // second one.
+    const journal: { event: AgentUsageEvent; entry?: AgentLogEntry } = { event };
+    pendingUsageJournal = journal;
+    try {
+      deliverUsageEvent(
+        event,
+        () => actorHolder.actorRef,
+        (dropped) => {
+          if (!cycleGate.isResolved()) {
+            return false;
+          }
+          onTrace({ type: "usage.dropped", event: dropped, reason: "settled" });
+          return true;
+        },
+      );
+    } finally {
+      pendingUsageJournal = undefined;
     }
-    deliverUsageEvent(
-      usage,
-      source,
-      () => actorHolder.actorRef,
-      (event) => {
-        if (!cycleGate.isResolved()) {
-          return false;
-        }
-        onTrace({ type: "usage.dropped", event, reason: "settled" });
-        return true;
-      },
-    );
+    if (journal.entry === undefined) {
+      appendLogEntry(event, usageEntrySnapshot());
+    }
   };
-  const runUsage = (): AgentUsage => ({ ...tokenTotals, modelCalls: modelCallCount });
+  let pendingUsageJournal: { event: AgentUsageEvent; entry?: AgentLogEntry } | undefined;
+  // Run-scoped, and a pure projection of the log: fold the `@agent.usage`
+  // entries THIS run appended (everything past the resumed prefix). The prior
+  // leg's entries are still in `result.events`, so a caller that wants the
+  // cumulative total folds the whole log with `getUsageFromEvents`.
+  const runUsage = (): AgentUsage => ({
+    ...getUsageFromEvents(logEntries.slice(resumedLogLength)),
+    modelCalls: modelCallCount,
+  });
 
   // Dev-only: on idle settle, warn once if the snapshot's context holds values
   // that won't round-trip through JSON persistence. Skipped in production and
@@ -1833,6 +2045,8 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   const provided = machine.provide({
     actors: options.actors as never,
   }) as TMachine;
+
+  logMachine = provided;
 
   const effectiveSources = provided.sources.actors as Record<string, AnyActorLogic>;
 
@@ -1931,7 +2145,188 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   const isIntentionalIdle = (snapshot: AnyMachineSnapshot) =>
     isIdle(snapshot) || collectPendingUserInputs(snapshot).length > 0;
 
-  const effectiveSnapshot = options.snapshot;
+  // ─── Resume precedence: the log is truth, the snapshot is a cache ───
+  //
+  // 1. `events` at THIS machine version — continue that log. A `snapshot`
+  //    stamped at the log's tail (same lineage, same length, matching hash) is
+  //    trusted as-is; anything else replays the log and, when the snapshot
+  //    claims a position in it, hash-checks the snapshot there.
+  // 2. `events` at ANOTHER machine version — a `snapshot` is required (XState's
+  //    `migrate` applies on restore) and the run opens a NEW log segment whose
+  //    init entry carries the post-migration snapshot and `migratedFrom`.
+  // 3. `snapshot` only — restore it and start a self-contained log from it.
+  // 4. Neither — a fresh start, logged from `input`.
+  const resumeEvents = options.events;
+  let effectiveSnapshot: Snapshot<unknown> | undefined = options.snapshot;
+  /** Deferred until after the illegal-resume check, so a rejected resume emits no entries. */
+  let seedInitEntry: (() => void) | undefined;
+
+  // The persisted form of `options.snapshot` AFTER XState has restored it
+  // (which is where `createMachine({ migrate })` runs), so an init entry
+  // records the snapshot the machine will actually resume from. Undefined when
+  // this machine cannot restore it — the raw snapshot is then recorded instead,
+  // and the run fails on its own terms a few lines later.
+  const restoredPersistedSnapshot = (): AgentPersistedSnapshot | undefined => {
+    try {
+      const restored = (
+        logMachine as unknown as {
+          restoreSnapshot(persisted: AgentPersistedSnapshot): AnyMachineSnapshot;
+        }
+      ).restoreSnapshot(options.snapshot as AgentPersistedSnapshot);
+      return logMachine.getPersistedSnapshot(restored) as AgentPersistedSnapshot;
+    } catch {
+      return undefined;
+    }
+  };
+
+  /**
+   * Appends the log's reserved first entry, trying each candidate `init` in
+   * turn and, for each, an unverified entry if the hash cannot be computed.
+   * A machine or snapshot that defeats every attempt leaves the run WITHOUT a
+   * log rather than failing it: `runAgent` predates the log, and an exotic
+   * machine that cannot be folded must still run.
+   */
+  const appendInitEntry = (
+    candidates: readonly AgentLogInit[],
+    metadata: Record<string, AgentLogJsonValue>,
+  ): void => {
+    for (const init of candidates) {
+      for (const verification of verificationEnabled ? [true, false] : [false]) {
+        try {
+          const entry = initEntry(logMachine, init, { machineVersion, verification, metadata });
+          logEntries.push(entry);
+          options.onEvent?.(entry);
+          return;
+        } catch {
+          // Try the next (less exact) form.
+        }
+      }
+    }
+    loggingEnabled = false;
+  };
+
+  /** Init forms for a snapshot resume, most faithful first. */
+  const snapshotInitCandidates = (): AgentLogInit[] => {
+    const restored = restoredPersistedSnapshot();
+    return [
+      ...(restored !== undefined ? [{ snapshot: restored } as AgentLogInit] : []),
+      { snapshot: options.snapshot as AgentPersistedSnapshot } as AgentLogInit,
+    ];
+  };
+
+  if (resumeEvents !== undefined && resumeEvents.length > 0) {
+    validateReplayEntries(resumeEvents);
+    const tail = resumeEvents[resumeEvents.length - 1]!;
+    const inheritedExecutionId = getLogExecutionId(resumeEvents);
+    const sameMachine =
+      resumeEvents[0]!.machineId === machineId && tail.machineVersion === machineVersion;
+
+    if (sameMachine) {
+      logEntries.push(...resumeEvents);
+      resumedLogLength = logEntries.length;
+      logExecutionId = inheritedExecutionId;
+
+      // Lineage, not length: a snapshot cached at index N of ANOTHER log (a
+      // fork, a sibling thread) can trivially collide with this log's length,
+      // so the fast path also requires the log's `executionId` and the tail
+      // entry's recorded hash to agree.
+      const cachedMeta = readAgentMeta(options.snapshot);
+      const tailStateHash = tail.verification?.stateHash;
+      const trustedCache =
+        options.snapshot !== undefined &&
+        inheritedExecutionId !== undefined &&
+        cachedMeta?.logId === inheritedExecutionId &&
+        cachedMeta.logIndex === resumeEvents.length &&
+        (tailStateHash === undefined || hashResumeSnapshot(options.snapshot) === tailStateHash);
+
+      if (!trustedCache) {
+        const cachedIndex = cachedMeta?.logIndex;
+        if (
+          options.snapshot !== undefined &&
+          typeof cachedIndex === "number" &&
+          cachedIndex >= 1 &&
+          cachedIndex <= resumeEvents.length
+        ) {
+          const atCache = replay(logMachine, resumeEvents.slice(0, cachedIndex), {
+            machineVersion,
+            verify: false,
+          });
+          const expected = getSnapshotStateHash(atCache.persistedSnapshot);
+          const actual = hashResumeSnapshot(options.snapshot);
+          if (expected !== actual) {
+            throw new AgentSnapshotDivergedError(expected, actual, cachedIndex);
+          }
+        }
+        effectiveSnapshot = replay(logMachine, resumeEvents, {
+          machineVersion,
+          verify: true,
+        }).persistedSnapshot as Snapshot<unknown>;
+      }
+    } else {
+      // Version bridge. Without a snapshot there is nothing to migrate FROM:
+      // the log's entries were produced by transitions this machine no longer
+      // has, so folding them is not sound.
+      if (options.snapshot === undefined) {
+        throw new AgentMachineVersionMismatchError(
+          tail.id,
+          tail.index,
+          { machineId, machineVersion },
+          { machineId: tail.machineId, machineVersion: tail.machineVersion },
+        );
+      }
+      logExecutionId = inheritedExecutionId;
+      const migratedFrom: Record<string, AgentLogJsonValue> = {
+        machineVersion: tail.machineVersion,
+        logIndex: resumeEvents.length,
+      };
+      seedInitEntry = () =>
+        appendInitEntry(snapshotInitCandidates(), {
+          ...(logExecutionId !== undefined ? { executionId: logExecutionId } : {}),
+          migratedFrom,
+        });
+    }
+  } else if (options.snapshot !== undefined) {
+    logExecutionId = crypto.randomUUID();
+    seedInitEntry = () =>
+      appendInitEntry(snapshotInitCandidates(), { executionId: logExecutionId! });
+  } else {
+    logExecutionId = crypto.randomUUID();
+    seedInitEntry = () =>
+      appendInitEntry([resolvedInput !== undefined ? { input: resolvedInput } : {}], {
+        executionId: logExecutionId!,
+      });
+  }
+
+  // ─── Per-call idempotency keys (`info.callKey`) ───
+  // `${executionId}:${siteId}#${n}`: the log lineage plus the occurrence of
+  // this call at this invoke site. `n` uses ONE counting rule
+  // (`agentCallOccurrence`) over the RESUMED prefix — the log as it stood when
+  // this run began — advanced by the calls this run has already started at that
+  // site. Reading the live log instead would race: XState starts the next
+  // invoke (and its executor) before the previous completion's entry is
+  // appended by the inspect handler, so two loop iterations would collide on
+  // `#1`. Seeding from the prefix keeps a resumed leg aligned: a crash recovery
+  // whose log holds one completion re-executes the in-flight call as `#2`,
+  // exactly the id a replay derives for it.
+  const resumedHistory: readonly AgentLogEntry[] = [...logEntries];
+  const siteCallCounts = new Map<string, number>();
+  const mintedCallKeys = new WeakMap<object, string>();
+  runCtx.callKey = (siteId: string, self?: object) => {
+    if (logExecutionId === undefined) {
+      return undefined;
+    }
+    const memoized = self === undefined ? undefined : mintedCallKeys.get(self);
+    if (memoized !== undefined) {
+      return memoized;
+    }
+    const startedHere = siteCallCounts.get(siteId) ?? 0;
+    siteCallCounts.set(siteId, startedHere + 1);
+    const key = `${logExecutionId}:${siteId}#${agentCallOccurrence(resumedHistory, siteId) + startedHere}`;
+    if (self !== undefined) {
+      mintedCallKeys.set(self, key);
+    }
+    return key;
+  };
 
   // Feature B: reject a resume `event` the restored state cannot take. Checked
   // here (before the actor starts, like the bind-time throws) against the
@@ -1952,6 +2347,10 @@ function createAgentSession<TMachine extends AnyStateMachine>(
       }
     }
   }
+
+  // The log's first entry is appended only once the run is actually going to
+  // start: a rejected resume event (above) must not emit an entry.
+  seedInitEntry?.();
 
   // One run = start (or resume event) to the next quiescence.
   let settled = false;
@@ -1984,15 +2383,28 @@ function createAgentSession<TMachine extends AnyStateMachine>(
         persistenceError = error;
       }
     }
+    // The log position this snapshot caches, frozen at settle: a straggler
+    // appended afterwards makes the cache stale, and the stamp says so.
+    const logIndexAtSettle = logEntries.length;
     const persist = () => {
       if (persistenceError !== undefined) {
         throw persistenceError;
       }
       persistedSnapshot ??= actor.getPersistedSnapshot() as Snapshot<unknown>;
+      // Stamped on the PERSISTED object only — a plain enumerable field, so it
+      // survives a JSON round-trip and is read back by the next resume. The
+      // live `result.snapshot` is left exactly as XState produced it.
+      (persistedSnapshot as { agentMeta?: AgentRunMeta }).agentMeta = {
+        machineId,
+        version: machineVersion,
+        ...(logExecutionId !== undefined ? { logId: logExecutionId } : {}),
+        logIndex: logIndexAtSettle,
+      };
       return persistedSnapshot;
     };
     const result = {
       ...outcome,
+      events: [...logEntries],
       persist,
       usage: runUsage(),
     } as RunAgentResult<TMachine>;
@@ -2087,6 +2499,29 @@ function createAgentSession<TMachine extends AnyStateMachine>(
       }
 
       const snapshot = event.snapshot as AnyMachineSnapshot;
+      lastRootSnapshot = snapshot;
+
+      // ─── Journaling ───
+      // The log is deliberately smaller than the trace: only EXTERNAL inputs
+      // are recorded, because replay re-derives everything else. A root
+      // transition is external when its event came from outside the root actor
+      // (a host `send`, the resume event, a child's
+      // `xstate.done.actor`/`xstate.error.actor`, the reserved `@agent.usage`
+      // and `agent.messages` events this library sends). `xstate.timer` is the
+      // one self-sent input that must be retained — a fired `after` delay is
+      // real time passing, not machine logic. Raised/internal events and
+      // `@xstate.init` are re-derived by `initialTransition`/`transition`.
+      if (
+        pendingUsageJournal !== undefined &&
+        (event.event as unknown) === (pendingUsageJournal.event as unknown)
+      ) {
+        pendingUsageJournal.entry = appendLogEntry(event.event as EventObject, snapshot);
+      } else if (
+        event.event.type !== "@xstate.init" &&
+        (event.sourceRef !== event.actorRef || event.event.type === "xstate.timer")
+      ) {
+        appendLogEntry(event.event as EventObject, snapshot);
+      }
 
       onTrace({
         type: "machine.transition",
@@ -2224,6 +2659,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   // to deliver a resume event to an actor XState has already stopped).
   if (!settled) {
     const startedSnapshot = actor.getSnapshot() as AnyMachineSnapshot;
+    lastRootSnapshot ??= startedSnapshot;
     if (startedSnapshot.status === "done") {
       settle({
         status: "done",

--- a/src/run-agent.ts
+++ b/src/run-agent.ts
@@ -24,6 +24,7 @@ import type {
   WithAgentInputSchema,
 } from "./types.js";
 import { AgentError } from "./errors.js";
+import { AgentEventLogConflictError, type AgentEventLogStore } from "./event-log-store.js";
 import {
   findNonSerializableContextPaths,
   isStandardSchema,
@@ -498,9 +499,24 @@ export interface RunAgentOptions<TMachine extends AnyStateMachine> {
    */
   events?: readonly AgentLogEntry[];
   /**
-   * Called synchronously as each log entry is appended, init entry first. The
-   * host persistence seam: append the entry to durable storage here and a crash
-   * mid-run loses nothing but the in-flight call.
+   * Durable log storage, write-ahead. With a `store` the run reads the thread's
+   * log to resume from (unless `events` is given, which wins) and writes every
+   * appended entry back through {@link AgentEventLogStore.append}, in log
+   * order. Writes are awaited before every model call, so a paid call is never
+   * made against an unpersisted log; pure transitions never wait. A rejected
+   * write (an {@link AgentEventLogConflictError} from a concurrent writer, or
+   * any other failure) stops the run: `{ status: 'error', cause: 'journal' }`.
+   *
+   * Requires {@link RunAgentOptions.threadId}.
+   */
+  store?: AgentEventLogStore;
+  /** The {@link RunAgentOptions.store} thread this run reads and appends to. Required whenever `store` is given. */
+  threadId?: string;
+  /**
+   * Called synchronously as each log entry is appended, init entry first. An
+   * observer, never awaited: persisting here is at-least-once and the run does
+   * not wait for it. Use {@link RunAgentOptions.store} for write-ahead
+   * durability.
    */
   onEvent?: (entry: AgentLogEntry) => void;
   /**
@@ -672,13 +688,16 @@ export type RunAgentResult<TMachine extends AnyStateMachine> = RunAgentOutcome<T
  *   (or wraps) a {@link AgentDecisionExhaustedError} that no `onError` handled.
  * - `'machine'` — any other machine error state.
  * - `'stopped'` — the actor was stopped externally (`status === 'stopped'`).
+ * - `'journal'` — a {@link RunAgentOptions.store} write rejected (a concurrent
+ *   writer's {@link AgentEventLogConflictError}, or any other storage failure).
  */
 export type RunAgentErrorCause =
   | "aborted"
   | "max-model-calls"
   | "decision-exhausted"
   | "machine"
-  | "stopped";
+  | "stopped"
+  | "journal";
 
 let nextRunAgentTraceId = 1;
 
@@ -1051,6 +1070,14 @@ interface RunAgentBindContext {
    * key. Unset off the runAgent path, and when the log has no `executionId`.
    */
   callKey?: (siteId: string, self?: object) => string | undefined;
+  /**
+   * The write-ahead barrier: awaited immediately before every text/decision
+   * executor invocation, so no paid call is made against a log that is not yet
+   * durable. Resolves immediately when the run has no
+   * {@link RunAgentOptions.store}; rejects with the journal's failure once a
+   * write has rejected. Unset off the runAgent path.
+   */
+  awaitJournal?: () => Promise<void>;
   /** Assigned right after createActor (§2.6); read lazily by decision wraps. */
   actorHolder: { actorRef: AnyActorRef | undefined };
   /** Registered `setupAgent` schemas (for event `inputSchema`s), if any. */
@@ -1201,6 +1228,8 @@ function bindTextLogic(logic: TextLogic, runCtx: RunAgentBindContext): TextLogic
     runCtx.emitTrace?.({ type: "request.start", request: agentRequest }, self);
     try {
       const callKey = id !== "" ? runCtx.callKey?.(id, self) : undefined;
+      // Write-ahead: the log up to this point must be durable before the call.
+      await runCtx.awaitJournal?.();
       const raw = await executor(requestWithTools as AgentExecutorTextRequest, {
         onChunk: (chunk: string) => {
           runCtx.emitTrace?.({ type: "stream.chunk", request: agentRequest, chunk }, self);
@@ -1291,6 +1320,8 @@ function createCountingDecide(
       // One key per invoke, not per decision attempt: `callKey` is memoized on
       // `self`, so a retried decision keeps the key its first attempt used.
       const callKey = id !== "" ? runCtx.callKey?.(id, self) : undefined;
+      // Write-ahead: the log up to this point must be durable before the call.
+      await runCtx.awaitJournal?.();
       // `runId` rides on the request like `signal` does: host-injected
       // correlation, never serialized into machine state. It also rides on the
       // `info` second argument, where generateText/streamText carry it.
@@ -1818,7 +1849,32 @@ export async function runAgent<TMachine extends AnyStateMachine>(
   machine: TMachine,
   options: RunAgentOptions<TMachine>,
 ): Promise<RunAgentResult<TMachine>> {
-  return createAgentSession(machine, options).settled();
+  const store = options.store;
+  if (store === undefined) {
+    // No store: the run starts synchronously, exactly as it always has.
+    return createAgentSession(machine, options).settled();
+  }
+  const threadId = options.threadId;
+  if (threadId === undefined || threadId === "") {
+    throw new AgentError(
+      "missing-thread-id",
+      "runAgent: `threadId` is required when `store` is given — it names the log thread to read and append to.",
+    );
+  }
+  if (options.events !== undefined) {
+    // An explicit log wins as the resume, but it must BE the thread's log:
+    // appending onto a store that has moved on would interleave two lineages.
+    const length = await store.length(threadId);
+    if (length !== options.events.length) {
+      throw new AgentEventLogConflictError(threadId, options.events.length, length);
+    }
+    return createAgentSession(machine, options).settled();
+  }
+  const stored = await store.read(threadId);
+  return createAgentSession(
+    machine,
+    stored.length > 0 ? { ...options, events: stored } : options,
+  ).settled();
 }
 
 interface AgentRunSession<TMachine extends AnyStateMachine> {
@@ -1895,6 +1951,82 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   // by the inspect handler below. It is the value returned as `result.events`,
   // and the value `options.onEvent` streams entry by entry.
   const logEntries: AgentLogEntry[] = [];
+
+  // ─── Write-ahead journaling (`options.store`) ───
+  //
+  // Every appended entry is queued onto ONE chain, so writes reach the store in
+  // log order and each carries its own index as `expectedIndex`. The chain is
+  // awaited at two points only: before a model call (`awaitJournal`, the
+  // barrier the executors call) and at settle. Pure transitions never wait.
+  // The first rejection wins, stops the run (`cause: 'journal'`) and blocks
+  // every later write and call.
+  const store = options.store;
+  const threadId = options.threadId;
+  if (store !== undefined && (threadId === undefined || threadId === "")) {
+    throw new AgentError(
+      "missing-thread-id",
+      "runAgent: `threadId` is required when `store` is given — it names the log thread to read and append to.",
+    );
+  }
+  let journalChain: Promise<void> = Promise.resolve();
+  let journalPending = 0;
+  let journalError: unknown;
+
+  const journalEntry = (entry: AgentLogEntry): void => {
+    if (store === undefined) {
+      return;
+    }
+    journalPending++;
+    journalChain = journalChain
+      .then(async () => {
+        if (journalError !== undefined) {
+          return;
+        }
+        await store.append({
+          threadId: threadId!,
+          expectedIndex: entry.index,
+          entries: [entry],
+        });
+      })
+      .catch((error: unknown) => {
+        journalError ??= error;
+        failRunOnJournalError(error);
+      })
+      .finally(() => {
+        journalPending--;
+      });
+  };
+
+  /** The barrier: settle the pending chain, then surface any failure. */
+  const awaitJournal = async (): Promise<void> => {
+    if (store === undefined) {
+      return;
+    }
+    while (journalPending > 0) {
+      await journalChain;
+    }
+    if (journalError !== undefined) {
+      throw journalError;
+    }
+  };
+
+  // A failed write means the log is no longer authoritative — abort the run.
+  // Settling stops the actor, which aborts every in-flight call's signal, and
+  // the barrier above rejects any call that has not started yet. Declared
+  // before `settle` exists; only ever called from a rejected write, i.e. after
+  // this function's synchronous body has run.
+  const failRunOnJournalError = (error: unknown): void => {
+    if (settled) {
+      return;
+    }
+    settle({
+      status: "error",
+      cause: "journal",
+      error,
+      snapshot: actor.getSnapshot() as SnapshotFrom<TMachine>,
+    });
+  };
+
   // Where THIS run's own entries begin — the fold boundary for `runUsage`.
   let resumedLogLength = 0;
   // The lineage id pinned in the log's init entry metadata; also the prefix of
@@ -1933,6 +2065,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
       ...(verificationEnabled && snapshot !== undefined ? { snapshot } : {}),
     });
     logEntries.push(entry);
+    journalEntry(entry);
     options.onEvent?.(entry);
     return entry;
   };
@@ -2069,6 +2202,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
     consumeModelCall,
     recordUsage,
     actorHolder,
+    awaitJournal,
     runId,
     schemas: getRegisteredAgentExecutionOptions(machine).schemas,
   };
@@ -2195,6 +2329,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
         try {
           const entry = initEntry(logMachine, init, { machineVersion, verification, metadata });
           logEntries.push(entry);
+          journalEntry(entry);
           options.onEvent?.(entry);
           return;
         } catch {
@@ -2354,6 +2489,8 @@ function createAgentSession<TMachine extends AnyStateMachine>(
 
   // One run = start (or resume event) to the next quiescence.
   let settled = false;
+  // The journal chain as it stood at settle (see `settle`).
+  let journalAtSettle: Promise<void> | undefined;
   // A call settling after the run resolved is a straggler (see
   // deliverUsageEvent): dropped after the run settles.
   cycleGate.isResolved = () => settled;
@@ -2386,6 +2523,10 @@ function createAgentSession<TMachine extends AnyStateMachine>(
     // The log position this snapshot caches, frozen at settle: a straggler
     // appended afterwards makes the cache stale, and the stamp says so.
     const logIndexAtSettle = logEntries.length;
+    // Every write queued so far, in one promise: the result waits for these.
+    // A straggler `@agent.usage` entry appended after this point is still
+    // written, but chains behind and is not awaited.
+    journalAtSettle = journalChain;
     const persist = () => {
       if (persistenceError !== undefined) {
         throw persistenceError;
@@ -2623,12 +2764,19 @@ function createAgentSession<TMachine extends AnyStateMachine>(
   }
 
   const sessionApi: AgentRunSession<TMachine> = {
-    settled: () =>
-      settled && lastResult !== undefined
-        ? Promise.resolve(lastResult)
-        : new Promise<RunAgentResult<TMachine>>((resolve) => {
-            waiters.push(resolve);
-          }),
+    settled: async () => {
+      const result =
+        settled && lastResult !== undefined
+          ? lastResult
+          : await new Promise<RunAgentResult<TMachine>>((resolve) => {
+              waiters.push(resolve);
+            });
+      // The run resolves only once the log it reports is durable. A write that
+      // rejected has already settled the run with `cause: 'journal'`, so the
+      // failure is on the result, not thrown here.
+      await journalAtSettle;
+      return result;
+    },
   };
 
   if (options.signal) {

--- a/src/run-agent.ts
+++ b/src/run-agent.ts
@@ -669,6 +669,15 @@ export type RunAgentResult<TMachine extends AnyStateMachine> = RunAgentOutcome<T
    */
   persist(): Snapshot<unknown>;
   /**
+   * Resolves once every {@link RunAgentOptions.store} write issued so far has
+   * landed — including a straggler `@agent.usage` entry appended by a call
+   * that settled after the run returned, which the result itself does not wait
+   * for. Await it before terminating the process if those entries matter.
+   * Resolves immediately when the run has no store, and never rejects: a
+   * failed write settles the run with `cause: 'journal'` instead.
+   */
+  drain(): Promise<void>;
+  /**
    * Aggregated model-call usage for THIS run — `modelCalls` plus the token
    * fields every executor reported (see {@link AgentUsage} for the
    * partial-sum rule). Present on all three variants: an `idle` or `error`
@@ -1066,8 +1075,10 @@ interface RunAgentBindContext {
   /**
    * Mints the per-call idempotency key threaded to executors as
    * `info.callKey` (`${executionId}:${siteId}#${n}`). Memoized per invoked
-   * leaf actor (`self`), so a decision's retries within one invoke share one
-   * key. Unset off the runAgent path, and when the log has no `executionId`.
+   * leaf actor (`self`), so every attempt of one decision invoke shares this
+   * invoke-level key; the decision wrap appends the attempt ordinal
+   * (`…#${n}.${attempts.length}`) so retries do not collide in a cache.
+   * Unset off the runAgent path, and when the log has no `executionId`.
    */
   callKey?: (siteId: string, self?: object) => string | undefined;
   /**
@@ -1317,9 +1328,18 @@ function createCountingDecide(
     runCtx.emitTrace?.({ type: "request.start", request: attemptRequest }, self);
     try {
       const { id } = selfIdAndSrc(self);
-      // One key per invoke, not per decision attempt: `callKey` is memoized on
-      // `self`, so a retried decision keeps the key its first attempt used.
-      const callKey = id !== "" ? runCtx.callKey?.(id, self) : undefined;
+      // The invoke-level key is memoized on `self`, so every attempt of this
+      // decision shares it — but each attempt is a DISTINCT paid call with a
+      // different request (the rejected attempts ride along as feedback), so
+      // the attempt ordinal is appended: `…#<n>.<attempt>`. Without it a
+      // compliant idempotency cache would replay the rejected first attempt
+      // for every retry. The ordinal comes from `request.attempts.length`, so
+      // a crash re-executing attempt k derives the same key again.
+      const invokeCallKey = id !== "" ? runCtx.callKey?.(id, self) : undefined;
+      const callKey =
+        invokeCallKey === undefined
+          ? undefined
+          : `${invokeCallKey}.${attemptRequest.attempts?.length ?? 0}`;
       // Write-ahead: the log up to this point must be durable before the call.
       await runCtx.awaitJournal?.();
       // `runId` rides on the request like `signal` does: host-injected
@@ -1863,11 +1883,13 @@ export async function runAgent<TMachine extends AnyStateMachine>(
   }
   if (options.events !== undefined) {
     // An explicit log wins as the resume, but it must BE the thread's log:
-    // appending onto a store that has moved on would interleave two lineages.
-    const length = await store.length(threadId);
-    if (length !== options.events.length) {
-      throw new AgentEventLogConflictError(threadId, options.events.length, length);
+    // appending onto a store that has moved on — or onto a same-length log
+    // that says something else — would interleave two lineages.
+    const storedThread = await store.read(threadId);
+    if (storedThread.length !== options.events.length) {
+      throw new AgentEventLogConflictError(threadId, options.events.length, storedThread.length);
     }
+    assertThreadMatchesEvents(threadId, storedThread, options.events);
     return createAgentSession(machine, options).settled();
   }
   const stored = await store.read(threadId);
@@ -1879,6 +1901,38 @@ export async function runAgent<TMachine extends AnyStateMachine>(
 
 interface AgentRunSession<TMachine extends AnyStateMachine> {
   settled(): Promise<RunAgentResult<TMachine>>;
+}
+
+/**
+ * Entry-by-entry check that the caller's `events` IS the store's thread. Equal
+ * lengths prove nothing: a fork, a rolled-back replay, or a concurrent writer
+ * that appended and truncated all produce a divergent log of the same size,
+ * and appending this run's entries onto it would splice two lineages together.
+ */
+function assertThreadMatchesEvents(
+  threadId: string,
+  stored: readonly AgentLogEntry[],
+  events: readonly AgentLogEntry[],
+): void {
+  for (let index = 0; index < stored.length; index++) {
+    const storedEntry = stored[index]!;
+    const givenEntry = events[index]!;
+    const storedHash = storedEntry.verification?.stateHash;
+    const givenHash = givenEntry.verification?.stateHash;
+    const same =
+      storedEntry.id === givenEntry.id &&
+      storedEntry.index === givenEntry.index &&
+      JSON.stringify(storedEntry.event) === JSON.stringify(givenEntry.event) &&
+      (storedHash === undefined || givenHash === undefined || storedHash === givenHash);
+    if (!same) {
+      throw new AgentError(
+        "event-log-conflict",
+        `runAgent: the given \`events\` diverge from thread "${threadId}" at index ${index} ` +
+          `(stored entry '${storedEntry.id}', given '${givenEntry.id}') — ` +
+          "the log passed in is not this thread's log.",
+      );
+    }
+  }
 }
 
 function createAgentSession<TMachine extends AnyStateMachine>(
@@ -1995,6 +2049,26 @@ function createAgentSession<TMachine extends AnyStateMachine>(
       .finally(() => {
         journalPending--;
       });
+  };
+
+  /**
+   * Every journal write ISSUED SO FAR, including the stragglers appended after
+   * the run settled. Re-reads the chain tail until it stops moving, so a write
+   * queued while an earlier one was in flight is covered too. Never rejects: a
+   * failed write already settled the run with `cause: 'journal'`.
+   */
+  const drainJournal = async (): Promise<void> => {
+    if (store === undefined) {
+      return;
+    }
+    let tail = journalChain;
+    for (;;) {
+      await tail;
+      if (journalPending === 0 && journalChain === tail) {
+        return;
+      }
+      tail = journalChain;
+    }
   };
 
   /** The barrier: settle the pending chain, then surface any failure. */
@@ -2353,8 +2427,18 @@ function createAgentSession<TMachine extends AnyStateMachine>(
     validateReplayEntries(resumeEvents);
     const tail = resumeEvents[resumeEvents.length - 1]!;
     const inheritedExecutionId = getLogExecutionId(resumeEvents);
-    const sameMachine =
-      resumeEvents[0]!.machineId === machineId && tail.machineVersion === machineVersion;
+    // A log written by a DIFFERENT machine is never a resume for this one: its
+    // entries fold against states this machine does not have, and its snapshot
+    // caches another artifact's state. Only a version change is bridgeable.
+    if (resumeEvents[0]!.machineId !== machineId) {
+      throw new AgentMachineVersionMismatchError(
+        tail.id,
+        tail.index,
+        { machineId, machineVersion },
+        { machineId: resumeEvents[0]!.machineId, machineVersion: tail.machineVersion },
+      );
+    }
+    const sameMachine = tail.machineVersion === machineVersion;
 
     if (sameMachine) {
       logEntries.push(...resumeEvents);
@@ -2364,7 +2448,10 @@ function createAgentSession<TMachine extends AnyStateMachine>(
       // Lineage, not length: a snapshot cached at index N of ANOTHER log (a
       // fork, a sibling thread) can trivially collide with this log's length,
       // so the fast path also requires the log's `executionId` and the tail
-      // entry's recorded hash to agree.
+      // entry's recorded hash to agree. The hash must be PRESENT: an
+      // unverified log (`verification: false`) records none, and trusting a
+      // snapshot on its self-reported `agentMeta` alone would let a tampered
+      // cache override the log. No hash, no fast path — the log is the truth.
       const cachedMeta = readAgentMeta(options.snapshot);
       const tailStateHash = tail.verification?.stateHash;
       const trustedCache =
@@ -2372,7 +2459,8 @@ function createAgentSession<TMachine extends AnyStateMachine>(
         inheritedExecutionId !== undefined &&
         cachedMeta?.logId === inheritedExecutionId &&
         cachedMeta.logIndex === resumeEvents.length &&
-        (tailStateHash === undefined || hashResumeSnapshot(options.snapshot) === tailStateHash);
+        tailStateHash !== undefined &&
+        hashResumeSnapshot(options.snapshot) === tailStateHash;
 
       if (!trustedCache) {
         const cachedIndex = cachedMeta?.logIndex;
@@ -2380,7 +2468,11 @@ function createAgentSession<TMachine extends AnyStateMachine>(
           options.snapshot !== undefined &&
           typeof cachedIndex === "number" &&
           cachedIndex >= 1 &&
-          cachedIndex <= resumeEvents.length
+          cachedIndex <= resumeEvents.length &&
+          // Only a verified log can call a snapshot divergent: with
+          // verification off the caller opted out of hashes, so a disagreeing
+          // snapshot is simply ignored in favour of the log.
+          resumeEvents[cachedIndex - 1]!.verification?.stateHash !== undefined
         ) {
           const atCache = replay(logMachine, resumeEvents.slice(0, cachedIndex), {
             machineVersion,
@@ -2407,6 +2499,37 @@ function createAgentSession<TMachine extends AnyStateMachine>(
           tail.index,
           { machineId, machineVersion },
           { machineId: tail.machineId, machineVersion: tail.machineVersion },
+        );
+      }
+      // The snapshot must BE the cache of THIS log's tail under the old
+      // version: the bridge cannot fold the log itself, so an older or foreign
+      // snapshot would silently roll the thread back to state the log has
+      // already moved past.
+      const bridgeMeta = readAgentMeta(options.snapshot);
+      if (inheritedExecutionId === undefined || bridgeMeta?.logId !== inheritedExecutionId) {
+        throw new AgentMachineVersionMismatchError(
+          tail.id,
+          tail.index,
+          { machineId, machineVersion },
+          { machineId: tail.machineId, machineVersion: tail.machineVersion },
+        );
+      }
+      const bridgeTailHash = tail.verification?.stateHash;
+      // Hashed BEFORE any migration: the recorded hash describes the snapshot
+      // as the old version persisted it.
+      const bridgeSnapshotHash = hashResumeSnapshot(options.snapshot);
+      if (bridgeMeta.logIndex !== resumeEvents.length) {
+        throw new AgentSnapshotDivergedError(
+          bridgeTailHash ?? "(unrecorded)",
+          bridgeSnapshotHash,
+          resumeEvents.length,
+        );
+      }
+      if (bridgeTailHash !== undefined && bridgeSnapshotHash !== bridgeTailHash) {
+        throw new AgentSnapshotDivergedError(
+          bridgeTailHash,
+          bridgeSnapshotHash,
+          resumeEvents.length,
         );
       }
       logExecutionId = inheritedExecutionId;
@@ -2547,6 +2670,7 @@ function createAgentSession<TMachine extends AnyStateMachine>(
       ...outcome,
       events: [...logEntries],
       persist,
+      drain: drainJournal,
       usage: runUsage(),
     } as RunAgentResult<TMachine>;
     if (idleTimer !== undefined) {

--- a/src/run-agent.ts
+++ b/src/run-agent.ts
@@ -81,6 +81,7 @@ import {
   type AgentLogInit,
   type AgentPersistedSnapshot,
   type JsonValue as AgentLogJsonValue,
+  canonicalEventJson,
 } from "./event-log.js";
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
@@ -1922,7 +1923,7 @@ function assertThreadMatchesEvents(
     const same =
       storedEntry.id === givenEntry.id &&
       storedEntry.index === givenEntry.index &&
-      JSON.stringify(storedEntry.event) === JSON.stringify(givenEntry.event) &&
+      canonicalEventJson(storedEntry.event) === canonicalEventJson(givenEntry.event) &&
       (storedHash === undefined || givenHash === undefined || storedHash === givenHash);
     if (!same) {
       throw new AgentError(

--- a/src/run-loop.test.ts
+++ b/src/run-loop.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { z } from "zod";
-import { runAgentLoop, setupAgent } from "./index.js";
+import { createInMemoryEventLogStore, runAgent, runAgentLoop, setupAgent } from "./index.js";
 
 test("runAgentLoop drives idle snapshots with host-supplied events", async () => {
   const agent = setupAgent({
@@ -32,4 +32,45 @@ test("runAgentLoop drives idle snapshots with host-supplied events", async () =>
   });
   expect(result.status).toBe("done");
   expect(persisted).toHaveLength(2);
+});
+
+test("a store-backed loop seeds `events` on the first turn only", async () => {
+  const agent = setupAgent({
+    context: z.object({}),
+    input: z.object({}),
+    output: z.object({ ok: z.boolean() }),
+    events: { NEXT: z.object({}), FINISH: z.object({}) },
+  });
+  const machine = agent.createMachine({
+    id: "stored-loop",
+    context: {},
+    initial: "first",
+    states: {
+      first: { on: { NEXT: { target: "second" } } },
+      second: { on: { FINISH: { target: "done" } } },
+      done: { type: "final", output: () => ({ ok: true }) },
+    },
+  });
+
+  const store = createInMemoryEventLogStore();
+  // A log the caller already holds: it is the thread's log on turn 1, but the
+  // store has moved on by turn 2, so re-asserting it would conflict.
+  const seeded = await runAgent(machine, { input: {}, store, threadId: "main" });
+  expect(seeded.status).toBe("idle");
+
+  const events: Array<{ type: "NEXT" } | { type: "FINISH" }> = [
+    { type: "NEXT" },
+    { type: "FINISH" },
+  ];
+  const result = await runAgentLoop(machine, {
+    store,
+    threadId: "main",
+    events: seeded.events,
+    onIdle: async () => events.shift(),
+  });
+
+  expect(result.status).toBe("done");
+  const thread = await store.read("main");
+  expect(thread.length).toBeGreaterThan(seeded.events.length);
+  expect(thread.map((entry) => entry.event.type)).toContain("FINISH");
 });

--- a/src/run-loop.ts
+++ b/src/run-loop.ts
@@ -1,5 +1,6 @@
 import type { AnyStateMachine, EventFromLogic } from "xstate";
 import { runAgent, type RunAgentOptions, type RunAgentResult } from "./run-agent.js";
+import type { AgentLogEntry } from "./event-log.js";
 import type { AgentUsage } from "./text-logic.js";
 
 export interface RunAgentLoopOptions<TMachine extends AnyStateMachine> extends Omit<
@@ -46,12 +47,17 @@ export async function runAgentLoop<TMachine extends AnyStateMachine>(
   let usage: AgentUsage = { modelCalls: 0 };
   let snapshot: ReturnType<RunAgentResult<TMachine>["persist"]> | undefined;
   let event: EventFromLogic<TMachine> | undefined;
+  // Threaded turn to turn so the whole loop yields ONE continuous log rather
+  // than a fresh segment per turn.
+  let events: readonly AgentLogEntry[] | undefined = options.events;
 
   for (let turn = 0; ; turn++) {
     const result = await runAgent(machine, {
       ...runOptions,
+      ...(events ? { events } : {}),
       ...(snapshot ? { snapshot, event } : {}),
     } as RunAgentOptions<TMachine>);
+    events = result.events;
     usage = addUsage(usage, result.usage);
     const cumulative = { ...result, usage } as RunAgentResult<TMachine>;
 

--- a/src/run-loop.ts
+++ b/src/run-loop.ts
@@ -48,8 +48,11 @@ export async function runAgentLoop<TMachine extends AnyStateMachine>(
   let snapshot: ReturnType<RunAgentResult<TMachine>["persist"]> | undefined;
   let event: EventFromLogic<TMachine> | undefined;
   // Threaded turn to turn so the whole loop yields ONE continuous log rather
-  // than a fresh segment per turn.
-  let events: readonly AgentLogEntry[] | undefined = options.events;
+  // than a fresh segment per turn. With a `store`, the log lives there: each
+  // turn reads the thread back, so carrying it here would only re-assert a
+  // length the store already knows.
+  const stored = options.store !== undefined;
+  let events: readonly AgentLogEntry[] | undefined = stored ? undefined : options.events;
 
   for (let turn = 0; ; turn++) {
     const result = await runAgent(machine, {
@@ -57,7 +60,9 @@ export async function runAgentLoop<TMachine extends AnyStateMachine>(
       ...(events ? { events } : {}),
       ...(snapshot ? { snapshot, event } : {}),
     } as RunAgentOptions<TMachine>);
-    events = result.events;
+    if (!stored) {
+      events = result.events;
+    }
     usage = addUsage(usage, result.usage);
     const cumulative = { ...result, usage } as RunAgentResult<TMachine>;
 

--- a/src/run-loop.ts
+++ b/src/run-loop.ts
@@ -39,7 +39,10 @@ export async function runAgentLoop<TMachine extends AnyStateMachine>(
   machine: TMachine,
   options: RunAgentLoopOptions<TMachine>,
 ): Promise<RunAgentResult<TMachine>> {
-  const { onIdle, persist, maxTurns = 100, ...runOptions } = options;
+  // `events` is pulled OUT of the forwarded options: it is turn-scoped (see
+  // below), and leaving it in `runOptions` would re-assert turn 1's log on
+  // every later turn — a store-backed loop would then conflict on turn 2.
+  const { onIdle, persist, maxTurns = 100, events: initialEvents, ...runOptions } = options;
   if (!Number.isInteger(maxTurns) || maxTurns < 0) {
     throw new Error("runAgentLoop: maxTurns must be a non-negative integer.");
   }
@@ -48,11 +51,11 @@ export async function runAgentLoop<TMachine extends AnyStateMachine>(
   let snapshot: ReturnType<RunAgentResult<TMachine>["persist"]> | undefined;
   let event: EventFromLogic<TMachine> | undefined;
   // Threaded turn to turn so the whole loop yields ONE continuous log rather
-  // than a fresh segment per turn. With a `store`, the log lives there: each
-  // turn reads the thread back, so carrying it here would only re-assert a
-  // length the store already knows.
+  // than a fresh segment per turn. With a `store`, the log lives there: the
+  // caller's `events` seeds the FIRST turn only, and every later turn reads
+  // the thread back from the store instead.
   const stored = options.store !== undefined;
-  let events: readonly AgentLogEntry[] | undefined = stored ? undefined : options.events;
+  let events: readonly AgentLogEntry[] | undefined = initialEvents;
 
   for (let turn = 0; ; turn++) {
     const result = await runAgent(machine, {
@@ -60,9 +63,7 @@ export async function runAgentLoop<TMachine extends AnyStateMachine>(
       ...(events ? { events } : {}),
       ...(snapshot ? { snapshot, event } : {}),
     } as RunAgentOptions<TMachine>);
-    if (!stored) {
-      events = result.events;
-    }
+    events = stored ? undefined : result.events;
     usage = addUsage(usage, result.usage);
     const cumulative = { ...result, usage } as RunAgentResult<TMachine>;
 

--- a/src/text-logic.ts
+++ b/src/text-logic.ts
@@ -735,6 +735,18 @@ export interface AgentRequestExecutorInfo {
    * call has no invoking actor.
    */
   requestId?: string;
+  /**
+   * A per-call idempotency key, `${executionId}:${requestId}#${n}` — the event
+   * log's lineage id plus the occurrence of this call at this invoke site.
+   * IDENTICAL across a crash re-execution: a run resumed from a log whose last
+   * call was still in flight re-issues that call under the same key, so an
+   * executor-level cache (or a provider's own idempotency header) can return
+   * the first attempt's result instead of paying for it twice. A decision's
+   * retries within one invoke share the key.
+   *
+   * Undefined off the `runAgent` path, and for a log with no `executionId`.
+   */
+  callKey?: string;
 }
 
 /**

--- a/src/text-logic.ts
+++ b/src/text-logic.ts
@@ -741,8 +741,14 @@ export interface AgentRequestExecutorInfo {
    * IDENTICAL across a crash re-execution: a run resumed from a log whose last
    * call was still in flight re-issues that call under the same key, so an
    * executor-level cache (or a provider's own idempotency header) can return
-   * the first attempt's result instead of paying for it twice. A decision's
-   * retries within one invoke share the key.
+   * the first attempt's result instead of paying for it twice. A decision
+   * retry appends its attempt ordinal (`${executionId}:${requestId}#${n}.${a}`,
+   * `a` being the number of prior failed attempts), so a retry never collides
+   * with the rejected attempt it is replacing.
+   *
+   * It identifies the CALL SITE, not the request: a fork inherits its parent's
+   * lineage id, so cache on `callKey` together with a fingerprint of the
+   * request and reuse a cached result only when the request also matches.
    *
    * Undefined off the `runAgent` path, and for a log with no `executionId`.
    */


### PR DESCRIPTION
## Summary

Re-adds an event log on top of the simplified API from #115, designed so the log is the source of truth and a snapshot is a verified cache over it. Replaces the closed #116.

## Model

- **Journal.** `runAgent` records the root machine's external inputs as `AgentLogEntry` values: init, host events, child completions, timers, `@agent.usage`, `agent.messages`. Raised events are re-derived on replay. `result.events` is a complete, self-contained segment. `verification` (default on) stamps a per-entry state hash from the live snapshot, no prefix replay.
- **Resume.** `runAgent({ events })` replays the log. Recorded results are never re-executed; an in-flight request re-executes with the same `info.callKey`. A `snapshot` alongside the log is trusted only when its `agentMeta` lineage id, index, and hash match the tail. Otherwise the log wins, and a diverged cache throws `AgentSnapshotDivergedError`.
- **Version bridge.** The log is authoritative within one `machine.version`. Across a change, pass old `events` + migrated `snapshot`; the result starts a new segment whose init entry carries the snapshot and `metadata.migratedFrom`. Old events without a snapshot throw `AgentMachineVersionMismatchError`.
- **Snapshot-only resume** also yields a self-contained log, so every result is replayable.
- **Usage** entries are spend records, journaled whether or not the machine handles them; `result.usage` folds the log via `getUsageFromEvents`.
- **Idempotency.** Executors get `info.callKey` = `<executionId>:<requestId>#<n>`, identical across crash re-execution.

## Persistence, two seams

- **`store` + `threadId`** (write-ahead). The run reads the thread as its resume log when `events` is omitted, appends each entry at its own `expectedIndex`, and no text or decision call starts until every earlier entry's write has resolved. Pure transitions never wait. A rejected write settles `{ status: "error", cause: "journal" }`. Same shape as a LangGraph checkpointer.
- **`onEvent`** (observer). Synchronous, never awaited. Persisting here is at-least-once, covered by `callKey`.
- `AgentEventLogStore` interface, `createInMemoryEventLogStore`, `assertEventLogStoreConformance` for host-written stores. No SQLite subpath; hosts own durability.

## Not included, on purpose
- No durable runner. The Cloudflare Durable Object example is the recipe: `runAgent(machine, { store, threadId, event, executors })` per turn.
- No SQLite subpath.

## Examples
- `cloudflare-agent-host`: journal in DO SQLite through the store interface, no snapshot persisted, tests cover two evictions with no re-executed model calls.
- `crash-recovery`: events-only recovery through a store, same `callKey` on the re-executed call.

## Known limits
- Custom actors a host invokes outside the executors are not gated by the write-ahead barrier.
- A machine whose initial state cannot be serialized to JSON produces no log. Documented under Hazards.

## Verification
`pnpm vitest --run` 783 passed, `pnpm run check`, `check:dts`, `test:cloudflare` (11 + 2), `docs:check` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added append-only event logs as the durable source of truth for agent runs.
  - Added replay-based recovery, branching, snapshot verification, usage tracking, and stable call keys.
  - Added write-ahead persistence, resume support, journal failure reporting, and `result.drain()`.
  - Added Cloudflare Durable Object SQLite storage support.
  - Added public APIs for event logs, stores, replay, validation, and conformance testing.
- **Documentation**
  - Expanded guidance for durability, persistence, observability, recovery, and executor idempotency.
- **Bug Fixes**
  - Improved validation of snapshots, event logs, replay consistency, and incompatible data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->